### PR TITLE
fix: fix fetch DROID_COMMENT_ID bug

### DIFF
--- a/src/github/operations/comments/fetch-droid-comment.ts
+++ b/src/github/operations/comments/fetch-droid-comment.ts
@@ -1,0 +1,94 @@
+import type { Octokits } from "../../api/client";
+
+export interface FetchDroidCommentParams {
+  owner: string;
+  repo: string;
+  commentId: number;
+  isPullRequestReviewCommentEvent: boolean;
+}
+
+export interface FetchDroidCommentResult {
+  comment: { body: string | null };
+  isPRReviewComment: boolean;
+}
+
+/**
+ * Fetches a comment from GitHub, trying both issue comment and PR review comment APIs.
+ *
+ * GitHub uses separate ID namespaces for review comments and issue comments.
+ * The comment type doesn't always match the event type (e.g., a PR review comment
+ * could have been created in a previous step, but now we're in a pull_request event).
+ * This function tries both endpoints to handle all cases.
+ */
+export async function fetchDroidComment(
+  octokit: Octokits,
+  params: FetchDroidCommentParams,
+): Promise<FetchDroidCommentResult> {
+  const { owner, repo, commentId, isPullRequestReviewCommentEvent } = params;
+
+  let comment: { body: string | null } | undefined;
+  let isPRReviewComment = false;
+
+  // First, try the endpoint matching the event type for efficiency
+  if (isPullRequestReviewCommentEvent) {
+    try {
+      console.log(`Fetching PR review comment ${commentId}`);
+      const { data: prComment } = await octokit.rest.pulls.getReviewComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+      comment = { body: prComment.body ?? null };
+      isPRReviewComment = true;
+      console.log("Successfully fetched as PR review comment");
+    } catch {
+      // Fall through to try issue comment API
+      console.log("PR review comment fetch failed, trying issue comment API");
+    }
+  }
+
+  // Try issue comment API
+  if (!comment) {
+    try {
+      console.log(`Fetching issue comment ${commentId}`);
+      const { data: issueComment } = await octokit.rest.issues.getComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+      comment = { body: issueComment.body ?? null };
+      isPRReviewComment = false;
+      console.log("Successfully fetched as issue comment");
+    } catch (issueError) {
+      // If event wasn't a PR review comment event, try review comment API as fallback
+      if (!isPullRequestReviewCommentEvent) {
+        console.log(
+          "Issue comment fetch failed, trying PR review comment API",
+        );
+        try {
+          const { data: prComment } = await octokit.rest.pulls.getReviewComment(
+            {
+              owner,
+              repo,
+              comment_id: commentId,
+            },
+          );
+          comment = { body: prComment.body ?? null };
+          isPRReviewComment = true;
+          console.log("Successfully fetched as PR review comment");
+        } catch {
+          // Both APIs failed, throw the original issue error
+          throw issueError;
+        }
+      } else {
+        throw issueError;
+      }
+    }
+  }
+
+  if (!comment) {
+    throw new Error("Failed to fetch comment");
+  }
+
+  return { comment, isPRReviewComment };
+}

--- a/test/fetch-droid-comment.test.ts
+++ b/test/fetch-droid-comment.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect, jest, beforeEach } from "bun:test";
+import type { Octokits } from "../src/github/api/client";
+import {
+  fetchDroidComment,
+  type FetchDroidCommentParams,
+} from "../src/github/operations/comments/fetch-droid-comment";
+
+describe("fetchDroidComment", () => {
+  let mockOctokit: Octokits;
+
+  beforeEach(() => {
+    mockOctokit = {
+      rest: {
+        issues: {
+          getComment: jest.fn(),
+        },
+        pulls: {
+          getReviewComment: jest.fn(),
+        },
+      },
+    } as unknown as Octokits;
+  });
+
+  test("should fetch issue comment successfully when event is not PR review comment", async () => {
+    const mockIssueComment = {
+      data: {
+        id: 123456,
+        body: "Test issue comment",
+        html_url:
+          "https://github.com/owner/repo/issues/1#issuecomment-123456",
+      },
+    };
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest
+      .fn()
+      .mockResolvedValue(mockIssueComment);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 123456,
+      isPullRequestReviewCommentEvent: false,
+    };
+
+    const result = await fetchDroidComment(mockOctokit, params);
+
+    expect(mockOctokit.rest.issues.getComment).toHaveBeenCalledWith({
+      owner: "testowner",
+      repo: "testrepo",
+      comment_id: 123456,
+    });
+    expect(result.comment.body).toBe("Test issue comment");
+    expect(result.isPRReviewComment).toBe(false);
+  });
+
+  test("should fetch PR review comment successfully when event is PR review comment", async () => {
+    const mockPRReviewComment = {
+      data: {
+        id: 789012,
+        body: "Test PR review comment",
+        html_url:
+          "https://github.com/owner/repo/pull/1#discussion_r789012",
+      },
+    };
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.pulls.getReviewComment = jest
+      .fn()
+      .mockResolvedValue(mockPRReviewComment);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 789012,
+      isPullRequestReviewCommentEvent: true,
+    };
+
+    const result = await fetchDroidComment(mockOctokit, params);
+
+    expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalledWith({
+      owner: "testowner",
+      repo: "testrepo",
+      comment_id: 789012,
+    });
+    expect(result.comment.body).toBe("Test PR review comment");
+    expect(result.isPRReviewComment).toBe(true);
+  });
+
+  test("should fallback to PR review comment API when issue comment API returns 404 (non-PR-review-comment event)", async () => {
+    // This is the key test case: event is pull_request (not pull_request_review_comment)
+    // but the comment ID is actually a PR review comment ID
+    const mockError = new Error("Not Found") as Error & { status: number };
+    mockError.status = 404;
+
+    const mockPRReviewComment = {
+      data: {
+        id: 3812927863,
+        body: "Test PR review comment fetched via fallback",
+        html_url:
+          "https://github.com/owner/repo/pull/8179#discussion_r3812927863",
+      },
+    };
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest.fn().mockRejectedValue(mockError);
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.pulls.getReviewComment = jest
+      .fn()
+      .mockResolvedValue(mockPRReviewComment);
+
+    const params: FetchDroidCommentParams = {
+      owner: "trywingman",
+      repo: "stringsai",
+      commentId: 3812927863,
+      isPullRequestReviewCommentEvent: false, // Event is pull_request, not pull_request_review_comment
+    };
+
+    const result = await fetchDroidComment(mockOctokit, params);
+
+    // Should have tried issue comment API first
+    expect(mockOctokit.rest.issues.getComment).toHaveBeenCalledWith({
+      owner: "trywingman",
+      repo: "stringsai",
+      comment_id: 3812927863,
+    });
+
+    // Then should have fallen back to PR review comment API
+    expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalledWith({
+      owner: "trywingman",
+      repo: "stringsai",
+      comment_id: 3812927863,
+    });
+
+    expect(result.comment.body).toBe(
+      "Test PR review comment fetched via fallback",
+    );
+    expect(result.isPRReviewComment).toBe(true);
+  });
+
+  test("should fallback to issue comment API when PR review comment API fails for PR review comment event", async () => {
+    const mockError = new Error("Not Found") as Error & { status: number };
+    mockError.status = 404;
+
+    const mockIssueComment = {
+      data: {
+        id: 456789,
+        body: "Test issue comment fetched via fallback",
+        html_url:
+          "https://github.com/owner/repo/issues/1#issuecomment-456789",
+      },
+    };
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.pulls.getReviewComment = jest
+      .fn()
+      .mockRejectedValue(mockError);
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest
+      .fn()
+      .mockResolvedValue(mockIssueComment);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 456789,
+      isPullRequestReviewCommentEvent: true,
+    };
+
+    const result = await fetchDroidComment(mockOctokit, params);
+
+    // Should have tried PR review comment API first
+    expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalledWith({
+      owner: "testowner",
+      repo: "testrepo",
+      comment_id: 456789,
+    });
+
+    // Then should have fallen back to issue comment API
+    expect(mockOctokit.rest.issues.getComment).toHaveBeenCalledWith({
+      owner: "testowner",
+      repo: "testrepo",
+      comment_id: 456789,
+    });
+
+    expect(result.comment.body).toBe(
+      "Test issue comment fetched via fallback",
+    );
+    expect(result.isPRReviewComment).toBe(false);
+  });
+
+  test("should throw error when both APIs fail for non-PR-review-comment event", async () => {
+    const issueError = new Error("Issue comment not found") as Error & {
+      status: number;
+    };
+    issueError.status = 404;
+
+    const prReviewError = new Error("PR review comment not found") as Error & {
+      status: number;
+    };
+    prReviewError.status = 404;
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest
+      .fn()
+      .mockRejectedValue(issueError);
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.pulls.getReviewComment = jest
+      .fn()
+      .mockRejectedValue(prReviewError);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 999999,
+      isPullRequestReviewCommentEvent: false,
+    };
+
+    // Should throw the original issue error after both APIs fail
+    await expect(fetchDroidComment(mockOctokit, params)).rejects.toThrow(
+      "Issue comment not found",
+    );
+
+    expect(mockOctokit.rest.issues.getComment).toHaveBeenCalled();
+    expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalled();
+  });
+
+  test("should throw error when both APIs fail for PR review comment event", async () => {
+    const prReviewError = new Error("PR review comment not found") as Error & {
+      status: number;
+    };
+    prReviewError.status = 404;
+
+    const issueError = new Error("Issue comment not found") as Error & {
+      status: number;
+    };
+    issueError.status = 404;
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.pulls.getReviewComment = jest
+      .fn()
+      .mockRejectedValue(prReviewError);
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest
+      .fn()
+      .mockRejectedValue(issueError);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 888888,
+      isPullRequestReviewCommentEvent: true,
+    };
+
+    // Should throw the issue error (from the fallback attempt)
+    await expect(fetchDroidComment(mockOctokit, params)).rejects.toThrow(
+      "Issue comment not found",
+    );
+
+    expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalled();
+    expect(mockOctokit.rest.issues.getComment).toHaveBeenCalled();
+  });
+
+  test("should handle null body in comment", async () => {
+    const mockIssueComment = {
+      data: {
+        id: 111222,
+        body: null,
+        html_url:
+          "https://github.com/owner/repo/issues/1#issuecomment-111222",
+      },
+    };
+
+    // @ts-expect-error Mock implementation
+    mockOctokit.rest.issues.getComment = jest
+      .fn()
+      .mockResolvedValue(mockIssueComment);
+
+    const params: FetchDroidCommentParams = {
+      owner: "testowner",
+      repo: "testrepo",
+      commentId: 111222,
+      isPullRequestReviewCommentEvent: false,
+    };
+
+    const result = await fetchDroidComment(mockOctokit, params);
+
+    expect(result.comment.body).toBeNull();
+    expect(result.isPRReviewComment).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes FAC-15570

Bug

Users see a 404 error when update-comment-link.ts tries to fetch a comment:

```
GET /repos/{owner}/{repo}/issues/comments/{id} - 404
HttpError: Not Found - https://docs.github.com/rest/issues/comments#get-an-issue-comment
```

Root Cause

GitHub uses separate ID namespaces and API endpoints for:

•  Issue comments (issues.getComment)
•  PR review comments (pulls.getReviewComment)

The original code determined which API to call based solely on the event type (pull_request_review_comment vs everything else). However, the DROID_COMMENT_ID could be a PR review comment ID even when the current event is pull_request (e.g., the comment was created in a previous workflow step).

When querying a PR review comment ID via the issue comments endpoint, GitHub returns 404.

Fix

Extracted comment fetching into a new helper function fetchDroidComment that tries both APIs:

First tries the API matching the event type (for efficiency)

Falls back to the other API if the first returns 404

This handles cases where the comment type doesn't match the event type.