### PR TITLE
feat: filter review output to P0/P1 findings only

### DIFF
--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -68,11 +68,13 @@ Only flag an issue as a bug if:
 8. The bug is clearly not intentional.
 
 Priority Levels:
-Use the following priority levels for your findings:
+Use the following priority levels to categorize findings:
 - [P0] - Drop everything to fix. Blocking release/operations
 - [P1] - Urgent. Should be addressed in next cycle
 - [P2] - Normal. To be fixed eventually
 - [P3] - Low. Nice to have
+
+IMPORTANT: Only post P0 and P1 findings as inline comments. Do NOT post P2 or P3 findings—they are too minor to warrant review noise. If all your findings are P2/P3, post no inline comments and note "no high-severity issues found" in the summary.
 
 Comment Guidelines:
 Your review comments should be:
@@ -86,8 +88,8 @@ Your review comments should be:
 8. Avoid excessive flattery
 
 Output Format:
-Structure each inline comment as:
-**[P0-P3] Clear title (≤ 80 chars, imperative mood)**
+Structure each inline comment as (P0/P1 only):
+**[P0/P1] Clear title (≤ 80 chars, imperative mood)**
 (blank line)
 Explanation of why this is a problem (1 paragraph max).
 

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -71,6 +71,8 @@ Priority Levels:
 Use the following priority levels for your findings:
 - [P0] - Drop everything to fix. Blocking release/operations
 - [P1] - Urgent. Should be addressed in next cycle
+- [P2] - Normal. To be fixed eventually
+- [P3] - Low. Nice to have
 
 Comment Guidelines:
 Your review comments should be:
@@ -85,7 +87,7 @@ Your review comments should be:
 
 Output Format:
 Structure each inline comment as:
-**[P0/P1] Clear title (≤ 80 chars, imperative mood)**
+**[P0-P3] Clear title (≤ 80 chars, imperative mood)**
 (blank line)
 Explanation of why this is a problem (1 paragraph max).
 


### PR DESCRIPTION
## Summary
Restores P2/P3 priority levels for internal categorization while filtering review output to only post P0/P1 findings.

## Changes
- Added P2 and P3 priority level definitions back to the review prompt
- Added explicit instruction to only post P0/P1 findings as inline comments
- P2/P3 findings are suppressed to reduce review noise from minor issues
- Updated output format to reflect P0/P1 only

## Context
PR #13's review flagged a trivial array allocation as P1, which was too aggressive. By having P2/P3 available for categorization but filtering them from output, the droid can properly classify minor issues without cluttering the review with noise.