### PR TITLE
feat: add review_model and fill_model inputs to override models per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Once committed, tagging `@droid fill` or `@droid review` on an open PR will trig
 | --- | --- |
 | `factory_api_key` | **Required.** Grants Droid Exec permission to run via Factory. |
 | `github_token` | Optional override if you prefer a custom GitHub App/token. By default the installed app token is used. |
+| `review_model` | Optional. Override the model used for code review (e.g., `claude-sonnet-4-5-20250929`, `gpt-5.1-codex`). Only applies to review flows. |
 
 ## Troubleshooting & Support
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Once committed, tagging `@droid fill` or `@droid review` on an open PR will trig
 | `factory_api_key` | **Required.** Grants Droid Exec permission to run via Factory. |
 | `github_token` | Optional override if you prefer a custom GitHub App/token. By default the installed app token is used. |
 | `review_model` | Optional. Override the model used for code review (e.g., `claude-sonnet-4-5-20250929`, `gpt-5.1-codex`). Only applies to review flows. |
+| `fill_model` | Optional. Override the model used for PR description fill (e.g., `claude-sonnet-4-5-20250929`, `gpt-5.1-codex`). Only applies to fill flows. |
 
 ## Troubleshooting & Support
 

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
     required: false
     default: ""
+  fill_model:
+    description: "Override the model used for PR description fill (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to fill flows."
+    required: false
+    default: ""
   experimental_allowed_domains:
     description: "Restrict network access to these domains only (newline-separated). If not set, no restrictions are applied. Provider domains are auto-detected."
     required: false
@@ -128,6 +132,7 @@ runs:
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
         REVIEW_MODEL: ${{ inputs.review_model }}
+        FILL_MODEL: ${{ inputs.fill_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         DROID_ARGS: ${{ inputs.droid_args }}
         ALL_INPUTS: ${{ toJson(inputs) }}

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: "Automatically run the review flow for pull request contexts without requiring an explicit @droid review command. Only supported for PR-related events."
     required: false
     default: "false"
+  review_model:
+    description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
+    required: false
+    default: ""
   experimental_allowed_domains:
     description: "Restrict network access to these domains only (newline-separated). If not set, no restrictions are applied. Provider domains are auto-detected."
     required: false
@@ -123,6 +127,7 @@ runs:
         DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
+        REVIEW_MODEL: ${{ inputs.review_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         DROID_ARGS: ${{ inputs.droid_args }}
         ALL_INPUTS: ${{ toJson(inputs) }}

--- a/src/tag/commands/fill.ts
+++ b/src/tag/commands/fill.ts
@@ -95,7 +95,7 @@ export async function prepareFillMode({
   // Add model override if specified
   const fillModel = process.env.FILL_MODEL?.trim();
   if (fillModel) {
-    droidArgParts.push(`--model ${fillModel}`);
+    droidArgParts.push(`--model "${fillModel}"`);
   }
 
   if (normalizedUserArgs) {

--- a/src/tag/commands/fill.ts
+++ b/src/tag/commands/fill.ts
@@ -91,6 +91,13 @@ export async function prepareFillMode({
 
   const droidArgParts: string[] = [];
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+
+  // Add model override if specified
+  const fillModel = process.env.FILL_MODEL?.trim();
+  if (fillModel) {
+    droidArgParts.push(`--model ${fillModel}`);
+  }
+
   if (normalizedUserArgs) {
     droidArgParts.push(normalizedUserArgs);
   }

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -100,6 +100,13 @@ export async function prepareReviewMode({
 
   const droidArgParts: string[] = [];
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+
+  // Add model override if specified
+  const reviewModel = process.env.REVIEW_MODEL?.trim();
+  if (reviewModel) {
+    droidArgParts.push(`--model ${reviewModel}`);
+  }
+
   if (normalizedUserArgs) {
     droidArgParts.push(normalizedUserArgs);
   }

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -104,7 +104,7 @@ export async function prepareReviewMode({
   // Add model override if specified
   const reviewModel = process.env.REVIEW_MODEL?.trim();
   if (reviewModel) {
-    droidArgParts.push(`--model ${reviewModel}`);
+    droidArgParts.push(`--model "${reviewModel}"`);
   }
 
   if (normalizedUserArgs) {

--- a/test/modes/tag/fill-command.test.ts
+++ b/test/modes/tag/fill-command.test.ts
@@ -162,7 +162,7 @@ describe("prepareFillMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).toContain("--model gpt-5.1-codex");
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.1-codex"');
   });
 
   it("does not add --model flag when FILL_MODEL is empty", async () => {

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -260,7 +260,7 @@ describe("prepareReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).toContain("--model claude-sonnet-4-5-20250929");
+    expect(droidArgsCall?.[1]).toContain('--model "claude-sonnet-4-5-20250929"');
   });
 
   it("does not add --model flag when REVIEW_MODEL is empty", async () => {


### PR DESCRIPTION
## Summary
Adds a new `review_model` input parameter that allows users to override the model used for `@droid review` and `automatic_review` flows.
## Changes
- Added `review_model` input to `action.yml` with description and empty default
- Passed `REVIEW_MODEL` environment variable to the prepare step
- Updated `src/tag/commands/review.ts` to append `--model` flag when `review_model` is set
- Added unit tests verifying the model flag is correctly added when set and omitted when empty
## Implementation Details
The `review_model` input flows through the action as follows:
1. User sets `review_model` in their workflow YAML
2. The value is passed to the prepare step via `REVIEW_MODEL` environment variable
3. In `prepareReviewMode()`, if `REVIEW_MODEL` is set and non-empty, `--model <value>` is appended to `droid_args`
## Usage
```yaml
- uses: Factory-AI/droid-action@v1
  with:
    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
    automatic_review: true
    review_model: "claude-sonnet-4-5-20250929"  # Optional
```
## Testing
- Added 2 new unit tests for the review command:
  - Verifies `--model` flag is added when `REVIEW_MODEL` is set
  - Verifies `--model` flag is omitted when `REVIEW_MODEL` is empty
- All existing tests continue to pass
## Related Issues
FAC-13933