### PR TITLE
feat: add modular sub-actions for parallel review workflow

### DIFF
--- a/combine/action.yml
+++ b/combine/action.yml
@@ -1,0 +1,71 @@
+name: "Droid Combine Results"
+description: "Combine code review results, post inline comments, update summary"
+
+inputs:
+  factory_api_key:
+    description: "Factory API key"
+    required: true
+  tracking_comment_id:
+    description: "ID of the tracking comment to update"
+    required: true
+  code_review_results:
+    description: "Path to code review results JSON (optional)"
+    required: false
+    default: ""
+  code_review_status:
+    description: "Code review job status (success/failure/skipped)"
+    required: false
+    default: "skipped"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Bun
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+      with:
+        bun-version: 1.2.11
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        bun install
+        cd ${{ github.action_path }}/../base-action
+        bun install
+
+    - name: Install Droid CLI
+      shell: bash
+      run: |
+        curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL https://app.factory.ai/cli | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/droid" --version
+
+    - name: Get GitHub Token
+      id: token
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/get-token.ts
+      env:
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+
+    - name: Generate Combine Prompt
+      id: prompt
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/generate-combine-prompt.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        CODE_REVIEW_RESULTS: ${{ inputs.code_review_results }}
+        CODE_REVIEW_STATUS: ${{ inputs.code_review_status }}
+
+    - name: Run Combine
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../base-action/src/index.ts
+      env:
+        INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
+        INPUT_DROID_ARGS: ${{ steps.prompt.outputs.droid_args }}
+        INPUT_MCP_TOOLS: ${{ steps.prompt.outputs.mcp_tools }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -1,0 +1,77 @@
+name: "Droid Prepare"
+description: "Initialize Droid review - creates tracking comment and detects review modes"
+
+inputs:
+  factory_api_key:
+    description: "Factory API key"
+    required: true
+  github_token:
+    description: "GitHub token"
+    required: false
+  automatic_review:
+    description: "Run automatic code review"
+    required: false
+    default: "false"
+
+outputs:
+  github_token:
+    description: "GitHub token (from OIDC or input)"
+    value: ${{ steps.prepare.outputs.github_token }}
+  comment_id:
+    description: "Tracking comment ID"
+    value: ${{ steps.prepare.outputs.droid_comment_id }}
+  run_code_review:
+    description: "Whether to run code review"
+    value: ${{ steps.detect.outputs.run_code_review }}
+  contains_trigger:
+    description: "Whether a trigger was detected"
+    value: ${{ steps.prepare.outputs.contains_trigger }}
+  pr_number:
+    description: "PR number"
+    value: ${{ steps.prepare.outputs.pr_number }}
+  base_branch:
+    description: "Base branch name"
+    value: ${{ steps.prepare.outputs.base_branch }}
+  head_branch:
+    description: "Head branch name"
+    value: ${{ steps.prepare.outputs.head_branch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Bun
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+      with:
+        bun-version: 1.2.11
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        bun install
+
+    - name: Prepare
+      id: prepare
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/prepare.ts
+      env:
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
+        AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
+        TRIGGER_PHRASE: "@droid"
+        ALLOWED_BOTS: ""
+        ALLOWED_NON_WRITE_USERS: ""
+        USE_STICKY_COMMENT: "false"
+        TRACK_PROGRESS: "false"
+
+    - name: Detect Review Types
+      id: detect
+      shell: bash
+      run: |
+        RUN_CODE="${{ steps.prepare.outputs.run_code_review }}"
+        if [ -z "$RUN_CODE" ]; then
+          RUN_CODE="${{ inputs.automatic_review }}"
+        fi
+        echo "run_code_review=$RUN_CODE" >> $GITHUB_OUTPUT
+        echo "Detected: code_review=$RUN_CODE"

--- a/review/action.yml
+++ b/review/action.yml
@@ -1,0 +1,83 @@
+name: "Droid Code Review"
+description: "Run Droid code review on a PR"
+
+inputs:
+  factory_api_key:
+    description: "Factory API key"
+    required: true
+  github_token:
+    description: "GitHub token (optional - will use OIDC if not provided)"
+    required: false
+    default: ""
+  tracking_comment_id:
+    description: "ID of the tracking comment to update"
+    required: true
+  review_model:
+    description: "Model to use for review"
+    required: false
+    default: ""
+  output_file:
+    description: "Path to write review results JSON"
+    required: false
+    default: ""
+
+outputs:
+  conclusion:
+    description: "Review conclusion (success/failure)"
+    value: ${{ steps.review.outputs.conclusion }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Bun
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+      with:
+        bun-version: 1.2.11
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        bun install
+        cd ${{ github.action_path }}/../base-action
+        bun install
+
+    - name: Install Droid CLI
+      shell: bash
+      run: |
+        curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL https://app.factory.ai/cli | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/droid" --version
+
+    - name: Get GitHub Token
+      id: token
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/get-token.ts
+      env:
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Generate Review Prompt
+      id: prompt
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/generate-review-prompt.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        REVIEW_MODEL: ${{ inputs.review_model }}
+        REVIEW_TYPE: "code"
+
+    - name: Run Code Review
+      id: review
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../base-action/src/index.ts
+      env:
+        INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
+        INPUT_DROID_ARGS: ${{ steps.prompt.outputs.droid_args }}
+        INPUT_MCP_TOOLS: ${{ steps.prompt.outputs.mcp_tools }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        DROID_OUTPUT_FILE: ${{ inputs.output_file }}

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -66,7 +66,7 @@ export function buildDisallowedToolsString(
 
 export function prepareContext(
   context: ParsedGitHubContext,
-  droidCommentId: string,
+  droidCommentId?: string,
   baseBranch?: string,
   droidBranch?: string,
   prBranchData?: { headRefName: string; headRefOid: string },
@@ -108,15 +108,12 @@ export function prepareContext(
     commonFields.droidBranch = droidBranch;
   }
 
-  const eventData = buildEventData(
-    context,
-    {
-      commentId,
-      commentBody,
-      baseBranch,
-      droidBranch,
-    },
-  );
+  const eventData = buildEventData(context, {
+    commentId,
+    commentBody,
+    baseBranch,
+    droidBranch,
+  });
 
   const result: PreparedContext = {
     ...commonFields,
@@ -282,13 +279,11 @@ function buildEventData(
   }
 }
 
-export type PromptGenerator = (
-  context: PreparedContext,
-) => string;
+export type PromptGenerator = (context: PreparedContext) => string;
 
 export type PromptCreationOptions = {
   githubContext: ParsedGitHubContext;
-  commentId: number;
+  commentId?: number;
   baseBranch?: string;
   droidBranch?: string;
   prBranchData?: { headRefName: string; headRefOid: string };
@@ -310,7 +305,7 @@ export async function createPrompt({
   includeActionsTools = false,
 }: PromptCreationOptions) {
   try {
-    const droidCommentId = commentId.toString();
+    const droidCommentId = commentId?.toString();
     const preparedContext = prepareContext(
       githubContext,
       droidCommentId,

--- a/src/create-prompt/templates/combine-prompt.ts
+++ b/src/create-prompt/templates/combine-prompt.ts
@@ -1,0 +1,83 @@
+import type { PreparedContext } from "../types";
+
+export function generateCombinePrompt(
+  context: PreparedContext,
+  codeReviewResultsPath: string,
+): string {
+  const prNumber = context.eventData.isPR
+    ? context.eventData.prNumber
+    : context.githubContext && "entityNumber" in context.githubContext
+      ? String(context.githubContext.entityNumber)
+      : "unknown";
+
+  const repoFullName = context.repository;
+
+  return `You are combining code review results for PR #${prNumber} in ${repoFullName}.
+The gh CLI is installed and authenticated via GH_TOKEN.
+
+## Context
+- Repo: ${repoFullName}
+- PR Number: ${prNumber}
+- Code Review Results: ${codeReviewResultsPath}
+
+## Task
+
+1. Read the results file (if it exists):
+   - ${codeReviewResultsPath} - Code review findings
+
+2. Post inline comments for all findings using github_inline_comment___create_inline_comment:
+   - Use side="RIGHT" for new/modified code
+   - Include severity, description, and suggested fix where available
+
+3. Analyze the PR diff to generate:
+   - A concise 1-2 sentence summary of what the PR does
+   - 3-5 key changes extracted from the diff
+   - The most important files changed (up to 5-7 files)
+
+4. Update the tracking comment with combined summary using github_comment___update_droid_comment:
+
+IMPORTANT: Do NOT use github_pr___submit_review. Only update the tracking comment and post inline comments.
+The tracking comment IS the summary - do not create any other summary comments.
+
+\`\`\`markdown
+## Code review completed
+
+### Summary
+{Brief 1-2 sentence description of what this PR does}
+
+### Key Changes
+- {Change 1}
+- {Change 2}
+- {Change 3}
+
+### Important Files Changed
+- \`path/to/file1.ts\` - {Brief description of changes}
+- \`path/to/file2.ts\` - {Brief description of changes}
+
+### Code Review
+| Type | Count |
+|------|-------|
+| 🐛 Bugs | X |
+| ⚠️ Issues | X |
+| 💡 Suggestions | X |
+
+### Findings
+| ID | Type | Severity | File | Description |
+|----|------|----------|------|-------------|
+| ... | ... | ... | ... | ... |
+
+[View workflow run](link)
+\`\`\`
+
+## Available Tools
+- github_comment___update_droid_comment - Update tracking comment (this is the ONLY place for the summary)
+- github_inline_comment___create_inline_comment - Post inline comments on specific lines
+- Read, Grep, Glob, LS, Execute - File operations
+
+DO NOT use github_pr___submit_review - it creates duplicate summary comments.
+
+## Important
+- If no results files exist or they're empty, report "No issues found"
+- Maximum 10 inline comments total
+`;
+}

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -2,7 +2,7 @@ import type { GitHubContext } from "../github/context";
 
 export type CommonFields = {
   repository: string;
-  droidCommentId: string;
+  droidCommentId?: string;
   triggerPhrase: string;
   triggerUsername?: string;
   droidBranch?: string;

--- a/src/entrypoints/generate-combine-prompt.ts
+++ b/src/entrypoints/generate-combine-prompt.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+
+/**
+ * Generate combine prompt for finalizing reviews
+ */
+
+import * as core from "@actions/core";
+import { createOctokit } from "../github/api/client";
+import { parseGitHubContext, isEntityContext } from "../github/context";
+import { fetchPRBranchData } from "../github/data/pr-fetcher";
+import { createPrompt } from "../create-prompt";
+import { prepareMcpTools } from "../mcp/install-mcp-server";
+import { generateCombinePrompt } from "../create-prompt/templates/combine-prompt";
+import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
+
+async function run() {
+  try {
+    const githubToken = process.env.GITHUB_TOKEN!;
+    const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
+    const codeReviewResults = process.env.CODE_REVIEW_RESULTS || "";
+
+    const context = parseGitHubContext();
+
+    if (!isEntityContext(context)) {
+      throw new Error("Combine requires entity context (PR or issue)");
+    }
+
+    if (!context.isPR) {
+      throw new Error("Combine is only supported on pull requests");
+    }
+
+    const octokit = createOctokit(githubToken);
+
+    const prData = await fetchPRBranchData({
+      octokits: octokit,
+      repository: context.repository,
+      prNumber: context.entityNumber,
+    });
+
+    // Generate combine prompt with paths to result files
+    await createPrompt({
+      githubContext: context,
+      commentId: commentId || undefined,
+      baseBranch: prData.baseRefName,
+      prBranchData: {
+        headRefName: prData.headRefName,
+        headRefOid: prData.headRefOid,
+      },
+      generatePrompt: (ctx) => generateCombinePrompt(ctx, codeReviewResults),
+    });
+
+    core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-combine");
+
+    const rawUserArgs = process.env.DROID_ARGS || "";
+    const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
+    const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
+      (tool) => tool.startsWith("github_") && tool.includes("___"),
+    );
+
+    // Combine step has tools for inline comments and tracking comment update
+    // NO github_pr___submit_review - it creates duplicate summary comments
+    const baseTools = [
+      "Read",
+      "Grep",
+      "Glob",
+      "LS",
+      "Execute",
+      "github_comment___update_droid_comment",
+      "github_inline_comment___create_inline_comment",
+    ];
+
+    const allowedTools = Array.from(
+      new Set([...baseTools, ...userAllowedMCPTools]),
+    );
+
+    const mcpTools = await prepareMcpTools({
+      githubToken,
+      owner: context.repository.owner,
+      repo: context.repository.repo,
+      droidCommentId: commentId ? commentId.toString() : undefined,
+      allowedTools,
+      mode: "tag",
+      context,
+    });
+
+    const droidArgParts: string[] = [];
+    // Only include built-in tools in --enabled-tools
+    const builtInTools = allowedTools.filter((t) => !t.includes("___"));
+    if (builtInTools.length > 0) {
+      droidArgParts.push(`--enabled-tools "${builtInTools.join(",")}"`);
+    }
+
+    if (normalizedUserArgs) {
+      droidArgParts.push(normalizedUserArgs);
+    }
+
+    core.setOutput("droid_args", droidArgParts.join(" ").trim());
+    core.setOutput("mcp_tools", mcpTools);
+
+    console.log(`Generated combine prompt`);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Generate combine prompt failed: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  run();
+}

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+
+/**
+ * Generate review prompt for standalone review action
+ */
+
+import * as core from "@actions/core";
+import { createOctokit } from "../github/api/client";
+import { parseGitHubContext, isEntityContext } from "../github/context";
+import { fetchPRBranchData } from "../github/data/pr-fetcher";
+import { createPrompt } from "../create-prompt";
+import { prepareMcpTools } from "../mcp/install-mcp-server";
+import { generateReviewPrompt } from "../create-prompt/templates/review-prompt";
+import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
+
+async function run() {
+  try {
+    const githubToken = process.env.GITHUB_TOKEN!;
+    const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
+
+    const context = parseGitHubContext();
+
+    if (!isEntityContext(context)) {
+      throw new Error("Review requires entity context (PR or issue)");
+    }
+
+    if (!context.isPR) {
+      throw new Error("Review is only supported on pull requests");
+    }
+
+    const octokit = createOctokit(githubToken);
+
+    const prData = await fetchPRBranchData({
+      octokits: octokit,
+      repository: context.repository,
+      prNumber: context.entityNumber,
+    });
+
+    const branchInfo = {
+      baseBranch: prData.baseRefName,
+      currentBranch: prData.headRefName,
+    };
+
+    await createPrompt({
+      githubContext: context,
+      commentId: commentId || undefined,
+      baseBranch: branchInfo.baseBranch,
+      prBranchData: {
+        headRefName: prData.headRefName,
+        headRefOid: prData.headRefOid,
+      },
+      generatePrompt: generateReviewPrompt,
+    });
+
+    core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
+
+    const rawUserArgs = process.env.DROID_ARGS || "";
+    const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
+    const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
+      (tool) => tool.startsWith("github_") && tool.includes("___"),
+    );
+
+    const baseTools = [
+      "Read",
+      "Grep",
+      "Glob",
+      "LS",
+      "Execute",
+      "github_comment___update_droid_comment",
+      "github_inline_comment___create_inline_comment",
+    ];
+
+    const reviewTools = [
+      "github_pr___list_review_comments",
+      "github_pr___submit_review",
+      "github_pr___delete_comment",
+      "github_pr___minimize_comment",
+      "github_pr___reply_to_comment",
+      "github_pr___resolve_review_thread",
+    ];
+
+    const allowedTools = Array.from(
+      new Set([...baseTools, ...reviewTools, ...userAllowedMCPTools]),
+    );
+
+    const mcpTools = await prepareMcpTools({
+      githubToken,
+      owner: context.repository.owner,
+      repo: context.repository.repo,
+      droidCommentId: commentId ? commentId.toString() : undefined,
+      allowedTools,
+      mode: "tag",
+      context,
+    });
+
+    const droidArgParts: string[] = [];
+    // Only include built-in tools in --enabled-tools
+    const builtInTools = allowedTools.filter((t) => !t.includes("___"));
+    if (builtInTools.length > 0) {
+      droidArgParts.push(`--enabled-tools "${builtInTools.join(",")}"`);
+    }
+
+    // Add model override if specified
+    const model = process.env.REVIEW_MODEL?.trim();
+    if (model) {
+      droidArgParts.push(`--model "${model}"`);
+    }
+
+    if (normalizedUserArgs) {
+      droidArgParts.push(normalizedUserArgs);
+    }
+
+    core.setOutput("droid_args", droidArgParts.join(" ").trim());
+    core.setOutput("mcp_tools", mcpTools);
+
+    console.log(`Generated review prompt`);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Generate prompt failed: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  run();
+}

--- a/src/entrypoints/get-token.ts
+++ b/src/entrypoints/get-token.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+
+/**
+ * Gets GitHub token via OIDC or uses provided token
+ */
+
+import * as core from "@actions/core";
+import { appendFileSync } from "fs";
+import { setupGitHubToken } from "../github/token";
+
+async function run() {
+  try {
+    const overrideToken = process.env.OVERRIDE_GITHUB_TOKEN?.trim();
+
+    let token: string;
+    if (overrideToken) {
+      console.log("Using provided GitHub token");
+      token = overrideToken;
+    } else {
+      console.log("Requesting OIDC token...");
+      token = await setupGitHubToken();
+      console.log("GitHub token obtained via OIDC");
+    }
+
+    // Set output for next steps
+    const githubOutput = process.env.GITHUB_OUTPUT;
+    if (githubOutput) {
+      appendFileSync(githubOutput, `github_token=${token}\n`);
+    }
+    core.setOutput("github_token", token);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Failed to get GitHub token: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  run();
+}

--- a/src/prepare/types.ts
+++ b/src/prepare/types.ts
@@ -9,6 +9,8 @@ export type PrepareResult = {
     currentBranch: string;
   };
   mcpTools: string;
+  skipped?: boolean;
+  reason?: string;
 };
 
 export type PrepareOptions = {


### PR DESCRIPTION
## Summary

Add modular sub-actions (`prepare/`, `review/`, `combine/`) that enable parallel execution of code reviews in multi-job GitHub Actions workflows.

## Changes

### New Sub-Actions
- **`prepare/action.yml`** - Initialize review, create tracking comment, detect review modes
- **`review/action.yml`** - Run code review as standalone job
- **`combine/action.yml`** - Combine results and post inline comments

### New Entrypoints
- `src/entrypoints/get-token.ts` - Get GitHub token via OIDC for sub-actions
- `src/entrypoints/generate-review-prompt.ts` - Generate review prompt for standalone review action
- `src/entrypoints/generate-combine-prompt.ts` - Generate combine prompt for result aggregation

### Type Changes
- Made `commentId` optional in `create-prompt` types to support sub-action usage
- Added `skipped` and `reason` fields to `PrepareResult` for better flow control

## Testing
- All existing tests pass
- Type checking passes

## Usage

This enables workflows like:

```yaml
jobs:
  prepare:
    steps:
      - uses: Factory-AI/droid-action/prepare@v1
        with:
          factory_api_key: ${{ secrets.FACTORY_API_KEY }}

  code-review:
    needs: prepare
    steps:
      - uses: Factory-AI/droid-action/review@v1
        with:
          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
          tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}

  combine:
    needs: [prepare, code-review]
    steps:
      - uses: Factory-AI/droid-action/combine@v1
        with:
          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
          tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
```

## Part of

This is PR 1 of 3 for the security review feature:
1. **This PR**: Sub-action infrastructure
2. PR 2: Code review refactor (output to JSON)
3. PR 3: Security review feature