### PR TITLE
feat: add PR checkout and cross-reference instructions to review prompt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,8 @@ runs:
       shell: bash
       run: |
         echo "Checking out PR #${{ steps.prepare.outputs.review_pr_number }} branch for full file access..."
+        # Reset any local changes from the merge commit to allow clean checkout
+        git reset --hard HEAD
         gh pr checkout ${{ steps.prepare.outputs.review_pr_number }}
         echo "Successfully checked out PR branch: $(git rev-parse --abbrev-ref HEAD)"
       env:

--- a/action.yml
+++ b/action.yml
@@ -173,6 +173,16 @@ runs:
       env:
         EXPERIMENTAL_ALLOWED_DOMAINS: ${{ inputs.experimental_allowed_domains }}
 
+    - name: Checkout PR branch for review
+      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.review_pr_number != ''
+      shell: bash
+      run: |
+        echo "Checking out PR #${{ steps.prepare.outputs.review_pr_number }} branch for full file access..."
+        gh pr checkout ${{ steps.prepare.outputs.review_pr_number }}
+        echo "Successfully checked out PR branch: $(git rev-parse --abbrev-ref HEAD)"
+      env:
+        GH_TOKEN: ${{ steps.prepare.outputs.github_token }}
+
     - name: Run Droid Exec
       id: droid
       if: steps.prepare.outputs.contains_trigger == 'true'

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -80,6 +80,17 @@ Use the following priority levels for your findings:
 - [P2] - Normal. To be fixed eventually
 - [P3] - Low. Nice to have
 
+Comment Guidelines:
+Your review comments should be:
+1. Clear about why the issue is a bug
+2. Appropriately communicate severity
+3. Brief - at most 1 paragraph
+4. Code chunks max 3 lines, wrapped in markdown
+5. Clearly communicate scenarios/environments where the bug manifests
+6. Matter-of-fact tone without being accusatory
+7. Immediately graspable by the original author
+8. Avoid excessive flattery
+
 Cross-reference capability:
 - When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).
 - Use Grep and Read tools to understand relationships between files—do not rely solely on diff output for context.

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -71,8 +71,6 @@ Priority Levels:
 Use the following priority levels for your findings:
 - [P0] - Drop everything to fix. Blocking release/operations
 - [P1] - Urgent. Should be addressed in next cycle
-- [P2] - Normal. To be fixed eventually
-- [P3] - Low. Nice to have
 
 Comment Guidelines:
 Your review comments should be:
@@ -89,7 +87,7 @@ Output Format:
 Structure each inline comment with:
 - Clear title (≤ 80 chars, imperative mood)
 - Explanation of why this is a problem
-- Priority level [P0-P3]
+- Priority level [P0-P1]
 
 In the review summary body (submitted via github_pr___submit_review), provide an overall assessment:
 - Whether the changes are correct or incorrect

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -92,13 +92,12 @@ Your review comments should be:
 8. Avoid excessive flattery
 
 Output Format:
-Structure your findings with:
-- Clear titles (≤ 80 chars, imperative mood)
+Structure each inline comment with:
+- Clear title (≤ 80 chars, imperative mood)
 - Explanation of why this is a problem
-- File path and line numbers where applicable
 - Priority level [P0-P3]
 
-Provide an overall assessment:
+In the review summary body (submitted via github_pr___submit_review), provide an overall assessment:
 - Whether the changes are correct or incorrect
 - 1-3 sentence overall explanation
 
@@ -122,7 +121,7 @@ Commenting rules:
 - Anchor findings to the relevant diff hunk so reviewers see the context immediately.
 - Focus on defects introduced or exposed by the PR's changes; if a new bug manifests on an unchanged line, you may post inline comments on those unchanged lines but clearly explain how the submitted changes trigger it.
 - Match the side parameter to the code segment you're referencing (default to RIGHT for new code) and provide line numbers from that same side
-- Use a matter-of-fact tone without being accusatory; keep comments concise and immediately graspable.
+- Keep comments concise and immediately graspable.
 - For low confidence findings, ask a question; for medium/high confidence, state the issue concretely.
 - Only include explicit code suggestions when you are absolutely certain the replacement is correct and safe.
 

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -24,6 +24,11 @@ Context:
 - PR Head SHA: ${headSha}
 - PR Base Ref: ${baseRefName}
 
+First, checkout the PR branch to access the full codebase:
+- Run: gh pr checkout ${prNumber} --repo ${repoFullName}
+
+This ensures you can read any file in the PR's branch, not just the diff output.
+
 Objectives:
 1) Re-check existing review comments and resolve threads when the issue is fixed (fall back to a brief "resolved" reply only if the thread cannot be marked resolved).
 2) Review the current PR diff and surface only clear, high-severity issues.
@@ -61,6 +66,12 @@ Analysis scope (prioritize high-confidence findings):
 - Evidence-based performance regressions (e.g., N+1 queries)
 - Resource leaks or dead/unreachable code affecting behavior
 - Regression risks relative to existing behavior or tests
+
+Cross-reference capability:
+- When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).
+- Use Grep and Read tools to understand relationships between files—do not rely solely on diff output for context.
+- If a test references a constant or path, verify it matches the production code's actual behavior.
+- For any suspicious pattern, search the codebase to confirm your understanding before flagging an issue.
 
 Accuracy gates:
 - Base findings strictly on the current diff and minimal repo context available via gh/MCP; avoid speculation.

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -91,6 +91,17 @@ Your review comments should be:
 7. Immediately graspable by the original author
 8. Avoid excessive flattery
 
+Output Format:
+Structure your findings with:
+- Clear titles (≤ 80 chars, imperative mood)
+- Explanation of why this is a problem
+- File path and line numbers where applicable
+- Priority level [P0-P3]
+
+Provide an overall assessment:
+- Whether the changes are correct or incorrect
+- 1-3 sentence overall explanation
+
 Cross-reference capability:
 - When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).
 - Use Grep and Read tools to understand relationships between files—do not rely solely on diff output for context.

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -59,6 +59,9 @@ Diff Side Selection (CRITICAL):
 - The 'line' parameter refers to the line number on the specified side of the diff  
 - Ensure the line numbers you use correspond to the side you choose;
 
+How Many Findings to Return:
+Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
+
 Key Guidelines for Bug Detection:
 Only flag an issue as a bug if:
 1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
@@ -70,6 +73,13 @@ Only flag an issue as a bug if:
 7. Must identify provably affected code parts (not speculation).
 8. The bug is clearly not intentional.
 
+Priority Levels:
+Use the following priority levels for your findings:
+- [P0] - Drop everything to fix. Blocking release/operations
+- [P1] - Urgent. Should be addressed in next cycle
+- [P2] - Normal. To be fixed eventually
+- [P3] - Low. Nice to have
+
 Cross-reference capability:
 - When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).
 - Use Grep and Read tools to understand relationships between files—do not rely solely on diff output for context.
@@ -77,9 +87,7 @@ Cross-reference capability:
 - For any suspicious pattern, search the codebase to confirm your understanding before flagging an issue.
 
 Accuracy gates:
-- Base findings strictly on the current diff and minimal repo context available via gh/MCP; avoid speculation.
-- Prioritize high-severity/high-confidence issues; cap at 10 comments total.
-- False positives are very undesirable—only surface an issue when you are genuinely confident.
+- Base findings strictly on the current diff and repo context available via gh/MCP; avoid speculation.
 - If confidence is low, phrase a single concise clarifying question instead of asserting a bug.
 - Never raise purely stylistic or preference-only concerns.
 
@@ -88,7 +96,7 @@ Deduplication policy:
 - Do not open a new thread for a previously reported issue; resolve the existing thread via github_pr___resolve_review_thread when possible, otherwise leave a brief reply in that discussion and move on.
 
 Commenting rules:
-- Maximum 10 inline comments total; one issue per comment.
+- One issue per comment.
 - Anchor findings to the relevant diff hunk so reviewers see the context immediately.
 - Focus on defects introduced or exposed by the PR's changes; if a new bug manifests on an unchanged line, you may post inline comments on those unchanged lines but clearly explain how the submitted changes trigger it.
 - Match the side parameter to the code segment you're referencing (default to RIGHT for new code) and provide line numbers from that same side
@@ -101,6 +109,6 @@ Submission:
 - If no issues are found and no prior "no issues" comment exists, post a single brief top-level summary noting no issues.
 - If issues are found, delete/minimize/supersede any prior "no issues" comment before submitting.
 - Prefer github_inline_comment___create_inline_comment for inline findings and submit the overall review via github_pr___submit_review (fall back to gh api repos/${repoFullName}/pulls/${prNumber}/reviews -f event=COMMENT -f body="$SUMMARY" -f comments='[$COMMENTS_JSON]' when MCP tools are unavailable).
-- Do not approve or request changes; submit a comment-only review with inline feedback (maximum 10 comments).
+- Do not approve or request changes; submit a comment-only review with inline feedback.
 `;
 }

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -1,8 +1,6 @@
 import type { PreparedContext } from "../types";
 
-export function generateReviewPrompt(
-  context: PreparedContext,
-): string {
+export function generateReviewPrompt(context: PreparedContext): string {
   const prNumber = context.eventData.isPR
     ? context.eventData.prNumber
     : context.githubContext && "entityNumber" in context.githubContext
@@ -23,11 +21,7 @@ Context:
 - PR Head Ref: ${headRefName}
 - PR Head SHA: ${headSha}
 - PR Base Ref: ${baseRefName}
-
-First, checkout the PR branch to access the full codebase:
-- Run: gh pr checkout ${prNumber} --repo ${repoFullName}
-
-This ensures you can read any file in the PR's branch, not just the diff output.
+- The PR branch has already been checked out. You have full access to read any file in the codebase, not just the diff output.
 
 Objectives:
 1) Re-check existing review comments and resolve threads when the issue is fixed (fall back to a brief "resolved" reply only if the thread cannot be marked resolved).

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -59,13 +59,16 @@ Diff Side Selection (CRITICAL):
 - The 'line' parameter refers to the line number on the specified side of the diff  
 - Ensure the line numbers you use correspond to the side you choose;
 
-Analysis scope (prioritize high-confidence findings):
-- Correctness bugs and boundary errors
-- Missing validation or contract misuse
-- Concurrency or async hazards
-- Evidence-based performance regressions (e.g., N+1 queries)
-- Resource leaks or dead/unreachable code affecting behavior
-- Regression risks relative to existing behavior or tests
+Key Guidelines for Bug Detection:
+Only flag an issue as a bug if:
+1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
+2. The bug is discrete and actionable (not a general issue).
+3. Fixing the bug does not demand a level of rigor not present in the rest of the codebase.
+4. The bug was introduced in the PR (pre-existing bugs should not be flagged).
+5. The author would likely fix the issue if made aware of it.
+6. The bug does not rely on unstated assumptions.
+7. Must identify provably affected code parts (not speculation).
+8. The bug is clearly not intentional.
 
 Cross-reference capability:
 - When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -31,7 +31,7 @@ This ensures you can read any file in the PR's branch, not just the diff output.
 
 Objectives:
 1) Re-check existing review comments and resolve threads when the issue is fixed (fall back to a brief "resolved" reply only if the thread cannot be marked resolved).
-2) Review the current PR diff and surface only clear, high-severity issues.
+2) Review the PR diff and surface all bugs that meet the detection criteria below.
 3) Leave concise inline comments (1-2 sentences) on bugs introduced by the PR. You may also comment on unchanged lines if the PR's changes expose or trigger issues there—but explain the connection clearly.
 
 Procedure:

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -100,7 +100,7 @@ Commenting rules:
 - Anchor findings to the relevant diff hunk so reviewers see the context immediately.
 - Focus on defects introduced or exposed by the PR's changes; if a new bug manifests on an unchanged line, you may post inline comments on those unchanged lines but clearly explain how the submitted changes trigger it.
 - Match the side parameter to the code segment you're referencing (default to RIGHT for new code) and provide line numbers from that same side
-- Tone should be deferential—write like a junior developer seeking confirmation; keep comments concise and respectful.
+- Use a matter-of-fact tone without being accusatory; keep comments concise and immediately graspable.
 - For low confidence findings, ask a question; for medium/high confidence, state the issue concretely.
 - Only include explicit code suggestions when you are absolutely certain the replacement is correct and safe.
 

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -84,10 +84,10 @@ Your review comments should be:
 8. Avoid excessive flattery
 
 Output Format:
-Structure each inline comment with:
-- Clear title (≤ 80 chars, imperative mood)
-- Explanation of why this is a problem
-- Priority level [P0-P1]
+Structure each inline comment as:
+**[P0/P1] Clear title (≤ 80 chars, imperative mood)**
+(blank line)
+Explanation of why this is a problem (1 paragraph max).
 
 In the review summary body (submitted via github_pr___submit_review), provide an overall assessment:
 - Whether the changes are correct or incorrect

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -113,6 +113,8 @@ export async function prepareReviewMode({
 
   core.setOutput("droid_args", droidArgParts.join(" ").trim());
   core.setOutput("mcp_tools", mcpTools);
+  core.setOutput("review_pr_number", context.entityNumber.toString());
+  core.setOutput("droid_comment_id", commentId.toString());
 
   return {
     commentId,

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -36,13 +36,15 @@ describe("generateReviewPrompt", () => {
     expect(prompt).toContain("every substantive comment must be inline on the changed line");
   });
 
-  it("emphasizes accuracy gates and comment limits", () => {
+  it("emphasizes accuracy gates and bug detection guidelines", () => {
     const prompt = generateReviewPrompt(createBaseContext());
 
-    expect(prompt).toContain("cap at 10 comments total");
+    expect(prompt).toContain("How Many Findings to Return:");
+    expect(prompt).toContain("Output all findings that the original author would fix");
+    expect(prompt).toContain("Key Guidelines for Bug Detection:");
+    expect(prompt).toContain("Priority Levels:");
+    expect(prompt).toContain("[P0]");
     expect(prompt).toContain("Never raise purely stylistic");
-    expect(prompt).toContain("Maximum 10 inline comments");
-    expect(prompt).toContain("False positives are very undesirable");
     expect(prompt).toContain("Never repeat or re-raise an issue previously highlighted");
   });
 

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -146,9 +146,11 @@ describe("review command integration", () => {
 
     expect(prompt).toContain("You are performing an automated code review");
     expect(prompt).toContain("github_inline_comment___create_inline_comment");
-    expect(prompt).toContain("cap at 10 comments total");
+    expect(prompt).toContain("How Many Findings to Return:");
+    expect(prompt).toContain("Output all findings that the original author would fix");
+    expect(prompt).toContain("Key Guidelines for Bug Detection:");
+    expect(prompt).toContain("Priority Levels:");
     expect(prompt).toContain("gh pr view 7 --repo test-owner/test-repo --json comments,reviews");
-    expect(prompt).toContain("False positives are very undesirable");
     expect(prompt).toContain("every substantive comment must be inline on the changed line");
     expect(prompt).toContain("github_pr___resolve_review_thread");
 


### PR DESCRIPTION
Closes FAC-14941

## Summary
Improves the Review Droid's ability to detect bugs by ensuring it has full codebase access during reviews.

## Changes
- Added instruction to checkout PR branch before analysis (`gh pr checkout`)
- Added "Cross-reference capability" section guiding the droid to use Grep/Read tools to verify relationships between files

## Context
Analysis in `docs/review-droid-vs-local-review-analysis.md` showed the Review Droid missed P0/P1 bugs that the local `/review` command caught. The root cause was the droid running on the base branch without access to PR files, relying only on truncated diff output.

## Testing
- Typecheck passes
- All 308 tests pass