### PR TITLE
refactor: change code review to output JSON for combine step

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -5,8 +5,33 @@ on:
     types: [opened, ready_for_review, reopened]
 
 jobs:
-  droid-review:
+  prepare:
     if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    outputs:
+      comment_id: ${{ steps.prepare.outputs.comment_id }}
+      run_code_review: ${{ steps.prepare.outputs.run_code_review }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Prepare
+        id: prepare
+        uses: Factory-AI/droid-action/prepare@v1
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+
+  code-review:
+    needs: prepare
+    if: needs.prepare.outputs.run_code_review == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,8 +45,47 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v1
+      - name: Run Code Review
+        uses: Factory-AI/droid-action/review@v1
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
-          automatic_review: true
+          tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
+          output_file: ${{ runner.temp }}/code-review-results.json
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-review-results
+          path: ${{ runner.temp }}/code-review-results.json
+          if-no-files-found: ignore
+
+  combine:
+    needs: [prepare, code-review]
+    if: always() && needs.prepare.outputs.run_code_review == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Download Code Review Results
+        uses: actions/download-artifact@v4
+        with:
+          name: code-review-results
+          path: ${{ runner.temp }}
+        continue-on-error: true
+
+      - name: Combine Results
+        uses: Factory-AI/droid-action/combine@v1
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
+          code_review_results: ${{ runner.temp }}/code-review-results.json
+          code_review_status: ${{ needs.code-review.result }}

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -1,8 +1,6 @@
 import type { PreparedContext } from "../types";
 
-export function generateReviewPrompt(
-  context: PreparedContext,
-): string {
+export function generateReviewPrompt(context: PreparedContext): string {
   const prNumber = context.eventData.isPR
     ? context.eventData.prNumber
     : context.githubContext && "entityNumber" in context.githubContext
@@ -25,34 +23,19 @@ Context:
 - PR Base Ref: ${baseRefName}
 
 Objectives:
-1) Re-check existing review comments and resolve threads when the issue is fixed (fall back to a brief "resolved" reply only if the thread cannot be marked resolved).
-2) Review the current PR diff and surface only clear, high-severity issues.
-3) Leave concise inline comments (1-2 sentences) on bugs introduced by the PR. You may also comment on unchanged lines if the PR's changes expose or trigger issues there—but explain the connection clearly.
+1) Review the current PR diff and surface only clear, high-severity issues.
+2) Output findings in JSON format for later processing (DO NOT post inline comments directly).
+3) Update the tracking comment with a summary.
 
 Procedure:
 - Run: gh pr view ${prNumber} --repo ${repoFullName} --json comments,reviews
 - Run: gh pr diff ${prNumber} --repo ${repoFullName}
 - Run: gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate --jq '.[] | {filename,patch,additions,deletions}'
-- Prefer github_inline_comment___create_inline_comment with side="RIGHT" to post inline findings on changed/added lines
-- Compute exact diff positions (path + position) for each issue; every substantive comment must be inline on the changed line (no new top-level issue comments).
-- Detect prior top-level "no issues" comments authored by this bot (e.g., "no issues", "No issues found", "LGTM", including emoji-prefixed variants).
-- If the current run finds issues and prior "no issues" comments exist, delete them via gh api -X DELETE repos/${repoFullName}/issues/comments/<comment_id>; if deletion fails, minimize via GraphQL or reply "Superseded: issues were found in newer commits".
-- If a previously reported issue appears resolved by nearby changes, call github_pr___resolve_review_thread (when permitted) to mark it resolved; otherwise provide a brief reply within that thread noting the resolution.
+- Analyze the diff for issues
+- Write findings to \`code-review-results.json\` in the current directory
 
-Preferred MCP tools (when available):
-- github_inline_comment___create_inline_comment to post inline feedback anchored to the diff
-- github_pr___submit_review to send inline review feedback
-- github_pr___delete_comment to remove outdated "no issues" comments
-- github_pr___minimize_comment when deletion is unavailable but minimization is acceptable
-- github_pr___reply_to_comment to acknowledge resolved threads
-- github_pr___resolve_review_thread to formally resolve threads once issues are fixed
-
-Diff Side Selection (CRITICAL):  
-- When calling github_inline_comment___create_inline_comment, ALWAYS specify the 'side' parameter  
-- Use side="RIGHT" for comments on NEW or MODIFIED code (what the PR adds/changes)  
-- Use side="LEFT" ONLY when commenting on code being REMOVED (only if you need to reference the old implementation)  
-- The 'line' parameter refers to the line number on the specified side of the diff  
-- Ensure the line numbers you use correspond to the side you choose;
+IMPORTANT: Do NOT post inline comments directly. Instead, write findings to a JSON file.
+The finalize step will post all inline comments to avoid overlapping with security review comments.
 
 Analysis scope (prioritize high-confidence findings):
 - Correctness bugs and boundary errors
@@ -77,16 +60,68 @@ Commenting rules:
 - Maximum 10 inline comments total; one issue per comment.
 - Anchor findings to the relevant diff hunk so reviewers see the context immediately.
 - Focus on defects introduced or exposed by the PR's changes; if a new bug manifests on an unchanged line, you may post inline comments on those unchanged lines but clearly explain how the submitted changes trigger it.
-- Match the side parameter to the code segment you're referencing (default to RIGHT for new code) and provide line numbers from that same side
 - Tone should be deferential—write like a junior developer seeking confirmation; keep comments concise and respectful.
 - For low confidence findings, ask a question; for medium/high confidence, state the issue concretely.
-- Only include explicit code suggestions when you are absolutely certain the replacement is correct and safe.
 
-Submission:
-- If no issues are found and a prior "no issues" comment from this bot already exists, skip submitting another comment to avoid redundancy.
-- If no issues are found and no prior "no issues" comment exists, post a single brief top-level summary noting no issues.
-- If issues are found, delete/minimize/supersede any prior "no issues" comment before submitting.
-- Prefer github_inline_comment___create_inline_comment for inline findings and submit the overall review via github_pr___submit_review (fall back to gh api repos/${repoFullName}/pulls/${prNumber}/reviews -f event=COMMENT -f body="$SUMMARY" -f comments='[$COMMENTS_JSON]' when MCP tools are unavailable).
-- Do not approve or request changes; submit a comment-only review with inline feedback (maximum 10 comments).
+Output:
+1. Analyze the PR to generate:
+   - A concise 1-2 sentence summary of what the PR does
+   - 3-5 key changes extracted from the diff
+   - The most important files changed (up to 5-7 files)
+
+2. Write findings to \`code-review-results.json\` with this structure:
+\`\`\`json
+{
+  "type": "code",
+  "summary": "Brief 1-2 sentence description of what this PR does",
+  "keyChanges": [
+    "Added new authentication flow",
+    "Refactored database queries for performance",
+    "Fixed validation bug in user input"
+  ],
+  "importantFiles": [
+    { "path": "src/auth/login.ts", "description": "New OAuth implementation" },
+    { "path": "src/db/queries.ts", "description": "Query optimization" }
+  ],
+  "findings": [
+    {
+      "id": "CR-001",
+      "type": "bug|issue|suggestion",
+      "severity": "high|medium|low",
+      "file": "path/to/file.ts",
+      "line": 45,
+      "side": "RIGHT",
+      "description": "Brief description of the issue",
+      "suggestion": "Optional code fix"
+    }
+  ]
+}
+\`\`\`
+
+3. Update the tracking comment with a summary using \`github_comment___update_droid_comment\`:
+\`\`\`markdown
+## Code review completed
+
+### Summary
+{Brief 1-2 sentence description of what this PR does}
+
+### Key Changes
+- {Change 1}
+- {Change 2}
+- {Change 3}
+
+### Important Files Changed
+- \`path/to/file1.ts\` - {Brief description of changes}
+- \`path/to/file2.ts\` - {Brief description of changes}
+
+### Review Findings
+| ID | Type | Severity | File | Description |
+|----|------|----------|------|-------------|
+| CR-001 | Bug | high | auth.ts:45 | Null pointer exception |
+
+*Inline comments will be posted after all reviews complete.*
+\`\`\`
+
+IMPORTANT: Do NOT post inline comments. Only write to the JSON file and update the tracking comment.
 `;
 }

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -28,12 +28,13 @@ describe("generateReviewPrompt", () => {
     const prompt = generateReviewPrompt(context);
 
     expect(prompt).toContain("Objectives:");
-    expect(prompt).toContain("Re-check existing review comments");
+    expect(prompt).toContain("Review the current PR diff");
     expect(prompt).toContain("gh pr diff 42 --repo test-owner/test-repo");
-    expect(prompt).toContain("gh api repos/test-owner/test-repo/pulls/42/files");
-    expect(prompt).toContain("github_inline_comment___create_inline_comment");
-    expect(prompt).toContain("github_pr___resolve_review_thread");
-    expect(prompt).toContain("every substantive comment must be inline on the changed line");
+    expect(prompt).toContain(
+      "gh api repos/test-owner/test-repo/pulls/42/files",
+    );
+    expect(prompt).toContain("code-review-results.json");
+    expect(prompt).toContain("Do NOT post inline comments");
   });
 
   it("emphasizes accuracy gates and comment limits", () => {
@@ -43,17 +44,22 @@ describe("generateReviewPrompt", () => {
     expect(prompt).toContain("Never raise purely stylistic");
     expect(prompt).toContain("Maximum 10 inline comments");
     expect(prompt).toContain("False positives are very undesirable");
-    expect(prompt).toContain("Never repeat or re-raise an issue previously highlighted");
+    expect(prompt).toContain(
+      "Never repeat or re-raise an issue previously highlighted",
+    );
   });
 
-  it("describes submission guidance", () => {
+  it("describes output format with JSON structure", () => {
     const prompt = generateReviewPrompt(createBaseContext());
 
-    expect(prompt).toContain("Prefer github_inline_comment___create_inline_comment");
-    expect(prompt).toContain("gh api repos/test-owner/test-repo/pulls/42/reviews");
-    expect(prompt).toContain("Do not approve or request changes");
-    expect(prompt).toContain("github_pr___submit_review");
-    expect(prompt).toContain("github_pr___resolve_review_thread");
-    expect(prompt).toContain("skip submitting another comment to avoid redundancy");
+    expect(prompt).toContain("code-review-results.json");
+    expect(prompt).toContain("github_comment___update_droid_comment");
+    expect(prompt).toContain(
+      "Inline comments will be posted after all reviews complete",
+    );
+    expect(prompt).toContain("### Summary");
+    expect(prompt).toContain("### Key Changes");
+    expect(prompt).toContain("### Important Files Changed");
+    expect(prompt).toContain("### Review Findings");
   });
 });


### PR DESCRIPTION
## Summary

Refactors the code review flow to output findings to a JSON file instead of posting inline comments directly. The combine step will then post all inline comments at once.

## Changes

### Review Prompt Changes
- Updated `review-prompt.ts` to output findings to `code-review-results.json`
- Review now outputs JSON with structure: summary, keyChanges, importantFiles, findings
- Inline comments are NOT posted directly - they're deferred to the combine step

### Workflow Changes  
- Updated `droid-review.yml` to use parallel workflow pattern:
  - `prepare` job: Creates tracking comment
  - `code-review` job: Runs review, outputs JSON, uploads artifact
  - `combine` job: Downloads artifact, posts inline comments, updates summary

### Test Updates
- Updated review prompt tests to match new JSON output format
- Updated integration tests to verify new behavior

## Why This Change?

This enables parallel execution of code review with future security review. The combine step will:
1. Download results from both reviews
2. Deduplicate findings (same file/line)
3. Post all inline comments at once (avoiding overlapping comments)
4. Generate a unified summary

## Depends On

- PR #8: Sub-action infrastructure

## Part of

This is PR 2 of 3 for the security review feature:
1. PR #8: Sub-action infrastructure
2. **This PR**: Code review refactor
3. PR 3: Security review feature