### PR TITLE
fix(review): reduce false positives and prevent tracking comment deletion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
     required: false
     default: "gpt-5.2"
+  reasoning_effort:
+    description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty and review_model is also empty, the action defaults internally to gpt-5.2 at high reasoning."
+    required: false
+    default: ""
   fill_model:
     description: "Override the model used for PR description fill (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to fill flows."
     required: false
@@ -132,6 +136,7 @@ runs:
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
         REVIEW_MODEL: ${{ inputs.review_model }}
+        REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         FILL_MODEL: ${{ inputs.fill_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         DROID_ARGS: ${{ inputs.droid_args }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: false
     default: ""
 
+  reasoning_effort:
+    description: "Optional reasoning effort to pass to Droid Exec via --reasoning-effort (e.g., 'low', 'medium', 'high', 'xhigh'). If empty, no --reasoning-effort flag is passed."
+    required: false
+    default: ""
+
   # Action settings
   droid_args:
     description: "Additional arguments to pass directly to Droid CLI (e.g., '--auto', '--enabled-tools read,edit')"
@@ -113,6 +118,7 @@ runs:
         INPUT_PROMPT_FILE: ${{ inputs.prompt_file }}
         INPUT_SETTINGS: ${{ inputs.settings }}
         INPUT_DROID_ARGS: ${{ inputs.droid_args }}
+        INPUT_REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -22,6 +22,7 @@ async function run() {
 
     await runDroid(promptConfig.path, {
       droidArgs: process.env.INPUT_DROID_ARGS,
+      reasoningEffort: process.env.INPUT_REASONING_EFFORT,
       allowedTools: process.env.INPUT_ALLOWED_TOOLS,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,
       maxTurns: process.env.INPUT_MAX_TURNS,

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -68,6 +68,7 @@ function sanitizeJsonOutput(
 
 export type DroidOptions = {
   droidArgs?: string;
+  reasoningEffort?: string;
   pathToDroidExecutable?: string;
   allowedTools?: string;
   disallowedTools?: string;
@@ -89,6 +90,11 @@ export function prepareRunConfig(
   options: DroidOptions,
 ): PreparedConfig {
   const droidArgs = [...BASE_ARGS];
+
+  // Add reasoning effort only when explicitly requested
+  if (options.reasoningEffort?.trim()) {
+    droidArgs.push("--reasoning-effort", options.reasoningEffort.trim());
+  }
 
   // Parse and add user's custom Droid arguments
   if (options.droidArgs?.trim()) {

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -46,7 +46,9 @@ Procedure:
 - Detect prior top-level "no issues" comments authored by this bot (e.g., "no issues", "No issues found", "LGTM", including emoji-prefixed variants).
 - If the current run finds issues and prior "no issues" comments exist, delete them via gh api -X DELETE repos/${repoFullName}/issues/comments/<comment_id>; if deletion fails, minimize via GraphQL or reply "Superseded: issues were found in newer commits".
 - IMPORTANT: Do NOT delete comment ID ${context.droidCommentId} - this is the tracking comment for the current run.
-- If a previously reported issue appears resolved by nearby changes, call github_pr___resolve_review_thread (when permitted) to mark it resolved; otherwise provide a brief reply within that thread noting the resolution.
+- Thread resolution rule (CRITICAL): NEVER resolve review threads.
+  - Do NOT call github_pr___resolve_review_thread under any circumstances.
+  - If a previously reported issue appears fixed, leave the thread unresolved.
 
 Preferred MCP tools (when available):
 - github_inline_comment___create_inline_comment to post inline feedback anchored to the diff

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -45,6 +45,7 @@ Procedure:
 - Compute exact diff positions (path + position) for each issue; every substantive comment must be inline on the changed line (no new top-level issue comments).
 - Detect prior top-level "no issues" comments authored by this bot (e.g., "no issues", "No issues found", "LGTM", including emoji-prefixed variants).
 - If the current run finds issues and prior "no issues" comments exist, delete them via gh api -X DELETE repos/${repoFullName}/issues/comments/<comment_id>; if deletion fails, minimize via GraphQL or reply "Superseded: issues were found in newer commits".
+- IMPORTANT: Do NOT delete comment ID ${context.droidCommentId} - this is the tracking comment for the current run.
 - If a previously reported issue appears resolved by nearby changes, call github_pr___resolve_review_thread (when permitted) to mark it resolved; otherwise provide a brief reply within that thread noting the resolution.
 
 Preferred MCP tools (when available):

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -129,6 +129,11 @@ Commenting rules:
 - Only include explicit code suggestions when you are absolutely certain the replacement is correct and safe.
 
 Submission:
+- Do not submit inline comments when:
+  - the PR appears formatting-only, or
+  - all findings are low-severity (P2/P3), or
+  - you cannot anchor a high-confidence issue to a specific changed line.
+- Do not escalate style/formatting into P0/P1 just to justify leaving an inline comment.
 - If no issues are found and a prior "no issues" comment from this bot already exists, skip submitting another comment to avoid redundancy.
 - If no issues are found and no prior "no issues" comment exists, post a single brief top-level summary noting no issues.
 - If issues are found, delete/minimize/supersede any prior "no issues" comment before submitting.

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -30,8 +30,17 @@ Objectives:
 
 Procedure:
 - Run: gh pr view ${prNumber} --repo ${repoFullName} --json comments,reviews
-- Run: gh pr diff ${prNumber} --repo ${repoFullName}
-- Run: gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate --jq '.[] | {filename,patch,additions,deletions}'
+- Prefer reviewing the local git diff since the PR branch is already checked out:
+  - Ensure you have the base branch ref locally (fetch if needed).
+  - Find merge base between HEAD and the base branch.
+  - Run git diff from that merge base to HEAD to see exactly what would merge.
+  - Example:
+    - git fetch origin ${baseRefName}:refs/remotes/origin/${baseRefName}
+    - MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/${baseRefName})
+    - git diff $MERGE_BASE..HEAD
+- Use gh PR diff/file APIs only as a fallback when local git diff is not possible:
+  - gh pr diff ${prNumber} --repo ${repoFullName}
+  - gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate --jq '.[] | {filename,patch,additions,deletions}'
 - Prefer github_inline_comment___create_inline_comment with side="RIGHT" to post inline findings on changed/added lines
 - Compute exact diff positions (path + position) for each issue; every substantive comment must be inline on the changed line (no new top-level issue comments).
 - Detect prior top-level "no issues" comments authored by this bot (e.g., "no issues", "No issues found", "LGTM", including emoji-prefixed variants).

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -74,8 +74,6 @@ Use the following priority levels to categorize findings:
 - [P2] - Normal. To be fixed eventually
 - [P3] - Low. Nice to have
 
-IMPORTANT: Only post P0 and P1 findings as inline comments. Do NOT post P2 or P3 findings—they are too minor to warrant review noise. If all your findings are P2/P3, post no inline comments and note "no high-severity issues found" in the summary.
-
 Comment Guidelines:
 Your review comments should be:
 1. Clear about why the issue is a bug
@@ -88,8 +86,8 @@ Your review comments should be:
 8. Avoid excessive flattery
 
 Output Format:
-Structure each inline comment as (P0/P1 only):
-**[P0/P1] Clear title (≤ 80 chars, imperative mood)**
+Structure each inline comment as:
+**[P0-P3] Clear title (≤ 80 chars, imperative mood)**
 (blank line)
 Explanation of why this is a problem (1 paragraph max).
 

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -101,10 +101,22 @@ export async function prepareReviewMode({
   const droidArgParts: string[] = [];
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
 
-  // Add model override if specified
   const reviewModel = process.env.REVIEW_MODEL?.trim();
-  if (reviewModel) {
-    droidArgParts.push(`--model "${reviewModel}"`);
+  const reasoningEffort = process.env.REASONING_EFFORT?.trim();
+
+  // Default behavior (behind the scenes): if neither is provided, run GPT-5.2 at high reasoning.
+  if (!reviewModel && !reasoningEffort) {
+    droidArgParts.push(`--model "gpt-5.2"`);
+    droidArgParts.push(`--reasoning-effort "high"`);
+  } else {
+    // Add model override if specified
+    if (reviewModel) {
+      droidArgParts.push(`--model "${reviewModel}"`);
+    }
+    // Add reasoning effort override if specified
+    if (reasoningEffort) {
+      droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
+    }
   }
 
   if (normalizedUserArgs) {

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -29,7 +29,11 @@ describe("generateReviewPrompt", () => {
 
     expect(prompt).toContain("Objectives:");
     expect(prompt).toContain("Re-check existing review comments");
-    expect(prompt).toContain("gh pr diff 42 --repo test-owner/test-repo");
+    expect(prompt).toContain("git merge-base");
+    expect(prompt).toContain("git diff");
+    expect(prompt).toContain(
+      "gh pr diff 42 --repo test-owner/test-repo",
+    );
     expect(prompt).toContain("gh api repos/test-owner/test-repo/pulls/42/files");
     expect(prompt).toContain("github_inline_comment___create_inline_comment");
     expect(prompt).toContain("github_pr___resolve_review_thread");

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -61,5 +61,9 @@ describe("generateReviewPrompt", () => {
     expect(prompt).toContain("github_pr___submit_review");
     expect(prompt).toContain("github_pr___resolve_review_thread");
     expect(prompt).toContain("skip submitting another comment to avoid redundancy");
+    expect(prompt).toContain("Do not submit inline comments");
+    expect(prompt).toContain(
+      "Do not escalate style/formatting into P0/P1 just to justify leaving an inline comment",
+    );
   });
 });

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -265,6 +265,7 @@ describe("prepareReviewMode", () => {
 
   it("does not add --model flag when REVIEW_MODEL is empty", async () => {
     process.env.REVIEW_MODEL = "";
+    delete process.env.REASONING_EFFORT;
 
     const context = createMockContext({
       eventName: "issue_comment",
@@ -312,6 +313,8 @@ describe("prepareReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).not.toContain("--model");
+    // When neither REVIEW_MODEL nor REASONING_EFFORT is provided, we default to gpt-5.2 at high reasoning.
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.2"');
+    expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 });


### PR DESCRIPTION
## Summary
Improve review prompt guidance to reduce false-positive inline comments and fix a bug where the review would delete its own tracking comment.

## Changes
- Prefer merge-base + `git diff` against the base branch (fallback to `gh pr diff`/`gh api` when needed)
- Restore/clarify P2/P3 priority levels and output format
- Allow no inline comments for formatting-only PRs or when findings are only P2/P3
- Add guidance to avoid escalating style/formatting into P0/P1 just to justify inline comments
- Prevent review from deleting its own tracking comment by explicitly excluding the current comment ID

## Testing
- bun test
- bun run typecheck

Closes FAC-15023