### PR TITLE
fix: generate prompt file for @droid review and @droid security commands

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Prepare
         id: prepare
-        uses: Factory-AI/droid-action/prepare@v1
+        uses: Factory-AI/droid-action/prepare@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Code Review
-        uses: Factory-AI/droid-action/review@v1
+        uses: Factory-AI/droid-action/review@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
@@ -78,7 +78,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Security Review
-        uses: Factory-AI/droid-action/security@v1
+        uses: Factory-AI/droid-action/security@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
@@ -127,7 +127,7 @@ jobs:
         continue-on-error: true
 
       - name: Combine Results
-        uses: Factory-AI/droid-action/combine@v1
+        uses: Factory-AI/droid-action/combine@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -34,6 +34,6 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v1
+        uses: Factory-AI/droid-action@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -187,14 +187,12 @@ export async function prepareTagExecution({
   if (commandContext?.command === "security") {
     core.setOutput("run_code_review", "false");
     core.setOutput("run_security_review", "true");
-    return {
-      skipped: false,
-      branchInfo: {
-        baseBranch: "",
-        currentBranch: "",
-      },
-      mcpTools: "",
-    };
+    return prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken,
+      trackingCommentId: commentId,
+    });
   }
 
   if (commandContext?.command === "security-full") {
@@ -214,14 +212,12 @@ export async function prepareTagExecution({
   ) {
     core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", "false");
-    return {
-      skipped: false,
-      branchInfo: {
-        baseBranch: "",
-        currentBranch: "",
-      },
-      mcpTools: "",
-    };
+    return prepareReviewMode({
+      context,
+      octokit,
+      githubToken,
+      trackingCommentId: commentId,
+    });
   }
 
   throw new Error(`Unexpected command: ${commandContext?.command}`);

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -7,6 +7,7 @@ import { createMockContext } from "../mockContext";
 import * as createInitial from "../../src/github/operations/comments/create-initial";
 import * as mcpInstaller from "../../src/mcp/install-mcp-server";
 import * as actorValidation from "../../src/github/validation/actor";
+import * as promptModule from "../../src/create-prompt";
 import * as core from "@actions/core";
 
 describe("review command integration", () => {
@@ -19,6 +20,7 @@ describe("review command integration", () => {
   let actorSpy: ReturnType<typeof spyOn>;
   let setOutputSpy: ReturnType<typeof spyOn>;
   let exportVarSpy: ReturnType<typeof spyOn>;
+  let promptSpy: ReturnType<typeof spyOn>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "review-int-"));
@@ -32,6 +34,7 @@ describe("review command integration", () => {
 
     mcpSpy = spyOn(mcpInstaller, "prepareMcpTools").mockResolvedValue("{}");
     actorSpy = spyOn(actorValidation, "checkHumanActor").mockResolvedValue();
+    promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
     setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
     exportVarSpy = spyOn(core, "exportVariable").mockImplementation(() => {});
   });
@@ -41,6 +44,7 @@ describe("review command integration", () => {
     createCommentSpy.mockRestore();
     mcpSpy.mockRestore();
     actorSpy.mockRestore();
+    promptSpy.mockRestore();
     setOutputSpy.mockRestore();
     exportVarSpy.mockRestore();
 
@@ -116,9 +120,10 @@ describe("review command integration", () => {
       githubToken: "token",
     });
 
-    // In the parallel workflow, @droid review sets output flags and returns early
-    // The actual review is done by downstream workflow jobs
-    expect(result.skipped).toBe(false);
+    expect(result.skipped).toBeFalsy();
+    expect(result.branchInfo.baseBranch).toBe("main");
+    expect(result.branchInfo.currentBranch).toBe("feature/review");
+    expect(promptSpy).toHaveBeenCalled();
 
     // Verify output flags were set correctly for code review only
     const runCodeReviewCall = setOutputSpy.mock.calls.find(
@@ -157,7 +162,29 @@ describe("review command integration", () => {
       } as any,
     });
 
-    const octokit = { rest: {} } as any;
+    const octokit = {
+      rest: {},
+      graphql: () =>
+        Promise.resolve({
+          repository: {
+            pullRequest: {
+              baseRefName: "main",
+              headRefName: "feature/security",
+              headRefOid: "abc123",
+            },
+          },
+        }),
+    } as any;
+
+    graphqlSpy = spyOn(octokit, "graphql").mockResolvedValue({
+      repository: {
+        pullRequest: {
+          baseRefName: "main",
+          headRefName: "feature/security",
+          headRefOid: "abc123",
+        },
+      },
+    });
 
     const result = await prepareTagExecution({
       context,
@@ -165,7 +192,10 @@ describe("review command integration", () => {
       githubToken: "token",
     });
 
-    expect(result.skipped).toBe(false);
+    expect(result.skipped).toBeFalsy();
+    expect(result.branchInfo.baseBranch).toBe("main");
+    expect(result.branchInfo.currentBranch).toBe("feature/security");
+    expect(promptSpy).toHaveBeenCalled();
 
     const runCodeReviewCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "run_code_review",


### PR DESCRIPTION
## Summary
Fixes a bug where `@droid review` and `@droid security` commands in PR comments fail with `Error: Prompt file '/home/runner/work/_temp/droid-prompts/droid-prompt.txt' does not exist`.
## Root Cause
The `prepareTagExecution` function in `src/tag/index.ts` had two code paths — for the explicit `@droid review` and `@droid security` commands — that set workflow output flags (`run_code_review`, `run_security_review`) but returned stub results without calling `prepareReviewMode()` or `prepareSecurityReviewMode()`. These functions are responsible for fetching PR branch data, generating the prompt file, and configuring MCP tools.
Without the prompt file, the downstream `base-action` immediately fails when it tries to read the prompt.
This did not affect `automatic_review` or `automatic_security_review` triggers, which correctly called the prepare functions. It also did not affect ``, which had its own correct code path.
## Changes
### `src/tag/index.ts`
- **`@droid review` / `@droid` (default)**: Replaced the stub return with a call to `prepareReviewMode()`, which fetches PR data, generates the review prompt file, and configures the allowed MCP tools.
- **`@droid security`**: Replaced the stub return with a call to `prepareSecurityReviewMode()`, which fetches PR data, generates the security review prompt file, and configures the allowed MCP tools.
### `test/integration/review-flow.test.ts`
- Added `createPrompt` mock to prevent actual file I/O during tests.
- Added GraphQL mock for the `@droid security` test case (needed by `prepareSecurityReviewMode` to fetch PR branch data).
- Updated assertions to validate that the prompt is generated and branch info is populated correctly.
### `.github/workflows/droid-review.yml` / `.github/workflows/droid.yml`
- Changed action references from `@v1` to `@dev` for testing.
## Testing
All 350 existing tests pass. The two previously affected integration tests (`prepares review flow end-to-end`, `sets security flag only for @droid security`) now validate the full prepare flow instead of stub behavior.
## Related Issues
None