### PR TITLE
feat: set gpt-5.2 as default model for code reviews

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ inputs:
   review_model:
     description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
     required: false
-    default: ""
+    default: "gpt-5.2"
   fill_model:
     description: "Override the model used for PR description fill (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to fill flows."
     required: false


### PR DESCRIPTION
## Summary
Updates the default model for the `review_model` input from empty (no override) to `gpt-5.2`.

## Changes
- Set `review_model` default to `gpt-5.2` in `action.yml`

Users can still override this by explicitly setting `review_model` in their workflow configuration.

Closes FAC-14920