### PR TITLE
chore: disable assignee and label triggers until instruct mode is implemented

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -3,7 +3,6 @@
 import * as core from "@actions/core";
 import {
   isIssuesEvent,
-  isIssuesAssignedEvent,
   isIssueCommentEvent,
   isPullRequestEvent,
   isPullRequestReviewEvent,
@@ -14,7 +13,7 @@ import { extractCommandFromContext } from "../utils/command-parser";
 
 export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   const {
-    inputs: { assigneeTrigger, labelTrigger, triggerPhrase },
+    inputs: { triggerPhrase },
   } = context;
 
   // Check for specific @droid commands (fill, review)
@@ -24,27 +23,26 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     return true;
   }
 
-  // Check for assignee trigger
-  if (isIssuesAssignedEvent(context)) {
-    // Remove @ symbol from assignee_trigger if present
-    let triggerUser = assigneeTrigger.replace(/^@/, "");
-    const assigneeUsername = context.payload.assignee?.login || "";
+  // TODO: Assignee trigger - disabled until instruct mode is implemented.
+  // Currently routes to review mode which throws on non-PR contexts.
+  // if (isIssuesAssignedEvent(context)) {
+  //   let triggerUser = assigneeTrigger.replace(/^@/, "");
+  //   const assigneeUsername = context.payload.assignee?.login || "";
+  //   if (triggerUser && assigneeUsername === triggerUser) {
+  //     console.log(`Issue assigned to trigger user '${triggerUser}'`);
+  //     return true;
+  //   }
+  // }
 
-    if (triggerUser && assigneeUsername === triggerUser) {
-      console.log(`Issue assigned to trigger user '${triggerUser}'`);
-      return true;
-    }
-  }
-
-  // Check for label trigger
-  if (isIssuesEvent(context) && context.eventAction === "labeled") {
-    const labelName = (context.payload as any).label?.name || "";
-
-    if (labelTrigger && labelName === labelTrigger) {
-      console.log(`Issue labeled with trigger label '${labelTrigger}'`);
-      return true;
-    }
-  }
+  // TODO: Label trigger - disabled until instruct mode is implemented.
+  // Currently routes to review mode which throws on non-PR contexts.
+  // if (isIssuesEvent(context) && context.eventAction === "labeled") {
+  //   const labelName = (context.payload as any).label?.name || "";
+  //   if (labelTrigger && labelName === labelTrigger) {
+  //     console.log(`Issue labeled with trigger label '${labelTrigger}'`);
+  //     return true;
+  //   }
+  // }
 
   // Check for issue body and title trigger on issue creation
   if (isIssuesEvent(context) && context.eventAction === "opened") {

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -14,7 +14,6 @@ import {
 } from "./mockContext";
 import type {
   IssueCommentEvent,
-  IssuesAssignedEvent,
   IssuesEvent,
   PullRequestEvent,
   PullRequestReviewEvent,
@@ -23,77 +22,18 @@ import type { ParsedGitHubContext } from "../src/github/context";
 
 describe("checkContainsTrigger", () => {
 
-  describe("assignee trigger", () => {
-    it("should return true when issue is assigned to the trigger user", () => {
+  // TODO: Assignee and label triggers are disabled until instruct mode is implemented.
+  // These tests verify the triggers are no-ops for now.
+  describe("assignee trigger (disabled)", () => {
+    it("should return false - trigger is disabled until instruct mode is implemented", () => {
       const context = mockIssueAssignedContext;
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should add @ symbol from assignee trigger", () => {
-      const context = {
-        ...mockIssueAssignedContext,
-        inputs: {
-          ...mockIssueAssignedContext.inputs,
-          assigneeTrigger: "droid-bot",
-        },
-      };
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should return false when issue is assigned to a different user", () => {
-      const context = {
-        ...mockIssueAssignedContext,
-        payload: {
-          ...mockIssueAssignedContext.payload,
-          assignee: {
-            ...(mockIssueAssignedContext.payload as IssuesAssignedEvent)
-              .assignee,
-            login: "otherUser",
-          },
-          issue: {
-            ...(mockIssueAssignedContext.payload as IssuesAssignedEvent).issue,
-            assignee: {
-              ...(mockIssueAssignedContext.payload as IssuesAssignedEvent).issue
-                .assignee,
-              login: "otherUser",
-            },
-          },
-        },
-      } as ParsedGitHubContext;
-
       expect(checkContainsTrigger(context)).toBe(false);
     });
   });
 
-  describe("label trigger", () => {
-    it("should return true when issue is labeled with the trigger label", () => {
+  describe("label trigger (disabled)", () => {
+    it("should return false - trigger is disabled until instruct mode is implemented", () => {
       const context = mockIssueLabeledContext;
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should return false when issue is labeled with a different label", () => {
-      const context = {
-        ...mockIssueLabeledContext,
-        payload: {
-          ...mockIssueLabeledContext.payload,
-          label: {
-            ...(mockIssueLabeledContext.payload as any).label,
-            name: "bug",
-          },
-        },
-      } as ParsedGitHubContext;
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
-
-    it("should return false for non-labeled events", () => {
-      const context = {
-        ...mockIssueLabeledContext,
-        eventAction: "opened",
-        payload: {
-          ...mockIssueLabeledContext.payload,
-          action: "opened",
-        },
-      } as ParsedGitHubContext;
       expect(checkContainsTrigger(context)).toBe(false);
     });
   });


### PR DESCRIPTION
Assignee and label triggers were routing to review mode, which throws on non-PR contexts. Commented out the trigger logic until instruct mode can handle issue contexts.

- Disabled trigger detection in `src/github/validation/trigger.ts`
- Updated tests to expect triggers to be no-ops
- Updated PRD to reflect planned status
