### PR TITLE
feat: add security review feature with @droid security command

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       comment_id: ${{ steps.prepare.outputs.comment_id }}
       run_code_review: ${{ steps.prepare.outputs.run_code_review }}
+      run_security_review: ${{ steps.prepare.outputs.run_security_review }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -28,6 +29,7 @@ jobs:
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
+          automatic_security_review: true
 
   code-review:
     needs: prepare
@@ -59,9 +61,44 @@ jobs:
           path: ${{ runner.temp }}/code-review-results.json
           if-no-files-found: ignore
 
+  security-review:
+    needs: prepare
+    if: needs.prepare.outputs.run_security_review == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Security Review
+        uses: Factory-AI/droid-action/security@v1
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
+          security_severity_threshold: medium
+          output_file: ${{ runner.temp }}/security-results.json
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-results
+          path: ${{ runner.temp }}/security-results.json
+          if-no-files-found: ignore
+
   combine:
-    needs: [prepare, code-review]
-    if: always() && needs.prepare.outputs.run_code_review == 'true'
+    needs: [prepare, code-review, security-review]
+    # Only run combine when BOTH code review AND security review were executed
+    if: |
+      always() &&
+      needs.prepare.outputs.run_code_review == 'true' &&
+      needs.prepare.outputs.run_security_review == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -82,10 +119,19 @@ jobs:
           path: ${{ runner.temp }}
         continue-on-error: true
 
+      - name: Download Security Results
+        uses: actions/download-artifact@v4
+        with:
+          name: security-results
+          path: ${{ runner.temp }}
+        continue-on-error: true
+
       - name: Combine Results
         uses: Factory-AI/droid-action/combine@v1
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
           code_review_results: ${{ runner.temp }}/code-review-results.json
+          security_results: ${{ runner.temp }}/security-results.json
           code_review_status: ${{ needs.code-review.result }}
+          security_review_status: ${{ needs.security-review.result }}

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,38 @@ inputs:
     description: "Automatically run the review flow for pull request contexts without requiring an explicit @droid review command. Only supported for PR-related events."
     required: false
     default: "false"
+  automatic_security_review:
+    description: "Automatically run the security review flow for pull request contexts without requiring an explicit @droid security-review command. Only supported for PR-related events."
+    required: false
+    default: "false"
+  security_model:
+    description: "Override the model used for security review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to security review flows."
+    required: false
+    default: ""
+  security_severity_threshold:
+    description: "Minimum severity to report in security reviews (critical, high, medium, low). Findings below this threshold will be filtered out."
+    required: false
+    default: "medium"
+  security_block_on_critical:
+    description: "Submit REQUEST_CHANGES review when critical severity findings are detected."
+    required: false
+    default: "true"
+  security_block_on_high:
+    description: "Submit REQUEST_CHANGES review when high severity findings are detected."
+    required: false
+    default: "false"
+  security_notify_team:
+    description: "GitHub team to @mention on critical findings (e.g., '@org/security-team')."
+    required: false
+    default: ""
+  security_scan_schedule:
+    description: "Enable scheduled security scans. Set to 'true' for schedule events to trigger full repository scans."
+    required: false
+    default: "false"
+  security_scan_days:
+    description: "Number of days of commits to scan for scheduled security scans. Only applies when security_scan_schedule is enabled."
+    required: false
+    default: "7"
   review_model:
     description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
     required: false
@@ -131,6 +163,14 @@ runs:
         DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
+        AUTOMATIC_SECURITY_REVIEW: ${{ inputs.automatic_security_review }}
+        SECURITY_MODEL: ${{ inputs.security_model }}
+        SECURITY_SEVERITY_THRESHOLD: ${{ inputs.security_severity_threshold }}
+        SECURITY_BLOCK_ON_CRITICAL: ${{ inputs.security_block_on_critical }}
+        SECURITY_BLOCK_ON_HIGH: ${{ inputs.security_block_on_high }}
+        SECURITY_NOTIFY_TEAM: ${{ inputs.security_notify_team }}
+        SECURITY_SCAN_SCHEDULE: ${{ inputs.security_scan_schedule }}
+        SECURITY_SCAN_DAYS: ${{ inputs.security_scan_days }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         FILL_MODEL: ${{ inputs.fill_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
@@ -172,6 +212,67 @@ runs:
         ${GITHUB_ACTION_PATH}/scripts/setup-network-restrictions.sh
       env:
         EXPERIMENTAL_ALLOWED_DOMAINS: ${{ inputs.experimental_allowed_domains }}
+
+    - name: Install Security Skills
+      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.install_security_skills == 'true'
+      shell: bash
+      run: |
+        echo "Installing security skills from Factory-AI/skills..."
+        SKILLS_DIR="$HOME/.factory/skills"
+        mkdir -p "$SKILLS_DIR"
+
+        # Clone public skills repo (sparse checkout for efficiency)
+        TEMP_DIR=$(mktemp -d)
+        git clone --filter=blob:none --sparse \
+          "https://github.com/Factory-AI/skills.git" \
+          "$TEMP_DIR" 2>/dev/null || {
+          echo "Warning: Could not clone skills repo. Security skills will not be available."
+          exit 0
+        }
+
+        cd "$TEMP_DIR"
+        git sparse-checkout set \
+          skills/threat-model-generation \
+          skills/commit-security-scan \
+          skills/vulnerability-validation \
+          skills/security-review 2>/dev/null || true
+
+        # Copy skills to ~/.factory/skills/ and track installed count
+        INSTALLED_COUNT=0
+        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
+          if [ -d "skills/$skill" ]; then
+            cp -r "skills/$skill" "$SKILLS_DIR/"
+            echo "  Installed skill: $skill"
+            INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+          else
+            echo "  Warning: Skill not found in repo: $skill"
+          fi
+        done
+
+        # Cleanup
+        rm -rf "$TEMP_DIR"
+
+        # Verify at least one skill was installed
+        if [ "$INSTALLED_COUNT" -eq 0 ]; then
+          echo "Warning: No security skills were installed. The skills may not exist in the Factory-AI/skills repository."
+          echo "Security review will proceed but may have limited functionality."
+        else
+          echo "Security skills installation complete ($INSTALLED_COUNT skills installed)"
+        fi
+
+        # Verify skills exist in the target directory
+        echo "Verifying installed skills in $SKILLS_DIR..."
+        VERIFIED_COUNT=0
+        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
+          if [ -d "$SKILLS_DIR/$skill" ]; then
+            echo "  Verified: $skill"
+            VERIFIED_COUNT=$((VERIFIED_COUNT + 1))
+          fi
+        done
+
+        if [ "$VERIFIED_COUNT" -ne "$INSTALLED_COUNT" ]; then
+          echo "Warning: Skill verification mismatch. Expected $INSTALLED_COUNT, found $VERIFIED_COUNT in $SKILLS_DIR"
+        fi
 
     - name: Run Droid Exec
       id: droid

--- a/combine/action.yml
+++ b/combine/action.yml
@@ -1,5 +1,5 @@
 name: "Droid Combine Results"
-description: "Combine code review results, post inline comments, update summary"
+description: "Combine code review and security review results, post inline comments, update summary"
 
 inputs:
   factory_api_key:
@@ -12,8 +12,16 @@ inputs:
     description: "Path to code review results JSON (optional)"
     required: false
     default: ""
+  security_results:
+    description: "Path to security results JSON (optional)"
+    required: false
+    default: ""
   code_review_status:
     description: "Code review job status (success/failure/skipped)"
+    required: false
+    default: "skipped"
+  security_review_status:
+    description: "Security review job status (success/failure/skipped)"
     required: false
     default: "skipped"
 
@@ -57,7 +65,9 @@ runs:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
         CODE_REVIEW_RESULTS: ${{ inputs.code_review_results }}
+        SECURITY_RESULTS: ${{ inputs.security_results }}
         CODE_REVIEW_STATUS: ${{ inputs.code_review_status }}
+        SECURITY_REVIEW_STATUS: ${{ inputs.security_review_status }}
 
     - name: Run Combine
       shell: bash

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Run automatic code review"
     required: false
     default: "false"
+  automatic_security_review:
+    description: "Run automatic security review"
+    required: false
+    default: "false"
 
 outputs:
   github_token:
@@ -23,6 +27,9 @@ outputs:
   run_code_review:
     description: "Whether to run code review"
     value: ${{ steps.detect.outputs.run_code_review }}
+  run_security_review:
+    description: "Whether to run security review"
+    value: ${{ steps.detect.outputs.run_security_review }}
   contains_trigger:
     description: "Whether a trigger was detected"
     value: ${{ steps.prepare.outputs.contains_trigger }}
@@ -59,6 +66,7 @@ runs:
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
+        AUTOMATIC_SECURITY_REVIEW: ${{ inputs.automatic_security_review }}
         TRIGGER_PHRASE: "@droid"
         ALLOWED_BOTS: ""
         ALLOWED_NON_WRITE_USERS: ""
@@ -69,9 +77,19 @@ runs:
       id: detect
       shell: bash
       run: |
+        # Use outputs from prepare step (set by src/tag/index.ts)
+        # Fall back to input flags if outputs not set
         RUN_CODE="${{ steps.prepare.outputs.run_code_review }}"
+        RUN_SEC="${{ steps.prepare.outputs.run_security_review }}"
+
+        # Default to input flags if prepare didn't set outputs
         if [ -z "$RUN_CODE" ]; then
           RUN_CODE="${{ inputs.automatic_review }}"
         fi
+        if [ -z "$RUN_SEC" ]; then
+          RUN_SEC="${{ inputs.automatic_security_review }}"
+        fi
+
         echo "run_code_review=$RUN_CODE" >> $GITHUB_OUTPUT
-        echo "Detected: code_review=$RUN_CODE"
+        echo "run_security_review=$RUN_SEC" >> $GITHUB_OUTPUT
+        echo "Detected: code_review=$RUN_CODE, security_review=$RUN_SEC"

--- a/security/action.yml
+++ b/security/action.yml
@@ -1,0 +1,130 @@
+name: "Droid Security Review"
+description: "Run Droid security review on a PR"
+
+inputs:
+  factory_api_key:
+    description: "Factory API key"
+    required: true
+  github_token:
+    description: "GitHub token (optional - will use OIDC if not provided)"
+    required: false
+    default: ""
+  tracking_comment_id:
+    description: "ID of the tracking comment to update"
+    required: true
+  security_model:
+    description: "Model to use for security review"
+    required: false
+    default: ""
+  security_severity_threshold:
+    description: "Minimum severity to report"
+    required: false
+    default: "medium"
+  security_block_on_critical:
+    description: "Block PR on critical findings"
+    required: false
+    default: "true"
+  security_block_on_high:
+    description: "Block PR on high findings"
+    required: false
+    default: "false"
+  output_file:
+    description: "Path to write security results JSON"
+    required: false
+    default: ""
+
+outputs:
+  conclusion:
+    description: "Review conclusion (success/failure)"
+    value: ${{ steps.review.outputs.conclusion }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Bun
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+      with:
+        bun-version: 1.2.11
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}/..
+        bun install
+        cd ${{ github.action_path }}/../base-action
+        bun install
+
+    - name: Install Droid CLI
+      shell: bash
+      run: |
+        curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL https://app.factory.ai/cli | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/bin/droid" --version
+
+    - name: Get GitHub Token
+      id: token
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/get-token.ts
+      env:
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Install Security Skills
+      shell: bash
+      run: |
+        echo "Installing security skills from Factory-AI/skills..."
+        SKILLS_DIR="$HOME/.factory/skills"
+        mkdir -p "$SKILLS_DIR"
+
+        TEMP_DIR=$(mktemp -d)
+        git clone --filter=blob:none --sparse \
+          "https://github.com/Factory-AI/skills.git" \
+          "$TEMP_DIR" 2>/dev/null || {
+          echo "Warning: Could not clone skills repo."
+          exit 0
+        }
+
+        cd "$TEMP_DIR"
+        git sparse-checkout set \
+          skills/threat-model-generation \
+          skills/commit-security-scan \
+          skills/vulnerability-validation \
+          skills/security-review 2>/dev/null || true
+
+        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
+          if [ -d "skills/$skill" ]; then
+            cp -r "skills/$skill" "$SKILLS_DIR/"
+            echo "  Installed skill: $skill"
+          fi
+        done
+
+        rm -rf "$TEMP_DIR"
+        echo "Security skills installation complete"
+
+    - name: Generate Security Prompt
+      id: prompt
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/generate-review-prompt.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        SECURITY_MODEL: ${{ inputs.security_model }}
+        SECURITY_SEVERITY_THRESHOLD: ${{ inputs.security_severity_threshold }}
+        SECURITY_BLOCK_ON_CRITICAL: ${{ inputs.security_block_on_critical }}
+        SECURITY_BLOCK_ON_HIGH: ${{ inputs.security_block_on_high }}
+        REVIEW_TYPE: "security"
+
+    - name: Run Security Review
+      id: review
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../base-action/src/index.ts
+      env:
+        INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
+        INPUT_DROID_ARGS: ${{ steps.prompt.outputs.droid_args }}
+        INPUT_MCP_TOOLS: ${{ steps.prompt.outputs.mcp_tools }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        DROID_OUTPUT_FILE: ${{ inputs.output_file }}

--- a/src/create-prompt/templates/security-report-prompt.ts
+++ b/src/create-prompt/templates/security-report-prompt.ts
@@ -1,0 +1,210 @@
+import type { PreparedContext } from "../types";
+import type { ScanScope } from "../../tag/commands/security-scan";
+
+export function generateSecurityReportPrompt(
+  context: PreparedContext,
+  scanScope: ScanScope,
+  branchName: string,
+): string {
+  const date = new Date().toISOString().split("T")[0];
+  const repoFullName = context.repository;
+
+  const scopeDescription =
+    scanScope.type === "full"
+      ? "Entire repository"
+      : `Last ${scanScope.days} days of commits`;
+
+  const scanTypeLabel =
+    scanScope.type === "full" ? "Full Repository" : "Weekly Scheduled";
+
+  const scanInstructions =
+    scanScope.type === "full"
+      ? `- Scan all source files in the repository
+- Focus on: TypeScript, JavaScript, Python, Go, Java, Ruby, PHP files
+- Use: \`find . -type f \\( -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.go" -o -name "*.java" -o -name "*.rb" -o -name "*.php" \\) -not -path "./node_modules/*" -not -path "./.git/*"\``
+      : `- Get commits from the last ${scanScope.days} days: \`git log --since="${scanScope.days} days ago" --name-only --pretty=format:""\`
+- Focus analysis on files changed in recent commits
+- Scan each changed file for security vulnerabilities`;
+
+  // Extract security configuration from context
+  const securityConfig = context.githubContext?.inputs;
+  const severityThreshold =
+    securityConfig?.securitySeverityThreshold ?? "medium";
+  const notifyTeam = securityConfig?.securityNotifyTeam ?? "";
+
+  return `You are performing a ${scanTypeLabel.toLowerCase()} security scan for ${repoFullName}.
+The gh CLI is installed and authenticated via GH_TOKEN.
+
+## Scan Configuration
+- Scope: ${scopeDescription}
+- Severity Threshold: ${severityThreshold} (only report findings at or above this level)
+- Output Branch: ${branchName}
+- Report Path: .factory/security/reports/security-report-${date}.md
+
+## Security Skills Available
+
+You have access to these Factory security skills (installed in ~/.factory/skills/):
+
+1. **threat-model-generation** - Generate STRIDE-based threat model for the repository
+2. **commit-security-scan** - Scan code for security vulnerabilities
+3. **vulnerability-validation** - Validate findings, assess exploitability, filter false positives
+4. **security-review** - Comprehensive security review and patch generation
+
+## Workflow
+
+### Step 1: Create Branch
+\`\`\`bash
+git checkout -b ${branchName}
+\`\`\`
+
+### Step 2: Threat Model Check
+- Check if \`.factory/threat-model.md\` exists in the repository
+- If missing: Invoke the **threat-model-generation** skill to create one
+- If exists: Check the file's last modified date
+  - If >90 days old: Regenerate and update the threat model
+  - If current: Use it as context for the security scan
+
+### Step 3: Security Scan
+${scanInstructions}
+
+For each file:
+- Invoke the **commit-security-scan** skill
+- Look for STRIDE vulnerabilities (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
+
+### Step 4: Validate Findings
+- For each finding from Step 3, invoke the **vulnerability-validation** skill
+- Assess:
+  - Reachability: Is the vulnerable code reachable from user input?
+  - Exploitability: How easy is it to exploit?
+  - Impact: What's the potential damage?
+- Filter out false positives and findings below the severity threshold (${severityThreshold})
+
+### Step 5: Generate Patches
+- For each confirmed finding that can be auto-fixed:
+  - Invoke **security-review** skill to generate patches
+  - Apply the patch to the codebase
+  - Commit the fix with message: \`fix(security): [VULN-XXX] Brief description\`
+
+### Step 6: Generate Report
+- Create directory: \`mkdir -p .factory/security/reports\`
+- Write report to: \`.factory/security/reports/security-report-${date}.md\`
+
+### Step 7: Create PR
+\`\`\`bash
+git add .
+git commit -m "fix(security): Security scan report - ${date}"
+git push origin ${branchName}
+gh pr create --title "fix(security): Security scan report - ${date} (N findings)" \\
+  --body "## Security Scan Report
+
+See \`.factory/security/reports/security-report-${date}.md\` for details.
+
+### Summary
+| Severity | Count | Auto-fixed | Manual Required |
+|----------|-------|------------|-----------------|
+| CRITICAL | X | X | X |
+| HIGH | X | X | X |
+| MEDIUM | X | X | X |
+| LOW | X | X | X |
+
+${notifyTeam ? `cc ${notifyTeam}` : ""}"
+\`\`\`
+
+## Report Format
+
+The report file should follow this structure:
+
+\`\`\`markdown
+# Security Scan Report
+
+**Generated:** ${date}
+**Scan Type:** ${scanTypeLabel}
+**Repository:** ${repoFullName}
+**Severity Threshold:** ${severityThreshold}
+
+## Executive Summary
+
+| Severity | Count | Auto-fixed | Manual Required |
+|----------|-------|------------|-----------------|
+| CRITICAL | X | X | X |
+| HIGH | X | X | X |
+| MEDIUM | X | X | X |
+| LOW | X | X | X |
+
+**Total Findings:** X
+**Auto-fixed:** X
+**Manual Review Required:** X
+
+## Critical Findings
+
+### VULN-001: [Vulnerability Title]
+
+| Attribute | Value |
+|-----------|-------|
+| **Severity** | CRITICAL |
+| **STRIDE Category** | [Tampering/Spoofing/etc] |
+| **CWE** | CWE-XXX |
+| **File** | path/to/file.ts:line |
+| **Status** | Patched / Manual fix required |
+
+**Description:**
+[Clear explanation of the vulnerability]
+
+**Evidence:**
+\\\`\\\`\\\`
+[Code snippet showing the vulnerability]
+\\\`\\\`\\\`
+
+**Fix Applied:** (if auto-patched)
+\\\`\\\`\\\`diff
+- vulnerable code
++ secure code
+\\\`\\\`\\\`
+
+**Recommended Fix:** (if manual)
+[Step-by-step remediation guidance]
+
+---
+
+## High Findings
+[Same format as Critical]
+
+## Medium Findings
+[Same format as Critical]
+
+## Low Findings
+[Same format as Critical]
+
+## Appendix
+
+### Threat Model
+- Version: [date or "newly generated"]
+- Location: .factory/threat-model.md
+
+### Scan Metadata
+- ${scanScope.type === "full" ? "Files" : "Commits"} Scanned: N
+- Scan Duration: Xm Ys
+- Skills Used: threat-model-generation, commit-security-scan, vulnerability-validation, security-review
+
+### References
+- [CWE Database](https://cwe.mitre.org/)
+- [STRIDE Threat Model](https://docs.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats)
+\`\`\`
+
+## Severity Definitions
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **CRITICAL** | Immediately exploitable, high impact, no auth required | RCE, hardcoded secrets, auth bypass |
+| **HIGH** | Exploitable with conditions, significant impact | SQL injection, stored XSS, IDOR |
+| **MEDIUM** | Requires specific conditions, moderate impact | CSRF, info disclosure, missing rate limits |
+| **LOW** | Difficult to exploit, low impact | Verbose errors, missing security headers |
+
+## Important Notes
+
+1. **Accuracy**: Only report high-confidence findings. False positives waste developer time.
+2. **Patches**: Test all generated patches before committing. Ensure they don't break functionality.
+3. **PR Description**: Update the PR body with actual finding counts before creating.
+4. **Commit Messages**: Use semantic commit format: \`fix(security): [VULN-XXX] Description\`
+`;
+}

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -1,0 +1,171 @@
+import type { PreparedContext } from "../types";
+
+export function generateSecurityReviewPrompt(context: PreparedContext): string {
+  const prNumber = context.eventData.isPR
+    ? context.eventData.prNumber
+    : context.githubContext && "entityNumber" in context.githubContext
+      ? String(context.githubContext.entityNumber)
+      : "unknown";
+
+  const repoFullName = context.repository;
+  const headRefName = context.prBranchData?.headRefName ?? "unknown";
+  const headSha = context.prBranchData?.headRefOid ?? "unknown";
+  const baseRefName = context.eventData.baseBranch ?? "unknown";
+
+  // Extract security configuration from context
+  const securityConfig = context.githubContext?.inputs;
+  const severityThreshold =
+    securityConfig?.securitySeverityThreshold ?? "medium";
+  const blockOnCritical = securityConfig?.securityBlockOnCritical ?? true;
+  const blockOnHigh = securityConfig?.securityBlockOnHigh ?? false;
+  const notifyTeam = securityConfig?.securityNotifyTeam ?? "";
+
+  return `You are performing a security-focused code review for PR #${prNumber} in ${repoFullName}.
+The gh CLI is installed and authenticated via GH_TOKEN.
+
+## Context
+- Repo: ${repoFullName}
+- PR Number: ${prNumber}
+- PR Head Ref: ${headRefName}
+- PR Head SHA: ${headSha}
+- PR Base Ref: ${baseRefName}
+
+## Security Configuration
+- Severity Threshold: ${severityThreshold} (only report findings at or above this level)
+- Block on Critical: ${blockOnCritical}
+- Block on High: ${blockOnHigh}
+${notifyTeam ? `- Notify Team: ${notifyTeam} (mention on critical findings)` : ""}
+
+## Security Skills Available
+
+You have access to these Factory security skills (installed in ~/.factory/skills/):
+
+1. **threat-model-generation** - Generate STRIDE-based threat model for the repository
+2. **commit-security-scan** - Scan code changes for security vulnerabilities
+3. **vulnerability-validation** - Validate findings, assess exploitability, filter false positives
+4. **security-review** - Comprehensive security review and patch generation
+
+## Review Workflow
+
+### Step 1: Threat Model Check
+- Check if \`.factory/threat-model.md\` exists in the repository
+- If missing: Invoke the **threat-model-generation** skill to create one, then commit it to the PR branch
+- If exists: Check the file's last modified date
+  - If >90 days old: Post a warning comment suggesting regeneration, but proceed with scan
+  - If current: Use it as context for the security scan
+
+### Step 2: Security Scan
+- Invoke the **commit-security-scan** skill on the PR diff
+- Gather the PR diff using: \`gh pr diff ${prNumber} --repo ${repoFullName}\`
+- Get file changes: \`gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate\`
+- Focus analysis on:
+  - New code introduced by this PR
+  - Modified code that may introduce vulnerabilities
+  - Changes that expose existing vulnerabilities
+
+### Step 3: Validate Findings
+- For each finding from Step 2, invoke the **vulnerability-validation** skill
+- Assess:
+  - Reachability: Is the vulnerable code reachable from user input?
+  - Exploitability: How easy is it to exploit?
+  - Impact: What's the potential damage?
+- Filter out false positives and findings below the severity threshold (${severityThreshold})
+
+### Step 4: Report & Patch
+- For each confirmed finding at or above ${severityThreshold} severity:
+  - Post inline comment using \`github_inline_comment___create_inline_comment\`
+  - Include: severity, STRIDE category, CWE ID, clear explanation, suggested fix
+- For auto-fixable issues: Invoke **security-review** skill to generate patches
+- Commit any generated patches to the PR branch
+
+## Security Scope (STRIDE Categories)
+
+**Spoofing** (S):
+- Weak authentication, session hijacking, token exposure
+
+**Tampering** (T):
+- SQL/NoSQL/command injection, XSS, mass assignment, unsafe deserialization
+
+**Repudiation** (R):
+- Missing audit logs, unsigned transactions
+
+**Information Disclosure** (I):
+- IDOR, verbose errors, hardcoded secrets, sensitive data in logs
+
+**Denial of Service** (D):
+- Missing rate limits, resource exhaustion, ReDoS
+
+**Elevation of Privilege** (E):
+- Missing authorization checks, role manipulation, privilege escalation
+
+## Severity Definitions
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **CRITICAL** | Immediately exploitable, high impact, no auth required | RCE, hardcoded secrets, auth bypass |
+| **HIGH** | Exploitable with conditions, significant impact | SQL injection, stored XSS, IDOR |
+| **MEDIUM** | Requires specific conditions, moderate impact | CSRF, info disclosure, missing rate limits |
+| **LOW** | Difficult to exploit, low impact | Verbose errors, missing security headers |
+
+## Output Requirements
+
+IMPORTANT: Do NOT post inline comments directly. Instead, write findings to a JSON file.
+The finalize step will post all inline comments to avoid overlapping with code review comments.
+
+1. Write findings to \`security-review-results.json\` with this structure:
+\`\`\`json
+{
+  "type": "security",
+  "findings": [
+    {
+      "id": "SEC-001",
+      "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+      "type": "SQL Injection",
+      "stride": "T",
+      "cwe": "CWE-89",
+      "file": "path/to/file.ts",
+      "line": 55,
+      "side": "RIGHT",
+      "description": "Brief description of the vulnerability",
+      "suggestion": "Optional code fix"
+    }
+  ],
+  "summary": "Brief overall summary",
+  "block_pr": ${blockOnCritical || blockOnHigh ? "true if CRITICAL/HIGH found" : "false"}
+}
+\`\`\`
+
+2. Update the tracking comment using \`github_comment___update_droid_comment\`
+
+## Summary Format (for tracking comment update)
+
+Use \`github_comment___update_droid_comment\` to update the tracking comment with this format:
+
+\`\`\`markdown
+## 🔐 Security Review Summary
+
+| Severity | Count |
+|----------|-------|
+| 🚨 CRITICAL | X |
+| 🔴 HIGH | X |
+| 🟡 MEDIUM | X |
+| 🟢 LOW | X |
+
+### Findings
+| ID | Severity | Type | File | Line | Reference |
+|----|----------|------|------|------|-----------|
+| SEC-001 | CRITICAL | SQL Injection | auth.ts | 55 | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) |
+| SEC-002 | HIGH | XSS | client.ts | 98 | [CWE-79](https://cwe.mitre.org/data/definitions/79.html) |
+
+${notifyTeam ? `cc ${notifyTeam}` : ""}
+\`\`\`
+
+## Accuracy Requirements
+
+- Base findings strictly on the current diff and repository context
+- False positives are very costly—only report high-confidence findings
+- If confidence is low, ask a clarifying question instead of asserting a vulnerability
+- Never raise purely stylistic concerns
+- Cap at 10 inline comments total
+`;
+}

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -26,6 +26,14 @@ export function collectActionInputsPresence(): void {
     experimental_allowed_domains: "",
     track_progress: "false",
     automatic_review: "false",
+    automatic_security_review: "false",
+    security_model: "",
+    security_severity_threshold: "medium",
+    security_block_on_critical: "true",
+    security_block_on_high: "false",
+    security_notify_team: "",
+    security_scan_schedule: "false",
+    security_scan_days: "7",
   };
 
   const allInputsJson = process.env.ALL_INPUTS;

--- a/src/entrypoints/combine-reviews.ts
+++ b/src/entrypoints/combine-reviews.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+
+/**
+ * Combine results from code review and security review into a single summary
+ * Updates the tracking comment with the combined results
+ */
+
+import * as core from "@actions/core";
+import { readFile } from "fs/promises";
+import { createOctokit } from "../github/api/client";
+import { parseGitHubContext } from "../github/context";
+import { GITHUB_SERVER_URL } from "../github/api/config";
+
+interface ReviewFinding {
+  id: string;
+  type: string;
+  severity?: string;
+  file: string;
+  line: number;
+  description: string;
+  cwe?: string;
+}
+
+interface ReviewResults {
+  type: "code" | "security";
+  findings: ReviewFinding[];
+  summary?: string;
+}
+
+async function loadResults(filePath: string): Promise<ReviewResults | null> {
+  if (!filePath || filePath === "") {
+    return null;
+  }
+
+  try {
+    const content = await readFile(filePath, "utf-8");
+    return JSON.parse(content);
+  } catch (error) {
+    console.warn(`Could not load results from ${filePath}:`, error);
+    return null;
+  }
+}
+
+function generateCombinedSummary(
+  codeResults: ReviewResults | null,
+  securityResults: ReviewResults | null,
+  codeStatus: string,
+  securityStatus: string,
+  jobUrl: string,
+): string {
+  const sections: string[] = [];
+
+  // Header
+  sections.push("## 🔍 PR Review Summary\n");
+
+  // Status overview
+  const statusTable = ["| Review Type | Status |", "|-------------|--------|"];
+
+  if (codeStatus !== "skipped") {
+    const codeIcon = codeStatus === "success" ? "✅" : "❌";
+    statusTable.push(`| Code Review | ${codeIcon} ${codeStatus} |`);
+  }
+
+  if (securityStatus !== "skipped") {
+    const securityIcon = securityStatus === "success" ? "✅" : "❌";
+    statusTable.push(`| Security Review | ${securityIcon} ${securityStatus} |`);
+  }
+
+  if (statusTable.length > 2) {
+    sections.push(statusTable.join("\n"));
+    sections.push("");
+  }
+
+  // Code Review Section
+  if (codeResults && codeResults.findings.length > 0) {
+    sections.push("### 📝 Code Review Findings\n");
+    sections.push("| ID | Type | File | Line | Description |");
+    sections.push("|----|------|------|------|-------------|");
+
+    for (const finding of codeResults.findings.slice(0, 10)) {
+      sections.push(
+        `| ${finding.id} | ${finding.type} | \`${finding.file}\` | ${finding.line} | ${finding.description} |`,
+      );
+    }
+
+    if (codeResults.findings.length > 10) {
+      sections.push(
+        `\n*...and ${codeResults.findings.length - 10} more findings*`,
+      );
+    }
+    sections.push("");
+  } else if (codeStatus === "success") {
+    sections.push("### 📝 Code Review\n");
+    sections.push("✅ No code quality issues found.\n");
+  }
+
+  // Security Review Section
+  if (securityResults && securityResults.findings.length > 0) {
+    sections.push("### 🔐 Security Review Findings\n");
+
+    // Severity counts
+    const severityCounts = {
+      CRITICAL: 0,
+      HIGH: 0,
+      MEDIUM: 0,
+      LOW: 0,
+    };
+
+    for (const finding of securityResults.findings) {
+      const sev = (finding.severity?.toUpperCase() ||
+        "MEDIUM") as keyof typeof severityCounts;
+      if (sev in severityCounts) {
+        severityCounts[sev]++;
+      }
+    }
+
+    sections.push("| Severity | Count |");
+    sections.push("|----------|-------|");
+    if (severityCounts.CRITICAL > 0)
+      sections.push(`| 🚨 CRITICAL | ${severityCounts.CRITICAL} |`);
+    if (severityCounts.HIGH > 0)
+      sections.push(`| 🔴 HIGH | ${severityCounts.HIGH} |`);
+    if (severityCounts.MEDIUM > 0)
+      sections.push(`| 🟡 MEDIUM | ${severityCounts.MEDIUM} |`);
+    if (severityCounts.LOW > 0)
+      sections.push(`| 🟢 LOW | ${severityCounts.LOW} |`);
+    sections.push("");
+
+    // Findings table
+    sections.push("| ID | Severity | Type | File | Line | Reference |");
+    sections.push("|----|----------|------|------|------|-----------|");
+
+    for (const finding of securityResults.findings.slice(0, 10)) {
+      const cweLink = finding.cwe
+        ? `[${finding.cwe}](https://cwe.mitre.org/data/definitions/${finding.cwe.replace("CWE-", "")}.html)`
+        : "-";
+      sections.push(
+        `| ${finding.id} | ${finding.severity || "MEDIUM"} | ${finding.type} | \`${finding.file}\` | ${finding.line} | ${cweLink} |`,
+      );
+    }
+
+    if (securityResults.findings.length > 10) {
+      sections.push(
+        `\n*...and ${securityResults.findings.length - 10} more findings*`,
+      );
+    }
+    sections.push("");
+  } else if (securityStatus === "success") {
+    sections.push("### 🔐 Security Review\n");
+    sections.push("✅ No security vulnerabilities found.\n");
+  }
+
+  // Footer with job link
+  sections.push(`---\n[View job run](${jobUrl})`);
+
+  return sections.join("\n");
+}
+
+async function run() {
+  try {
+    const githubToken = process.env.GITHUB_TOKEN!;
+    const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
+    const codeResultsPath = process.env.CODE_REVIEW_RESULTS || "";
+    const securityResultsPath = process.env.SECURITY_RESULTS || "";
+    const codeStatus = process.env.CODE_REVIEW_STATUS || "skipped";
+    const securityStatus = process.env.SECURITY_REVIEW_STATUS || "skipped";
+    const runId = process.env.GITHUB_RUN_ID || "";
+
+    if (!commentId) {
+      throw new Error("DROID_COMMENT_ID is required");
+    }
+
+    const context = parseGitHubContext();
+    const { owner, repo } = context.repository;
+    const octokit = createOctokit(githubToken);
+
+    // Load results from artifacts
+    const codeResults = await loadResults(codeResultsPath);
+    const securityResults = await loadResults(securityResultsPath);
+
+    // Generate job URL
+    const jobUrl = `${GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${runId}`;
+
+    // Generate combined summary
+    const summary = generateCombinedSummary(
+      codeResults,
+      securityResults,
+      codeStatus,
+      securityStatus,
+      jobUrl,
+    );
+
+    // Update the tracking comment
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body: summary,
+    });
+
+    console.log(
+      `✅ Updated tracking comment ${commentId} with combined summary`,
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Combine reviews failed: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  run();
+}

--- a/src/entrypoints/generate-combine-prompt.ts
+++ b/src/entrypoints/generate-combine-prompt.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Generate combine prompt for finalizing reviews
+ * Generate combine prompt for finalizing parallel reviews
  */
 
 import * as core from "@actions/core";
@@ -18,6 +18,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN!;
     const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
     const codeReviewResults = process.env.CODE_REVIEW_RESULTS || "";
+    const securityResults = process.env.SECURITY_RESULTS || "";
 
     const context = parseGitHubContext();
 
@@ -40,13 +41,14 @@ async function run() {
     // Generate combine prompt with paths to result files
     await createPrompt({
       githubContext: context,
-      commentId: commentId || undefined,
+      commentId,
       baseBranch: prData.baseRefName,
       prBranchData: {
         headRefName: prData.headRefName,
         headRefOid: prData.headRefOid,
       },
-      generatePrompt: (ctx) => generateCombinePrompt(ctx, codeReviewResults),
+      generatePrompt: (ctx) =>
+        generateCombinePrompt(ctx, codeReviewResults, securityResults),
     });
 
     core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-combine");
@@ -77,7 +79,7 @@ async function run() {
       githubToken,
       owner: context.repository.owner,
       repo: context.repository.repo,
-      droidCommentId: commentId ? commentId.toString() : undefined,
+      droidCommentId: commentId.toString(),
       allowedTools,
       mode: "tag",
       context,

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Generate review prompt for standalone review action
+ * Generate review prompt for standalone review/security actions
  */
 
 import * as core from "@actions/core";
@@ -11,11 +11,13 @@ import { fetchPRBranchData } from "../github/data/pr-fetcher";
 import { createPrompt } from "../create-prompt";
 import { prepareMcpTools } from "../mcp/install-mcp-server";
 import { generateReviewPrompt } from "../create-prompt/templates/review-prompt";
+import { generateSecurityReviewPrompt } from "../create-prompt/templates/security-review-prompt";
 import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
 
 async function run() {
   try {
     const githubToken = process.env.GITHUB_TOKEN!;
+    const reviewType = process.env.REVIEW_TYPE || "code";
     const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
 
     const context = parseGitHubContext();
@@ -41,18 +43,27 @@ async function run() {
       currentBranch: prData.headRefName,
     };
 
+    // Select prompt generator based on review type
+    const generatePrompt =
+      reviewType === "security"
+        ? generateSecurityReviewPrompt
+        : generateReviewPrompt;
+
     await createPrompt({
       githubContext: context,
-      commentId: commentId || undefined,
+      commentId,
       baseBranch: branchInfo.baseBranch,
       prBranchData: {
         headRefName: prData.headRefName,
         headRefOid: prData.headRefOid,
       },
-      generatePrompt: generateReviewPrompt,
+      generatePrompt,
     });
 
-    core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
+    // Set run type
+    const runType =
+      reviewType === "security" ? "droid-security-review" : "droid-review";
+    core.exportVariable("DROID_EXEC_RUN_TYPE", runType);
 
     const rawUserArgs = process.env.DROID_ARGS || "";
     const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
@@ -60,6 +71,8 @@ async function run() {
       (tool) => tool.startsWith("github_") && tool.includes("___"),
     );
 
+    // Base tools for analysis only - NO inline comment tools
+    // Inline comments will be posted by the finalize step to avoid overlaps
     const baseTools = [
       "Read",
       "Grep",
@@ -67,17 +80,10 @@ async function run() {
       "LS",
       "Execute",
       "github_comment___update_droid_comment",
-      "github_inline_comment___create_inline_comment",
     ];
 
-    const reviewTools = [
-      "github_pr___list_review_comments",
-      "github_pr___submit_review",
-      "github_pr___delete_comment",
-      "github_pr___minimize_comment",
-      "github_pr___reply_to_comment",
-      "github_pr___resolve_review_thread",
-    ];
+    // Review tools for reading existing comments only
+    const reviewTools = ["github_pr___list_review_comments"];
 
     const allowedTools = Array.from(
       new Set([...baseTools, ...reviewTools, ...userAllowedMCPTools]),
@@ -87,7 +93,7 @@ async function run() {
       githubToken,
       owner: context.repository.owner,
       repo: context.repository.repo,
-      droidCommentId: commentId ? commentId.toString() : undefined,
+      droidCommentId: commentId.toString(),
       allowedTools,
       mode: "tag",
       context,
@@ -95,13 +101,18 @@ async function run() {
 
     const droidArgParts: string[] = [];
     // Only include built-in tools in --enabled-tools
+    // MCP tools are discovered dynamically from registered servers
     const builtInTools = allowedTools.filter((t) => !t.includes("___"));
     if (builtInTools.length > 0) {
       droidArgParts.push(`--enabled-tools "${builtInTools.join(",")}"`);
     }
 
     // Add model override if specified
-    const model = process.env.REVIEW_MODEL?.trim();
+    const model =
+      reviewType === "security"
+        ? process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim()
+        : process.env.REVIEW_MODEL?.trim();
+
     if (model) {
       droidArgParts.push(`--model "${model}"`);
     }
@@ -110,10 +121,11 @@ async function run() {
       droidArgParts.push(normalizedUserArgs);
     }
 
+    // Output for next step - use core.setOutput which handles GITHUB_OUTPUT internally
     core.setOutput("droid_args", droidArgParts.join(" ").trim());
     core.setOutput("mcp_tools", mcpTools);
 
-    console.log(`Generated review prompt`);
+    console.log(`Generated ${reviewType} review prompt`);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     core.setFailed(`Generate prompt failed: ${errorMessage}`);

--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -123,3 +123,13 @@ export const USER_QUERY = `
     }
   }
 `;
+
+export const REPO_DEFAULT_BRANCH_QUERY = `
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      defaultBranchRef {
+        name
+      }
+    }
+  }
+`;

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -90,6 +90,14 @@ type BaseContext = {
     allowedNonWriteUsers: string;
     trackProgress: boolean;
     automaticReview: boolean;
+    automaticSecurityReview: boolean;
+    securityModel: string;
+    securitySeverityThreshold: string;
+    securityBlockOnCritical: boolean;
+    securityBlockOnHigh: boolean;
+    securityNotifyTeam: string;
+    securityScanSchedule: boolean;
+    securityScanDays: number;
   };
 };
 
@@ -140,6 +148,16 @@ export function parseGitHubContext(): GitHubContext {
       allowedNonWriteUsers: process.env.ALLOWED_NON_WRITE_USERS ?? "",
       trackProgress: process.env.TRACK_PROGRESS === "true",
       automaticReview: process.env.AUTOMATIC_REVIEW === "true",
+      automaticSecurityReview: process.env.AUTOMATIC_SECURITY_REVIEW === "true",
+      securityModel: process.env.SECURITY_MODEL ?? "",
+      securitySeverityThreshold:
+        process.env.SECURITY_SEVERITY_THRESHOLD ?? "medium",
+      securityBlockOnCritical:
+        process.env.SECURITY_BLOCK_ON_CRITICAL !== "false",
+      securityBlockOnHigh: process.env.SECURITY_BLOCK_ON_HIGH === "true",
+      securityNotifyTeam: process.env.SECURITY_NOTIFY_TEAM ?? "",
+      securityScanSchedule: process.env.SECURITY_SCAN_SCHEDULE === "true",
+      securityScanDays: parseInt(process.env.SECURITY_SCAN_DAYS ?? "7", 10),
     },
   };
 

--- a/src/github/data/pr-fetcher.ts
+++ b/src/github/data/pr-fetcher.ts
@@ -1,5 +1,5 @@
 import type { Octokits } from "../api/client";
-import { PR_QUERY } from "../api/queries/github";
+import { PR_QUERY, REPO_DEFAULT_BRANCH_QUERY } from "../api/queries/github";
 import type { GitHubPullRequest } from "../types";
 
 /**
@@ -56,5 +56,48 @@ export async function fetchPRBranchData({
   } catch (error) {
     console.error(`Failed to fetch PR branch data:`, error);
     throw new Error(`Failed to fetch PR branch data for PR #${prNumber}`);
+  }
+}
+
+type RepoDefaultBranchQueryResponse = {
+  repository: {
+    defaultBranchRef: {
+      name: string;
+    } | null;
+  };
+};
+
+/**
+ * Fetches the repository's default branch name.
+ * Used by security-scan which operates without a PR context.
+ */
+export async function fetchRepoDefaultBranch({
+  octokits,
+  repository,
+}: {
+  octokits: Octokits;
+  repository: { owner: string; repo: string };
+}): Promise<string> {
+  try {
+    const result = await octokits.graphql<RepoDefaultBranchQueryResponse>(
+      REPO_DEFAULT_BRANCH_QUERY,
+      {
+        owner: repository.owner,
+        repo: repository.repo,
+      },
+    );
+
+    if (!result.repository.defaultBranchRef) {
+      throw new Error(
+        `Default branch not found for ${repository.owner}/${repository.repo}`,
+      );
+    }
+
+    return result.repository.defaultBranchRef.name;
+  } catch (error) {
+    console.error(`Failed to fetch default branch:`, error);
+    throw new Error(
+      `Failed to fetch default branch for ${repository.owner}/${repository.repo}`,
+    );
   }
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -18,11 +18,19 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
+export type CommentType = "default" | "security";
+
 export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
+  type: CommentType = "default",
 ): string {
-  return `Droid is working…
+  const message =
+    type === "security"
+      ? "Droid is running a security check…"
+      : "Droid is working…";
+
+  return `${message}
 
 ${jobRunLink}${branchLink}`;
 }

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -6,7 +6,11 @@
  */
 
 import { appendFileSync } from "fs";
-import { createJobRunLink, createCommentBody } from "./common";
+import {
+  createJobRunLink,
+  createCommentBody,
+  type CommentType,
+} from "./common";
 import {
   isPullRequestReviewCommentEvent,
   isPullRequestEvent,
@@ -19,11 +23,12 @@ const DROID_APP_BOT_ID = 209825114;
 export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
+  commentType: CommentType = "default",
 ) {
   const { owner, repo } = context.repository;
 
   const jobRunLink = createJobRunLink(owner, repo, context.runId);
-  const initialBody = createCommentBody(jobRunLink);
+  const initialBody = createCommentBody(jobRunLink, "", commentType);
 
   try {
     let response;

--- a/src/github/validation/trigger-commands.test.ts
+++ b/src/github/validation/trigger-commands.test.ts
@@ -9,8 +9,9 @@ import type {
   PullRequestReviewEvent,
 } from "@octokit/webhooks-types";
 
-type ContextOverrides =
-  Partial<Omit<ParsedGitHubContext, "payload">> & { payload?: unknown };
+type ContextOverrides = Partial<Omit<ParsedGitHubContext, "payload">> & {
+  payload?: unknown;
+};
 
 const defaultPayload = {
   action: "created",
@@ -27,7 +28,9 @@ const defaultPayload = {
 } as unknown as IssueCommentEvent;
 
 // Helper function to create a mock context
-function createMockContext(overrides: ContextOverrides = {}): ParsedGitHubContext {
+function createMockContext(
+  overrides: ContextOverrides = {},
+): ParsedGitHubContext {
   return {
     runId: "run-1",
     eventName: "issue_comment",
@@ -50,6 +53,7 @@ function createMockContext(overrides: ContextOverrides = {}): ParsedGitHubContex
       botName: "droid[bot]",
       trackProgress: false,
       automaticReview: false,
+      automaticSecurityReview: false,
       useStickyComment: false,
     },
     payload: defaultPayload,
@@ -70,7 +74,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as PullRequestEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 
@@ -84,7 +88,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as IssueCommentEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 
@@ -101,7 +105,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as PullRequestReviewCommentEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 
@@ -118,7 +122,21 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as PullRequestReviewEvent,
     });
-    
+
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should trigger on @droid security in issue comment", () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      eventAction: "created",
+      payload: {
+        comment: {
+          body: "Can you @droid security this PR?",
+        },
+      } as unknown as IssueCommentEvent,
+    });
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 
@@ -132,7 +150,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as IssueCommentEvent,
     });
-    
+
     // This should still trigger because of the existing trigger phrase logic
     // but now it will be handled as default command
     expect(checkContainsTrigger(context)).toBe(true);
@@ -148,7 +166,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as IssueCommentEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 
@@ -162,7 +180,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as IssueCommentEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(false);
   });
 
@@ -179,7 +197,7 @@ describe("checkContainsTrigger with commands", () => {
         },
       } as unknown as IssuesEvent,
     });
-    
+
     expect(checkContainsTrigger(context)).toBe(true);
   });
 });

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -18,8 +18,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
 
   // Check for specific @droid commands (fill, review)
   const command = extractCommandFromContext(context);
-  if (command && ['fill', 'review'].includes(command.command)) {
-    console.log(`Detected @droid ${command.command} command, triggering action`);
+  if (command && ["fill", "review", "security"].includes(command.command)) {
+    console.log(
+      `Detected @droid ${command.command} command, triggering action`,
+    );
     return true;
   }
 

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -1,0 +1,128 @@
+import * as core from "@actions/core";
+import type { GitHubContext } from "../../github/context";
+import { fetchPRBranchData } from "../../github/data/pr-fetcher";
+import { createPrompt } from "../../create-prompt";
+import { prepareMcpTools } from "../../mcp/install-mcp-server";
+import { createInitialComment } from "../../github/operations/comments/create-initial";
+import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
+import { isEntityContext } from "../../github/context";
+import { generateSecurityReviewPrompt } from "../../create-prompt/templates/security-review-prompt";
+import type { Octokits } from "../../github/api/client";
+import type { PrepareResult } from "../../prepare/types";
+
+type SecurityReviewCommandOptions = {
+  context: GitHubContext;
+  octokit: Octokits;
+  githubToken: string;
+  trackingCommentId?: number;
+};
+
+export async function prepareSecurityReviewMode({
+  context,
+  octokit,
+  githubToken,
+  trackingCommentId,
+}: SecurityReviewCommandOptions): Promise<PrepareResult> {
+  if (!isEntityContext(context)) {
+    throw new Error("Security review command requires an entity event context");
+  }
+
+  if (!context.isPR) {
+    throw new Error(
+      "Security review command is only supported on pull requests",
+    );
+  }
+
+  const commentId =
+    trackingCommentId ?? (await createInitialComment(octokit.rest, context)).id;
+
+  const prData = await fetchPRBranchData({
+    octokits: octokit,
+    repository: context.repository,
+    prNumber: context.entityNumber,
+  });
+
+  const branchInfo = {
+    baseBranch: prData.baseRefName,
+    droidBranch: undefined,
+    currentBranch: prData.headRefName,
+  };
+
+  await createPrompt({
+    githubContext: context,
+    commentId,
+    baseBranch: branchInfo.baseBranch,
+    droidBranch: branchInfo.droidBranch,
+    prBranchData: {
+      headRefName: prData.headRefName,
+      headRefOid: prData.headRefOid,
+    },
+    generatePrompt: generateSecurityReviewPrompt,
+  });
+  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-security-review");
+
+  // Signal that security skills should be installed
+  core.setOutput("install_security_skills", "true");
+
+  const rawUserArgs = process.env.DROID_ARGS || "";
+  const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
+  const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
+    (tool) => tool.startsWith("github_") && tool.includes("___"),
+  );
+
+  const baseTools = [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Execute",
+    "github_comment___update_droid_comment",
+    "github_inline_comment___create_inline_comment",
+  ];
+
+  const reviewTools = [
+    "github_pr___list_review_comments",
+    "github_pr___submit_review",
+    "github_pr___delete_comment",
+    "github_pr___minimize_comment",
+    "github_pr___reply_to_comment",
+    "github_pr___resolve_review_thread",
+  ];
+
+  const allowedTools = Array.from(
+    new Set([...baseTools, ...reviewTools, ...userAllowedMCPTools]),
+  );
+
+  const mcpTools = await prepareMcpTools({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    droidCommentId: commentId.toString(),
+    allowedTools,
+    mode: "tag",
+    context,
+  });
+
+  const droidArgParts: string[] = [];
+  droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+
+  // Add model override if specified (prefer SECURITY_MODEL, fallback to REVIEW_MODEL)
+  const securityModel =
+    process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim();
+  if (securityModel) {
+    droidArgParts.push(`--model "${securityModel}"`);
+  }
+
+  if (normalizedUserArgs) {
+    droidArgParts.push(normalizedUserArgs);
+  }
+
+  core.setOutput("droid_args", droidArgParts.join(" ").trim());
+  core.setOutput("mcp_tools", mcpTools);
+
+  return {
+    commentId,
+    branchInfo,
+    mcpTools,
+  };
+}

--- a/src/tag/commands/security-scan.ts
+++ b/src/tag/commands/security-scan.ts
@@ -1,0 +1,107 @@
+import * as core from "@actions/core";
+import type { GitHubContext } from "../../github/context";
+import { fetchRepoDefaultBranch } from "../../github/data/pr-fetcher";
+import { createPrompt } from "../../create-prompt";
+import { prepareMcpTools } from "../../mcp/install-mcp-server";
+import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
+import { isEntityContext } from "../../github/context";
+import { generateSecurityReportPrompt } from "../../create-prompt/templates/security-report-prompt";
+import type { Octokits } from "../../github/api/client";
+import type { PrepareResult } from "../../prepare/types";
+
+export type ScanScope = { type: "full" } | { type: "scheduled"; days: number };
+
+type SecurityScanCommandOptions = {
+  context: GitHubContext;
+  octokit: Octokits;
+  githubToken: string;
+  scanScope: ScanScope;
+};
+
+export async function prepareSecurityScanMode({
+  context,
+  octokit,
+  githubToken,
+  scanScope,
+}: SecurityScanCommandOptions): Promise<PrepareResult> {
+  if (!isEntityContext(context)) {
+    throw new Error("Security scan command requires an entity event context");
+  }
+
+  // Fetch the repository's default branch (could be main, master, develop, etc.)
+  const defaultBranch = await fetchRepoDefaultBranch({
+    octokits: octokit,
+    repository: context.repository,
+  });
+
+  const date = new Date().toISOString().split("T")[0];
+  const branchName = `droid/security-report-${date}`;
+
+  const branchInfo = {
+    baseBranch: defaultBranch,
+    droidBranch: branchName,
+    currentBranch: branchName,
+  };
+
+  await createPrompt({
+    githubContext: context,
+    baseBranch: branchInfo.baseBranch,
+    droidBranch: branchInfo.droidBranch,
+    generatePrompt: (ctx) =>
+      generateSecurityReportPrompt(ctx, scanScope, branchName),
+  });
+  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-security-scan");
+
+  // Signal that security skills should be installed
+  core.setOutput("install_security_skills", "true");
+
+  const rawUserArgs = process.env.DROID_ARGS || "";
+  const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
+  const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
+    (tool) => tool.startsWith("github_") && tool.includes("___"),
+  );
+
+  const baseTools = [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Execute",
+    "github_comment___update_droid_comment",
+  ];
+
+  const allowedTools = Array.from(
+    new Set([...baseTools, ...userAllowedMCPTools]),
+  );
+
+  const mcpTools = await prepareMcpTools({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    allowedTools,
+    mode: "tag",
+    context,
+  });
+
+  const droidArgParts: string[] = [];
+  droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+
+  // Add model override if specified (prefer SECURITY_MODEL, fallback to REVIEW_MODEL)
+  const securityModel =
+    process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim();
+  if (securityModel) {
+    droidArgParts.push(`--model "${securityModel}"`);
+  }
+
+  if (normalizedUserArgs) {
+    droidArgParts.push(normalizedUserArgs);
+  }
+
+  core.setOutput("droid_args", droidArgParts.join(" ").trim());
+  core.setOutput("mcp_tools", mcpTools);
+
+  return {
+    branchInfo,
+    mcpTools,
+  };
+}

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -1,22 +1,64 @@
+import * as core from "@actions/core";
 import { checkContainsTrigger } from "../github/validation/trigger";
 import { checkHumanActor } from "../github/validation/actor";
 import { createInitialComment } from "../github/operations/comments/create-initial";
-import { isEntityContext } from "../github/context";
+import { isEntityContext, type ParsedGitHubContext } from "../github/context";
 import { extractCommandFromContext } from "../github/utils/command-parser";
 import { prepareFillMode } from "./commands/fill";
 import { prepareReviewMode } from "./commands/review";
+import { prepareSecurityReviewMode } from "./commands/security-review";
+import { prepareSecurityScanMode } from "./commands/security-scan";
 import type { GitHubContext } from "../github/context";
 import type { PrepareResult } from "../prepare/types";
 import type { Octokits } from "../github/api/client";
+
+const DROID_APP_BOT_ID = 209825114;
+const SECURITY_REVIEW_MARKER = "## Security Review Summary";
 
 export function shouldTriggerTag(context: GitHubContext): boolean {
   if (!isEntityContext(context)) {
     return false;
   }
-  if (context.inputs.automaticReview) {
+  if (
+    context.inputs.automaticReview ||
+    context.inputs.automaticSecurityReview
+  ) {
     return context.isPR;
   }
   return checkContainsTrigger(context);
+}
+
+/**
+ * Checks if a security review has already been performed on this PR.
+ * Used to implement "run once" behavior for automatic security reviews.
+ */
+async function hasExistingSecurityReview(
+  octokit: Octokits,
+  context: ParsedGitHubContext,
+): Promise<boolean> {
+  const { owner, repo } = context.repository;
+
+  try {
+    const comments = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: context.entityNumber,
+      per_page: 100,
+    });
+
+    const hasSecurityReview = comments.data.some((comment) => {
+      const isOurBot =
+        comment.user?.id === DROID_APP_BOT_ID ||
+        (comment.user?.type === "Bot" &&
+          comment.user?.login.toLowerCase().includes("droid"));
+      return isOurBot && comment.body?.includes(SECURITY_REVIEW_MARKER);
+    });
+
+    return hasSecurityReview;
+  } catch (error) {
+    console.warn("Failed to check for existing security review:", error);
+    return false;
+  }
 }
 
 type PrepareTagOptions = {
@@ -36,17 +78,94 @@ export async function prepareTagExecution({
 
   await checkHumanActor(octokit.rest, context);
 
-  const commentData = await createInitialComment(octokit.rest, context);
-  const commentId = commentData.id;
-
   if (context.inputs.automaticReview && !context.isPR) {
     throw new Error("automatic_review requires a pull request context");
   }
 
+  if (context.inputs.automaticSecurityReview && !context.isPR) {
+    throw new Error(
+      "automatic_security_review requires a pull request context",
+    );
+  }
+
   const commandContext = extractCommandFromContext(context);
 
+  // Determine if this is a security-related command for the initial comment
+  const isSecurityCommand =
+    context.inputs.automaticSecurityReview ||
+    commandContext?.command === "security" ||
+    commandContext?.command === "security-full";
+
+  const commentData = await createInitialComment(
+    octokit.rest,
+    context,
+    isSecurityCommand ? "security" : "default",
+  );
+  const commentId = commentData.id;
+
+  // Handle parallel review mode when both flags are set
+  if (
+    context.inputs.automaticReview &&
+    context.inputs.automaticSecurityReview
+  ) {
+    // Output flags for parallel workflow jobs
+    const runCodeReview = true;
+    let runSecurityReview = true;
+
+    // Check if security review already exists on this PR (run once behavior)
+    const hasExisting = await hasExistingSecurityReview(octokit, context);
+    if (hasExisting) {
+      console.log(
+        "Security review already exists on this PR, skipping security",
+      );
+      runSecurityReview = false;
+    }
+
+    // Set outputs for downstream jobs
+    core.setOutput("run_code_review", runCodeReview.toString());
+    core.setOutput("run_security_review", runSecurityReview.toString());
+
+    // For parallel mode, return early - individual jobs will run their own reviews
+    return {
+      skipped: false,
+      branchInfo: {
+        baseBranch: "",
+        currentBranch: "",
+      },
+      mcpTools: "",
+    };
+  }
+
   if (context.inputs.automaticReview) {
+    core.setOutput("run_code_review", "true");
+    core.setOutput("run_security_review", "false");
     return prepareReviewMode({
+      context,
+      octokit,
+      githubToken,
+      trackingCommentId: commentId,
+    });
+  }
+
+  if (context.inputs.automaticSecurityReview) {
+    // Check if security review already exists on this PR (run once behavior)
+    const hasExisting = await hasExistingSecurityReview(octokit, context);
+    if (hasExisting) {
+      console.log("Security review already exists on this PR, skipping");
+      return {
+        skipped: true,
+        reason: "security_review_exists",
+        branchInfo: {
+          baseBranch: "",
+          currentBranch: "",
+        },
+        mcpTools: "",
+      };
+    }
+
+    core.setOutput("run_code_review", "false");
+    core.setOutput("run_security_review", "true");
+    return prepareSecurityReviewMode({
       context,
       octokit,
       githubToken,
@@ -63,17 +182,58 @@ export async function prepareTagExecution({
     });
   }
 
+  // Handle explicit commands - set output flags for parallel workflow jobs
+  if (commandContext?.command === "review-security") {
+    core.setOutput("run_code_review", "true");
+    core.setOutput("run_security_review", "true");
+    return {
+      skipped: false,
+      branchInfo: {
+        baseBranch: "",
+        currentBranch: "",
+      },
+      mcpTools: "",
+    };
+  }
+
+  if (commandContext?.command === "security") {
+    core.setOutput("run_code_review", "false");
+    core.setOutput("run_security_review", "true");
+    return {
+      skipped: false,
+      branchInfo: {
+        baseBranch: "",
+        currentBranch: "",
+      },
+      mcpTools: "",
+    };
+  }
+
+  if (commandContext?.command === "security-full") {
+    return prepareSecurityScanMode({
+      context,
+      octokit,
+      githubToken,
+      scanScope: { type: "full" },
+    });
+  }
+
+  // @droid review or @droid (default) = code review only
   if (
     commandContext?.command === "review" ||
     !commandContext ||
     commandContext.command === "default"
   ) {
-    return prepareReviewMode({
-      context,
-      octokit,
-      githubToken,
-      trackingCommentId: commentId,
-    });
+    core.setOutput("run_code_review", "true");
+    core.setOutput("run_security_review", "false");
+    return {
+      skipped: false,
+      branchInfo: {
+        baseBranch: "",
+        currentBranch: "",
+      },
+      mcpTools: "",
+    };
   }
 
   throw new Error(`Unexpected command: ${commandContext?.command}`);

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -26,6 +26,14 @@ describe("prepareContext", () => {
       allowedNonWriteUsers: "",
       trackProgress: false,
       automaticReview: false,
+      automaticSecurityReview: false,
+      securityModel: "",
+      securitySeverityThreshold: "medium",
+      securityBlockOnCritical: true,
+      securityBlockOnHigh: false,
+      securityNotifyTeam: "",
+      securityScanSchedule: false,
+      securityScanDays: 7,
     },
   } as const;
 

--- a/test/create-prompt/templates/security-report-prompt.test.ts
+++ b/test/create-prompt/templates/security-report-prompt.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { generateSecurityReportPrompt } from "../../../src/create-prompt/templates/security-report-prompt";
+import type { PreparedContext } from "../../../src/create-prompt/types";
+
+describe("generateSecurityReportPrompt", () => {
+  const baseContext: PreparedContext = {
+    repository: "test-owner/test-repo",
+    triggerPhrase: "@droid",
+    eventData: {
+      eventName: "issue_comment",
+      commentId: "123",
+      issueNumber: "1",
+      isPR: false,
+      baseBranch: "main",
+      droidBranch: "droid/security-report-2024-01-15",
+      commentBody: "@droid security --full",
+    },
+    githubContext: {
+      runId: "1234567890",
+      eventName: "issue_comment",
+      eventAction: "created",
+      repository: {
+        owner: "test-owner",
+        repo: "test-repo",
+        full_name: "test-owner/test-repo",
+      },
+      actor: "test-user",
+      payload: {} as any,
+      entityNumber: 1,
+      isPR: false,
+      inputs: {
+        triggerPhrase: "@droid",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        useStickyComment: false,
+        allowedBots: "",
+        allowedNonWriteUsers: "",
+        trackProgress: false,
+        automaticReview: false,
+        automaticSecurityReview: false,
+        securityModel: "",
+        securitySeverityThreshold: "high",
+        securityBlockOnCritical: true,
+        securityBlockOnHigh: false,
+        securityNotifyTeam: "@org/security-team",
+        securityScanSchedule: false,
+        securityScanDays: 7,
+      },
+    },
+  };
+
+  test("includes scan configuration for full repository scan", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("full repository");
+    expect(prompt).toContain("Entire repository");
+    expect(prompt).toContain("droid/security-report-2024-01-15");
+    expect(prompt).toContain(".factory/security/reports/security-report-");
+  });
+
+  test("includes scan configuration for scheduled scan", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "scheduled", days: 7 },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("weekly scheduled");
+    expect(prompt).toContain("Last 7 days of commits");
+    expect(prompt).toContain("git log --since=");
+  });
+
+  test("includes security skills workflow", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("threat-model-generation");
+    expect(prompt).toContain("commit-security-scan");
+    expect(prompt).toContain("vulnerability-validation");
+    expect(prompt).toContain("security-review");
+  });
+
+  test("includes PR creation instructions", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("git checkout -b");
+    expect(prompt).toContain("git push origin");
+    expect(prompt).toContain("gh pr create");
+    expect(prompt).toContain("fix(security):");
+  });
+
+  test("includes report format template", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("# Security Scan Report");
+    expect(prompt).toContain("Executive Summary");
+    expect(prompt).toContain(
+      "| Severity | Count | Auto-fixed | Manual Required |",
+    );
+    expect(prompt).toContain("VULN-001");
+    expect(prompt).toContain("STRIDE");
+    expect(prompt).toContain("CWE");
+  });
+
+  test("includes severity definitions", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("CRITICAL");
+    expect(prompt).toContain("HIGH");
+    expect(prompt).toContain("MEDIUM");
+    expect(prompt).toContain("LOW");
+    expect(prompt).toContain("Immediately exploitable");
+  });
+
+  test("includes security configuration from context", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain("Severity Threshold: high");
+    expect(prompt).toContain("@org/security-team");
+  });
+
+  test("includes threat model check instructions", () => {
+    const prompt = generateSecurityReportPrompt(
+      baseContext,
+      { type: "full" },
+      "droid/security-report-2024-01-15",
+    );
+
+    expect(prompt).toContain(".factory/threat-model.md");
+    expect(prompt).toContain("Threat Model Check");
+    expect(prompt).toContain("90 days old");
+  });
+});

--- a/test/create-prompt/templates/security-review-prompt.test.ts
+++ b/test/create-prompt/templates/security-review-prompt.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { generateSecurityReviewPrompt } from "../../../src/create-prompt/templates/security-review-prompt";
+import type { PreparedContext } from "../../../src/create-prompt/types";
+
+function createBaseContext(
+  overrides: Partial<PreparedContext> = {},
+): PreparedContext {
+  return {
+    repository: "test-owner/test-repo",
+    droidCommentId: "123",
+    triggerPhrase: "@droid",
+    eventData: {
+      eventName: "issue_comment",
+      commentId: "456",
+      prNumber: "42",
+      isPR: true,
+      commentBody: "@droid security-review",
+    },
+    githubContext: undefined,
+    ...overrides,
+  } as PreparedContext;
+}
+
+describe("generateSecurityReviewPrompt", () => {
+  it("includes security context and skill workflow", () => {
+    const prompt = generateSecurityReviewPrompt(createBaseContext());
+
+    expect(prompt).toContain("security-focused code review");
+    expect(prompt).toContain("## Security Skills Available");
+    expect(prompt).toContain("threat-model-generation");
+    expect(prompt).toContain("commit-security-scan");
+    expect(prompt).toContain("vulnerability-validation");
+    expect(prompt).toContain("security-review");
+    expect(prompt).toContain("## Review Workflow");
+    expect(prompt).toContain("gh pr diff 42 --repo test-owner/test-repo");
+    expect(prompt).toContain(
+      "gh api repos/test-owner/test-repo/pulls/42/files",
+    );
+    expect(prompt).toContain("security-review-results.json");
+    expect(prompt).toContain("Do NOT post inline comments");
+  });
+
+  it("lists STRIDE security categories", () => {
+    const prompt = generateSecurityReviewPrompt(createBaseContext());
+
+    expect(prompt).toContain("Spoofing");
+    expect(prompt).toContain("Tampering");
+    expect(prompt).toContain("Repudiation");
+    expect(prompt).toContain("Information Disclosure");
+    expect(prompt).toContain("Denial of Service");
+    expect(prompt).toContain("Elevation of Privilege");
+  });
+
+  it("includes severity definitions", () => {
+    const prompt = generateSecurityReviewPrompt(createBaseContext());
+
+    expect(prompt).toContain("CRITICAL");
+    expect(prompt).toContain("HIGH");
+    expect(prompt).toContain("MEDIUM");
+    expect(prompt).toContain("LOW");
+  });
+
+  it("includes security configuration from context", () => {
+    const contextWithConfig = createBaseContext({
+      githubContext: {
+        inputs: {
+          securitySeverityThreshold: "high",
+          securityBlockOnCritical: true,
+          securityBlockOnHigh: true,
+          securityNotifyTeam: "@org/security-team",
+        },
+      } as any,
+    });
+
+    const prompt = generateSecurityReviewPrompt(contextWithConfig);
+
+    expect(prompt).toContain("Severity Threshold: high");
+    expect(prompt).toContain("Block on Critical: true");
+    expect(prompt).toContain("Block on High: true");
+    expect(prompt).toContain("@org/security-team");
+  });
+});

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -1,14 +1,7 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import path from "node:path";
 import os from "node:os";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { prepareTagExecution } from "../../src/tag";
 import { createMockContext } from "../mockContext";
 import * as createInitial from "../../src/github/operations/comments/create-initial";
@@ -123,46 +116,111 @@ describe("review command integration", () => {
       githubToken: "token",
     });
 
-    expect(result.commentId).toBe(202);
-    expect(graphqlSpy).toHaveBeenCalled();
-    expect(mcpSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allowedTools: expect.arrayContaining([
-          "github_pr___list_review_comments",
-          "github_pr___submit_review",
-          "github_inline_comment___create_inline_comment",
-          "github_pr___resolve_review_thread",
-        ]),
-      }),
-    );
+    // In the parallel workflow, @droid review sets output flags and returns early
+    // The actual review is done by downstream workflow jobs
+    expect(result.skipped).toBe(false);
 
-    const promptPath = path.join(
-      process.env.RUNNER_TEMP!,
-      "droid-prompts",
-      "droid-prompt.txt",
-    );
-    const prompt = await readFile(promptPath, "utf8");
-
-    // New prompt outputs to JSON file instead of posting inline comments directly
-    expect(prompt).toContain("You are performing an automated code review");
-    expect(prompt).toContain("code-review-results.json");
-    expect(prompt).toContain("cap at 10 comments total");
-    expect(prompt).toContain(
-      "gh pr view 7 --repo test-owner/test-repo --json comments,reviews",
-    );
-    expect(prompt).toContain("False positives are very undesirable");
-    expect(prompt).toContain("Do NOT post inline comments");
-    expect(prompt).toContain("github_comment___update_droid_comment");
-
-    const droidArgsCall = setOutputSpy.mock.calls.find(
-      (call: unknown[]) => call[0] === "droid_args",
+    // Verify output flags were set correctly for code review only
+    const runCodeReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_code_review",
+    ) as [string, string] | undefined;
+    const runSecurityReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_security_review",
     ) as [string, string] | undefined;
 
-    expect(droidArgsCall?.[1]).toContain("github_pr___list_review_comments");
-    expect(droidArgsCall?.[1]).toContain("github_pr___submit_review");
-    expect(droidArgsCall?.[1]).toContain(
-      "github_inline_comment___create_inline_comment",
-    );
-    expect(droidArgsCall?.[1]).toContain("github_pr___resolve_review_thread");
+    expect(runCodeReviewCall?.[1]).toBe("true");
+    expect(runSecurityReviewCall?.[1]).toBe("false");
+  });
+
+  it("sets both review flags for @droid review security", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      actor: "human-reviewer",
+      entityNumber: 7,
+      repository: {
+        owner: "test-owner",
+        repo: "test-repo",
+        full_name: "test-owner/test-repo",
+      },
+      payload: {
+        comment: {
+          id: 888,
+          body: "@droid review security",
+          user: { login: "human-reviewer" },
+          created_at: "2024-02-02T00:00:00Z",
+        },
+        issue: {
+          number: 7,
+          pull_request: {},
+        },
+      } as any,
+    });
+
+    const octokit = { rest: {} } as any;
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBe(false);
+
+    const runCodeReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_code_review",
+    ) as [string, string] | undefined;
+    const runSecurityReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_security_review",
+    ) as [string, string] | undefined;
+
+    expect(runCodeReviewCall?.[1]).toBe("true");
+    expect(runSecurityReviewCall?.[1]).toBe("true");
+  });
+
+  it("sets security flag only for @droid security", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      actor: "human-reviewer",
+      entityNumber: 7,
+      repository: {
+        owner: "test-owner",
+        repo: "test-repo",
+        full_name: "test-owner/test-repo",
+      },
+      payload: {
+        comment: {
+          id: 888,
+          body: "@droid security",
+          user: { login: "human-reviewer" },
+          created_at: "2024-02-02T00:00:00Z",
+        },
+        issue: {
+          number: 7,
+          pull_request: {},
+        },
+      } as any,
+    });
+
+    const octokit = { rest: {} } as any;
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBe(false);
+
+    const runCodeReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_code_review",
+    ) as [string, string] | undefined;
+    const runSecurityReviewCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "run_security_review",
+    ) as [string, string] | undefined;
+
+    expect(runCodeReviewCall?.[1]).toBe("false");
+    expect(runSecurityReviewCall?.[1]).toBe("true");
   });
 });

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -19,6 +19,14 @@ const defaultInputs = {
   allowedNonWriteUsers: "",
   trackProgress: false,
   automaticReview: false,
+  automaticSecurityReview: false,
+  securityModel: "",
+  securitySeverityThreshold: "medium",
+  securityBlockOnCritical: true,
+  securityBlockOnHigh: false,
+  securityNotifyTeam: "",
+  securityScanSchedule: false,
+  securityScanDays: 7,
 };
 
 const defaultRepository = {

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -52,4 +52,17 @@ describe("shouldTriggerTag", () => {
 
     expect(shouldTriggerTag(contextWithAutomaticReview)).toBe(true);
   });
+
+  test("returns true for PR contexts when automaticSecurityReview is enabled", () => {
+    const contextWithAutomaticSecurityReview = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      inputs: {
+        ...createMockContext().inputs,
+        automaticSecurityReview: true,
+      },
+    });
+
+    expect(shouldTriggerTag(contextWithAutomaticSecurityReview)).toBe(true);
+  });
 });

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as core from "@actions/core";
+import { prepareSecurityReviewMode } from "../../../src/tag/commands/security-review";
+import { createMockContext } from "../../mockContext";
+
+import * as prFetcher from "../../../src/github/data/pr-fetcher";
+import * as promptModule from "../../../src/create-prompt";
+import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
+import * as comments from "../../../src/github/operations/comments/create-initial";
+
+const MOCK_PR_DATA = {
+  baseRefName: "main",
+  headRefName: "feature/security-review",
+  headRefOid: "123abc",
+} as const;
+
+describe("prepareSecurityReviewMode", () => {
+  const originalArgs = process.env.DROID_ARGS;
+  const originalReviewModel = process.env.REVIEW_MODEL;
+  const originalSecurityModel = process.env.SECURITY_MODEL;
+  let fetchPRSpy: ReturnType<typeof spyOn>;
+  let promptSpy: ReturnType<typeof spyOn>;
+  let mcpSpy: ReturnType<typeof spyOn>;
+  let setOutputSpy: ReturnType<typeof spyOn>;
+  let createInitialSpy: ReturnType<typeof spyOn>;
+  let exportVariableSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    process.env.DROID_ARGS = "";
+    delete process.env.REVIEW_MODEL;
+    delete process.env.SECURITY_MODEL;
+
+    fetchPRSpy = spyOn(prFetcher, "fetchPRBranchData").mockResolvedValue({
+      baseRefName: MOCK_PR_DATA.baseRefName,
+      headRefName: MOCK_PR_DATA.headRefName,
+      headRefOid: MOCK_PR_DATA.headRefOid,
+    });
+
+    promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
+    mcpSpy = spyOn(mcpInstaller, "prepareMcpTools").mockResolvedValue(
+      "mock-config",
+    );
+    setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    createInitialSpy = spyOn(
+      comments,
+      "createInitialComment",
+    ).mockResolvedValue({ id: 777 } as any);
+    exportVariableSpy = spyOn(core, "exportVariable").mockImplementation(
+      () => {},
+    );
+  });
+
+  afterEach(() => {
+    fetchPRSpy.mockRestore();
+    promptSpy.mockRestore();
+    mcpSpy.mockRestore();
+    setOutputSpy.mockRestore();
+    createInitialSpy.mockRestore();
+    exportVariableSpy.mockRestore();
+
+    process.env.DROID_ARGS = originalArgs;
+    if (originalReviewModel !== undefined) {
+      process.env.REVIEW_MODEL = originalReviewModel;
+    } else {
+      delete process.env.REVIEW_MODEL;
+    }
+    if (originalSecurityModel !== undefined) {
+      process.env.SECURITY_MODEL = originalSecurityModel;
+    } else {
+      delete process.env.SECURITY_MODEL;
+    }
+  });
+
+  it("prepares security review flow with limited toolset when tracking comment exists", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 101,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 24,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    const result = await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 555,
+    });
+
+    expect(fetchPRSpy).toHaveBeenCalledWith({
+      octokits: octokit,
+      repository: context.repository,
+      prNumber: 24,
+    });
+    expect(promptSpy).toHaveBeenCalled();
+    expect(mcpSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedTools: expect.arrayContaining([
+          "Execute",
+          "github_comment___update_droid_comment",
+          "github_inline_comment___create_inline_comment",
+          "github_pr___list_review_comments",
+          "github_pr___submit_review",
+          "github_pr___resolve_review_thread",
+        ]),
+      }),
+    );
+    expect(createInitialSpy).not.toHaveBeenCalled();
+    expect(result.commentId).toBe(555);
+    expect(result.branchInfo.baseBranch).toBe("main");
+    expect(result.branchInfo.currentBranch).toBe("feature/security-review");
+    expect(result.branchInfo.droidBranch).toBeUndefined();
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).toContain("Execute");
+    [
+      "github_comment___update_droid_comment",
+      "github_inline_comment___create_inline_comment",
+      "github_pr___list_review_comments",
+      "github_pr___submit_review",
+      "github_pr___delete_comment",
+      "github_pr___minimize_comment",
+      "github_pr___reply_to_comment",
+      "github_pr___resolve_review_thread",
+    ].forEach((tool) => {
+      expect(droidArgsCall?.[1]).toContain(tool);
+    });
+
+    expect(exportVariableSpy).toHaveBeenCalledWith(
+      "DROID_EXEC_RUN_TYPE",
+      "droid-security-review",
+    );
+  });
+
+  it("creates tracking comment when not provided", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 102,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 25,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    const result = await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(createInitialSpy).toHaveBeenCalled();
+    expect(result.commentId).toBe(777);
+  });
+
+  it("throws when invoked on non-PR context", async () => {
+    const context = createMockContext({ isPR: false });
+
+    await expect(
+      prepareSecurityReviewMode({
+        context,
+        octokit: { rest: {}, graphql: () => {} } as any,
+        githubToken: "token",
+      }),
+    ).rejects.toThrow(
+      "Security review command is only supported on pull requests",
+    );
+  });
+
+  it("adds --model flag when REVIEW_MODEL is set", async () => {
+    process.env.REVIEW_MODEL = "claude-sonnet-4-5-20250929";
+
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 103,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 26,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 556,
+    });
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).toContain(
+      '--model "claude-sonnet-4-5-20250929"',
+    );
+  });
+
+  it("does not add --model flag when REVIEW_MODEL is empty", async () => {
+    process.env.REVIEW_MODEL = "";
+
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 104,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 27,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 557,
+    });
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).not.toContain("--model");
+  });
+
+  it("outputs install_security_skills flag", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 105,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 28,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 558,
+    });
+
+    const installSkillsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "install_security_skills",
+    ) as [string, string] | undefined;
+    expect(installSkillsCall?.[1]).toBe("true");
+  });
+
+  it("prefers SECURITY_MODEL over REVIEW_MODEL", async () => {
+    process.env.SECURITY_MODEL = "gpt-5.1-codex";
+    process.env.REVIEW_MODEL = "claude-sonnet-4-5-20250929";
+
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 106,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 29,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 559,
+    });
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.1-codex"');
+    expect(droidArgsCall?.[1]).not.toContain("claude-sonnet");
+  });
+
+  it("falls back to REVIEW_MODEL when SECURITY_MODEL is not set", async () => {
+    process.env.REVIEW_MODEL = "claude-sonnet-4-5-20250929";
+
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 107,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 30,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 560,
+    });
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).toContain(
+      '--model "claude-sonnet-4-5-20250929"',
+    );
+  });
+});

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -68,6 +68,14 @@ describe("checkWritePermissions", () => {
       allowedNonWriteUsers: "",
       trackProgress: false,
       automaticReview: false,
+      automaticSecurityReview: false,
+      securityModel: "",
+      securitySeverityThreshold: "medium",
+      securityBlockOnCritical: true,
+      securityBlockOnHigh: false,
+      securityNotifyTeam: "",
+      securityScanSchedule: false,
+      securityScanDays: 7,
     },
   });
 


### PR DESCRIPTION
## Summary

Add comprehensive security review functionality with new commands, configuration options, and Factory security skills integration.

## New Commands

| Command | Description |
|---------|-------------|
| `@droid security` | Security-focused code review using STRIDE methodology |
| `@droid review security` | Run both code and security reviews in parallel |
| `@droid security review` | Same as above (order doesn't matter) |
| `@droid security --full` | Full repository security scan (creates PR with report) |

## New Configuration Options

| Input | Default | Description |
|-------|---------|-------------|
| `automatic_security_review` | `false` | Auto-run security review on PRs |
| `security_model` | `""` | Override model for security reviews |
| `security_severity_threshold` | `medium` | Filter by severity (critical/high/medium/low) |
| `security_block_on_critical` | `true` | Block PR on critical findings |
| `security_block_on_high` | `false` | Block PR on high findings |
| `security_notify_team` | `""` | Team to @mention on critical findings |
| `security_scan_schedule` | `false` | Enable scheduled full repo scans |
| `security_scan_days` | `7` | Days of commits to scan for scheduled scans |

## New Sub-Action

```yaml
- uses: Factory-AI/droid-action/security@v1
  with:
    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
    tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
    security_severity_threshold: medium
```

## Security Skills Integration

Auto-installs Factory security skills from `Factory-AI/skills`:
- **threat-model-generation** - STRIDE-based threat modeling
- **commit-security-scan** - Vulnerability scanning
- **vulnerability-validation** - False positive filtering
- **security-review** - Comprehensive review and patching

## Parallel Workflow

When both `automatic_review` and `automatic_security_review` are enabled, reviews run in parallel:

```
prepare → code-review ──┬──→ combine
         security-review ─┘
```

The combine step only runs when BOTH reviews are enabled, ensuring deduplicated inline comments.

## Testing

- All 344 tests pass
- Type checking passes
- New tests added for security commands and prompts

## Depends On

- PR #8: Sub-action infrastructure
- PR #9: Code review refactor

## Part of

This is PR 3 of 3 for the security review feature:
1. PR #8: Sub-action infrastructure
2. PR #9: Code review refactor  
3. **This PR**: Security review feature