### PR TITLE
feat: changes for benchmark

### DIFF
--- a/.factory/droids/file-group-reviewer.md
+++ b/.factory/droids/file-group-reviewer.md
@@ -1,0 +1,74 @@
+---
+name: file-group-reviewer
+description: Reviews an assigned subset of PR files for bugs, security issues, and correctness problems. Spawned in parallel by the main review agent to ensure thorough coverage.
+model: inherit
+tools: ["Read", "Grep", "Glob", "LS"]
+---
+
+You are a senior staff software engineer and expert code reviewer.
+
+Your task: Review the assigned files from the PR and generate a JSON array of **high-confidence, actionable** review comments that pinpoint genuine issues.
+
+<review_guidelines>
+- You are currently checked out to the PR branch.
+- Review ALL files assigned to you thoroughly.
+- Focus on: functional correctness, syntax errors, logic bugs, broken dependencies/contracts/tests, security issues, and performance problems.
+- High-signal bug patterns to actively check for (only comment when evidenced in the diff):
+  - Null/undefined/Optional dereferences; missing-key errors on untrusted/external dict/JSON payloads
+  - Resource leaks (unclosed files/streams/connections; missing cleanup on error paths)
+  - Injection vulnerabilities (SQL injection, XSS, command/template injection) and auth/security invariant violations
+  - OAuth/CSRF invariants: state must be per-flow unpredictable and validated; avoid deterministic/predictable state or missing state checks
+  - Concurrency/race/atomicity hazards (TOCTOU, lost updates, unsafe shared state, process/thread lifecycle bugs)
+  - Missing error handling for critical operations (network, persistence, auth, migrations, external APIs)
+  - Wrong-variable/shadowing mistakes; contract mismatches (serializer/validated_data, interfaces/abstract methods)
+  - Type-assumption bugs (e.g., numeric ops on datetime/strings, ordering key type mismatches)
+  - Offset/cursor/pagination semantic mismatches (off-by-one, prev/next behavior, commit semantics)
+- Only flag issues you are confident about—avoid speculative or stylistic nitpicks.
+</review_guidelines>
+
+<workflow>
+1. Read each assigned file in full to understand the context
+2. Read the relevant diff sections provided in the prompt
+3. Read related files as needed to fully understand the changes:
+   - Imported modules and dependencies
+   - Interfaces, base classes, and type definitions
+   - Related tests to understand expected behavior
+   - Callers/callees of modified functions
+   - Configuration files if behavior depends on them
+4. Analyze the changes for issues matching the bug patterns above
+5. For each issue found, verify it against the actual code and related context before including it
+</workflow>
+
+<output_format>
+Return your findings as a JSON array (no wrapper object, just the array):
+
+```json
+[
+  {
+    "path": "src/index.ts",
+    "body": "[P1] Title\n\n1 paragraph explanation.",
+    "line": 42,
+    "startLine": null,
+    "side": "RIGHT"
+  }
+]
+```
+
+If no issues found, return an empty array: `[]`
+
+Field definitions:
+- `path`: Relative file path (must match exactly as provided in your assignment)
+- `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation
+  - P0: Critical bugs (crashes, security vulnerabilities, data loss)
+  - P1: Important bugs (incorrect behavior, logic errors)
+  - P2: Minor bugs (edge cases, non-critical issues)
+- `line`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
+- `startLine`: `null` for single-line comments, or start line number for multi-line comments
+- `side`: "RIGHT" for new/modified code (default), "LEFT" only for commenting on removed code
+</output_format>
+
+<constraints>
+- Output ONLY the JSON array—no additional commentary or markdown formatting around it.
+- Do not include `commit_id` in your output—the parent agent will add this.
+- Do not attempt to post comments to GitHub—just return the JSON array.
+</constraints>

--- a/action.yml
+++ b/action.yml
@@ -349,7 +349,7 @@ runs:
 
     - name: Prepare validator
       id: prepare_validator
-      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true'
+      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true' && steps.prepare.outputs.run_code_review == 'true'
       shell: bash
       run: |
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare-validator.ts
@@ -362,7 +362,7 @@ runs:
 
     - name: Run Droid Exec (validator)
       id: droid_validator
-      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true'
+      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true' && steps.prepare.outputs.run_code_review == 'true'
       shell: bash
       run: |
 
@@ -401,7 +401,7 @@ runs:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         IS_PR: ${{ github.event.issue.pull_request != null || github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review_comment' }}
-        DROID_SUCCESS: ${{ (inputs.review_use_validator == 'true' && steps.droid_validator.outputs.conclusion == 'success') || (inputs.review_use_validator != 'true' && steps.droid.outputs.conclusion == 'success') }}
+        DROID_SUCCESS: ${{ (inputs.review_use_validator == 'true' && steps.prepare.outputs.run_code_review == 'true' && steps.droid_validator.outputs.conclusion == 'success') || (!(inputs.review_use_validator == 'true' && steps.prepare.outputs.run_code_review == 'true') && steps.droid.outputs.conclusion == 'success') }}
         TRIGGER_USERNAME: ${{ github.event.comment.user.login || github.event.issue.user.login || github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,18 @@ inputs:
     description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty and review_model is also empty, the action defaults internally to gpt-5.2 at high reasoning."
     required: false
     default: ""
+  review_use_validator:
+    description: "Enable two-pass review: generate candidate comments to JSON, then validate and post only approved ones."
+    required: false
+    default: "true"
+  review_candidates_path:
+    description: "Path to write review candidates JSON (run #1 when review_use_validator=true)."
+    required: false
+    default: "${{ runner.temp }}/droid-prompts/review_candidates.json"
+  review_validated_path:
+    description: "Path to write review validated JSON (run #2 when review_use_validator=true)."
+    required: false
+    default: "${{ runner.temp }}/droid-prompts/review_validated.json"
   fill_model:
     description: "Override the model used for PR description fill (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to fill flows."
     required: false
@@ -177,6 +189,9 @@ runs:
         SECURITY_SCAN_DAYS: ${{ inputs.security_scan_days }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        REVIEW_USE_VALIDATOR: ${{ inputs.review_use_validator }}
+        REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         FILL_MODEL: ${{ inputs.fill_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         DROID_ARGS: ${{ inputs.droid_args }}
@@ -208,6 +223,20 @@ runs:
         echo "Using custom Droid executable: ${{ inputs.path_to_droid_executable }}"
         DROID_DIR=$(dirname "${{ inputs.path_to_droid_executable }}")
         echo "$DROID_DIR" >> "$GITHUB_PATH"
+
+    - name: Setup Custom Droids
+      if: steps.prepare.outputs.contains_trigger == 'true'
+      shell: bash
+      run: |
+        echo "Setting up custom droids..."
+        mkdir -p ~/.factory/droids
+        if [ -d "${GITHUB_ACTION_PATH}/.factory/droids" ]; then
+          cp -r ${GITHUB_ACTION_PATH}/.factory/droids/* ~/.factory/droids/
+          echo "Copied custom droids to ~/.factory/droids/"
+          ls -la ~/.factory/droids/
+        else
+          echo "No custom droids found in action"
+        fi
 
     - name: Setup Network Restrictions
       if: steps.prepare.outputs.contains_trigger == 'true' && inputs.experimental_allowed_domains != ''
@@ -291,6 +320,7 @@ runs:
       env:
         GH_TOKEN: ${{ steps.prepare.outputs.github_token }}
 
+
     - name: Run Droid Exec
       id: droid
       if: steps.prepare.outputs.contains_trigger == 'true'
@@ -317,6 +347,46 @@ runs:
         DETAILED_PERMISSION_MESSAGES: "1"
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
 
+    - name: Prepare validator
+      id: prepare_validator
+      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true'
+      shell: bash
+      run: |
+        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare-validator.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare.outputs.github_token }}
+        REVIEW_USE_VALIDATOR: ${{ inputs.review_use_validator }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
+        REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
+        DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
+
+    - name: Run Droid Exec (validator)
+      id: droid_validator
+      if: steps.prepare.outputs.contains_trigger == 'true' && inputs.review_use_validator == 'true'
+      shell: bash
+      run: |
+
+        # Run the base-action
+        bun run ${GITHUB_ACTION_PATH}/base-action/src/index.ts
+      env:
+        # Base-action inputs
+        INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
+        INPUT_SETTINGS: ${{ inputs.settings }}
+        INPUT_DROID_ARGS: ${{ steps.prepare_validator.outputs.droid_args }}
+        INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
+        INPUT_EXPERIMENTAL_SLASH_COMMANDS_DIR: ${{ github.action_path }}/slash-commands
+        INPUT_ACTION_INPUTS_PRESENT: ${{ steps.prepare.outputs.action_inputs_present }}
+        INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
+        INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+
+        # Model configuration
+        GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        NODE_VERSION: ${{ env.NODE_VERSION }}
+        DETAILED_PERMISSION_MESSAGES: "1"
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+
+
     - name: Update comment with job link
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.droid_comment_id && always()
       shell: bash
@@ -331,7 +401,7 @@ runs:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         IS_PR: ${{ github.event.issue.pull_request != null || github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review_comment' }}
-        DROID_SUCCESS: ${{ steps.droid.outputs.conclusion == 'success' }}
+        DROID_SUCCESS: ${{ (inputs.review_use_validator == 'true' && steps.droid_validator.outputs.conclusion == 'success') || (inputs.review_use_validator != 'true' && steps.droid.outputs.conclusion == 'success') }}
         TRIGGER_USERNAME: ${{ github.event.comment.user.login || github.event.issue.user.login || github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
@@ -348,16 +418,7 @@ runs:
           ~/.factory/logs/droid-log-single.log
           ~/.factory/logs/console.log
           ~/.factory/sessions/*
+          ~/.factory/droids/*
+          ${{ runner.temp }}/droid-prompts/**
         if-no-files-found: ignore
         retention-days: 7
-
-    - name: Revoke app token
-      if: always() && inputs.github_token == '' && steps.prepare.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
-      shell: bash
-      run: |
-        curl -L \
-          -X DELETE \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ steps.prepare.outputs.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          ${GITHUB_API_URL:-https://api.github.com}/installation/token

--- a/base-action/test/run-droid-mcp.test.ts
+++ b/base-action/test/run-droid-mcp.test.ts
@@ -94,6 +94,7 @@ mock.module("child_process", () => ({
     });
   },
   spawn: mockSpawn,
+  execSync: (_cmd: string) => "",
 }));
 
 type RunDroidModule = typeof import("../src/run-droid");

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -15,14 +15,20 @@ import {
   isPullRequestReviewCommentEvent,
 } from "../github/context";
 import type { ParsedGitHubContext } from "../github/context";
-import type { CommonFields, PreparedContext, EventData } from "./types";
+import type {
+  CommonFields,
+  PreparedContext,
+  EventData,
+  ReviewArtifacts,
+} from "./types";
 
-export type { CommonFields, PreparedContext } from "./types";
+export type { CommonFields, PreparedContext, ReviewArtifacts } from "./types";
 
 const BASE_ALLOWED_TOOLS = [
   "Execute",
   "Edit",
   "Create",
+  "ApplyPatch",
   "Read",
   "Glob",
   "Grep",
@@ -70,6 +76,7 @@ export function prepareContext(
   baseBranch?: string,
   droidBranch?: string,
   prBranchData?: { headRefName: string; headRefOid: string },
+  reviewArtifacts?: ReviewArtifacts,
 ): PreparedContext {
   const repository = context.repository.full_name;
   const triggerPhrase = context.inputs.triggerPhrase || "@droid";
@@ -123,6 +130,10 @@ export function prepareContext(
 
   if (prBranchData) {
     result.prBranchData = prBranchData;
+  }
+
+  if (reviewArtifacts) {
+    result.reviewArtifacts = reviewArtifacts;
   }
 
   return result;
@@ -291,6 +302,7 @@ export type PromptCreationOptions = {
   allowedTools?: string[];
   disallowedTools?: string[];
   includeActionsTools?: boolean;
+  reviewArtifacts?: ReviewArtifacts;
 };
 
 export async function createPrompt({
@@ -303,6 +315,7 @@ export async function createPrompt({
   allowedTools = [],
   disallowedTools = [],
   includeActionsTools = false,
+  reviewArtifacts,
 }: PromptCreationOptions) {
   try {
     const droidCommentId = commentId?.toString();
@@ -312,6 +325,7 @@ export async function createPrompt({
       baseBranch,
       droidBranch,
       prBranchData,
+      reviewArtifacts,
     );
 
     await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/droid-prompts`, {

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -1,0 +1,200 @@
+import type { PreparedContext } from "../types";
+
+export function generateReviewCandidatesPrompt(context: PreparedContext): string {
+  const prNumber = context.eventData.isPR
+    ? context.eventData.prNumber
+    : context.githubContext && "entityNumber" in context.githubContext
+      ? String(context.githubContext.entityNumber)
+      : "unknown";
+
+  const repoFullName = context.repository;
+  const prHeadRef = context.prBranchData?.headRefName ?? "unknown";
+  const prHeadSha = context.prBranchData?.headRefOid ?? "unknown";
+  const prBaseRef = context.eventData.baseBranch ?? "unknown";
+
+  const diffPath =
+    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
+  const commentsPath =
+    context.reviewArtifacts?.commentsPath ??
+    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
+
+  const reviewCandidatesPath =
+    process.env.REVIEW_CANDIDATES_PATH ??
+    "$RUNNER_TEMP/droid-prompts/review_candidates.json";
+
+  return `You are a senior staff software engineer and expert code reviewer.
+
+Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
+
+<context>
+Repo: ${repoFullName}
+PR Number: ${prNumber}
+PR Head Ref: ${prHeadRef}
+PR Head SHA: ${prHeadSha}
+PR Base Ref: ${prBaseRef}
+
+Precomputed data files:
+- Full PR Diff: \`${diffPath}\`
+- Existing Comments: \`${commentsPath}\`
+</context>
+
+<review_guidelines>
+- You are currently checked out to the PR branch.
+- Review ALL modified files in the PR branch.
+- Focus on: functional correctness, syntax errors, logic bugs, broken dependencies/contracts/tests, security issues, and performance problems.
+- High-signal bug patterns to actively check for (only comment when evidenced in the diff):
+  - Null/undefined/Optional dereferences; missing-key errors on untrusted/external dict/JSON payloads
+  - Resource leaks (unclosed files/streams/connections; missing cleanup on error paths)
+  - Injection vulnerabilities (SQL injection, XSS, command/template injection) and auth/security invariant violations
+  - OAuth/CSRF invariants: state must be per-flow unpredictable and validated; avoid deterministic/predictable state or missing state checks
+  - Concurrency/race/atomicity hazards (TOCTOU, lost updates, unsafe shared state, process/thread lifecycle bugs)
+  - Missing error handling for critical operations (network, persistence, auth, migrations, external APIs)
+  - Wrong-variable/shadowing mistakes; contract mismatches (serializer/validated_data, interfaces/abstract methods)
+  - Type-assumption bugs (e.g., numeric ops on datetime/strings, ordering key type mismatches)
+  - Offset/cursor/pagination semantic mismatches (off-by-one, prev/next behavior, commit semantics)
+- Do NOT duplicate comments already in \`${commentsPath}\`.
+- Only flag issues you are confident about—avoid speculative or stylistic nitpicks.
+</review_guidelines>
+
+<triage_phase>
+**Step 1: Analyze and group the modified files**
+
+Before reviewing, you must triage the PR to enable parallel review:
+
+1. Read the diff file (\`${diffPath}\`) to identify ALL modified files
+2. Group the files into logical clusters based on:
+   - **Related functionality**: Files in the same module or feature area
+   - **File relationships**: A component and its tests, a class and its interface
+   - **Risk profile**: Security-sensitive files together, database/migration files together
+   - **Dependencies**: Files that import each other or share types
+
+3. Document your grouping briefly, for example:
+   - Group 1 (Auth): src/auth/login.ts, src/auth/session.ts, tests/auth.test.ts
+   - Group 2 (API handlers): src/api/users.ts, src/api/orders.ts
+   - Group 3 (Database): src/db/migrations/001.ts, src/db/schema.ts
+
+Guidelines for grouping:
+- Aim for 3-6 groups to balance parallelism with context coherence
+- Keep related files together so reviewers have full context
+- Each group should be reviewable independently
+</triage_phase>
+
+<parallel_review_phase>
+**Step 2: Spawn parallel subagents to review each group**
+
+After grouping, use the Task tool to spawn parallel \`file-group-reviewer\` subagents. Each subagent will review one group of files independently.
+
+**IMPORTANT**: Spawn ALL subagents in a single response to enable parallel execution.
+
+For each group, invoke the Task tool with:
+- \`subagent_type\`: "file-group-reviewer"
+- \`description\`: Brief label (e.g., "Review auth module")
+- \`prompt\`: Must include:
+  1. The PR context (repo, PR number, base/head refs)
+  2. The list of assigned files for this group
+  3. The relevant diff sections for those files (extract from \`${diffPath}\`)
+  4. Instructions to return a JSON array of findings
+
+Example Task invocation for one group:
+\`\`\`
+Task(
+  subagent_type: "file-group-reviewer",
+  description: "Review auth module",
+  prompt: """
+    Review the following files from PR #${prNumber} in ${repoFullName}.
+    
+    PR Context:
+    - Head SHA: ${prHeadSha}
+    - Base Ref: ${prBaseRef}
+    
+    Assigned files:
+    - src/auth/login.ts
+    - src/auth/session.ts
+    - tests/auth.test.ts
+    
+    Diff for these files:
+    <paste relevant diff sections here>
+    
+    Return a JSON array of issues found. If no issues, return [].
+  """
+)
+\`\`\`
+
+Spawn all group reviewers in parallel by including multiple Task calls in one response.
+</parallel_review_phase>
+
+<aggregation_phase>
+**Step 3: Aggregate subagent results**
+
+After all subagents complete, collect and merge their findings:
+
+1. **Collect results**: Each subagent returns a JSON array of comment objects
+2. **Merge arrays**: Combine all arrays into a single comments array
+3. **Add commit_id**: Add \`"commit_id": "${prHeadSha}"\` to each comment object
+4. **Deduplicate**: If multiple subagents flagged the same location (same path + line), keep only one comment (prefer higher priority: P0 > P1 > P2)
+5. **Filter existing**: Remove any comments that duplicate issues already in \`${commentsPath}\`
+6. **Write reviewSummary**: Synthesize a 1-3 sentence overall assessment based on all findings
+
+Write the final aggregated result to \`${reviewCandidatesPath}\` using the schema in \`<output_spec>\`.
+</aggregation_phase>
+
+<output_spec>
+Write output to \`${reviewCandidatesPath}\` using this exact schema:
+
+\`\`\`json
+{
+  "version": 1,
+  "meta": {
+    "repo": "owner/repo",
+    "prNumber": 123,
+    "headSha": "<head sha>",
+    "baseRef": "main",
+    "generatedAt": "<ISO timestamp>"
+  },
+  "comments": [
+    {
+      "path": "src/index.ts",
+      "body": "[P1] Title\n\n1 paragraph.",
+      "line": 42,
+      "startLine": null,
+      "side": "RIGHT",
+      "commit_id": "<head sha>"
+    }
+  ],
+  "reviewSummary": {
+    "body": "1-3 sentence overall assessment"
+  }
+}
+\`\`\`
+
+<schema_details>
+- **version**: Always \`1\`
+
+- **meta**: Metadata object
+  - \`repo\`: "${repoFullName}"
+  - \`prNumber\`: ${prNumber}
+  - \`headSha\`: "${prHeadSha}"
+  - \`baseRef\`: "${prBaseRef}"
+  - \`generatedAt\`: ISO 8601 timestamp (e.g., "2024-01-15T10:30:00Z")
+
+- **comments**: Array of comment objects
+  - \`path\`: Relative file path (e.g., "src/index.ts")
+  - \`body\`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation
+  - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
+  - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
+  - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code
+  - \`commit_id\`: "${prHeadSha}"
+
+- **reviewSummary**:
+  - \`body\`: 1-3 sentence overall assessment
+</schema_details>
+</output_spec>
+
+<critical_constraints>
+**DO NOT** post to GitHub.
+**DO NOT** invoke any PR mutation tools (inline comments, submit review, delete/minimize/reply/resolve, etc.).
+**DO NOT** modify any files other than writing to \`${reviewCandidatesPath}\`.
+Output ONLY the JSON file—no additional commentary.
+</critical_constraints>
+`;
+}

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -12,194 +12,339 @@ export function generateReviewPrompt(context: PreparedContext): string {
   const headSha = context.prBranchData?.headRefOid ?? "unknown";
   const baseRefName = context.eventData.baseBranch ?? "unknown";
 
+  const diffPath =
+    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
+  const commentsPath =
+    context.reviewArtifacts?.commentsPath ??
+    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
+
   return `You are performing an automated code review for PR #${prNumber} in ${repoFullName}.
 The gh CLI is installed and authenticated via GH_TOKEN.
 
-Context:
-- Repo: ${repoFullName}
-- PR Number: ${prNumber}
-- PR Head Ref: ${headRefName}
-- PR Head SHA: ${headSha}
-- PR Base Ref: ${baseRefName}
-- The PR branch has already been checked out. You have full access to read any file in the codebase, not just the diff output.
+### Context
 
-Objectives:
-1) Re-check existing review comments and resolve threads when the issue is fixed (fall back to a brief "resolved" reply only if the thread cannot be marked resolved).
-2) Review the PR diff and surface all bugs that meet the detection criteria below.
-3) Leave concise inline comments (1-2 sentences) on bugs introduced by the PR. You may also comment on unchanged lines if the PR's changes expose or trigger issues there—but explain the connection clearly.
+* Repo: ${repoFullName}
+* PR Number: ${prNumber}
+* PR Head Ref: ${headRefName}
+* PR Head SHA: ${headSha}
+* PR Base Ref: ${baseRefName}
+* The PR branch has already been checked out. You have full access to read any file in the codebase, not just the diff output.
 
-Procedure:
-- Run: gh pr view ${prNumber} --repo ${repoFullName} --json comments,reviews
-- Prefer reviewing the local git diff since the PR branch is already checked out:
-  - Ensure you have the base branch ref locally (fetch if needed).
-  - Find merge base between HEAD and the base branch.
-  - Run git diff from that merge base to HEAD to see exactly what would merge.
-  - Example:
-    - git fetch origin ${baseRefName}:refs/remotes/origin/${baseRefName}
-    - MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/${baseRefName})
-    - git diff $MERGE_BASE..HEAD
-- Use gh PR diff/file APIs only as a fallback when local git diff is not possible:
-  - gh pr diff ${prNumber} --repo ${repoFullName}
-  - gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate --jq '.[] | {filename,patch,additions,deletions}'
-- Prefer github_inline_comment___create_inline_comment with side="RIGHT" to post inline findings on changed/added lines
-- Compute exact diff positions (path + position) for each issue; every substantive comment must be inline on the changed line (no new top-level issue comments).
-- Detect prior top-level "no issues" comments authored by this bot (e.g., "no issues", "No issues found", "LGTM", including emoji-prefixed variants).
-- If the current run finds issues and prior "no issues" comments exist, delete them via gh api -X DELETE repos/${repoFullName}/issues/comments/<comment_id>; if deletion fails, minimize via GraphQL or reply "Superseded: issues were found in newer commits".
-- IMPORTANT: Do NOT delete comment ID ${context.droidCommentId} - this is the tracking comment for the current run.
-- Thread resolution rule (CRITICAL): NEVER resolve review threads.
-  - Do NOT call github_pr___resolve_review_thread under any circumstances.
-  - If a previously reported issue appears fixed, leave the thread unresolved.
+### Pre-computed Review Artifacts
 
-Preferred MCP tools (when available):
-- github_inline_comment___create_inline_comment to post inline feedback anchored to the diff
-- github_pr___submit_review to send inline review feedback
-- github_pr___delete_comment to remove outdated "no issues" comments
-- github_pr___minimize_comment when deletion is unavailable but minimization is acceptable
-- github_pr___reply_to_comment to acknowledge resolved threads
-- github_pr___resolve_review_thread to formally resolve threads once issues are fixed
+The following files have been pre-computed and contain the COMPLETE data for this PR:
 
-Diff Side Selection (CRITICAL):  
-- When calling github_inline_comment___create_inline_comment, ALWAYS specify the 'side' parameter  
-- Use side="RIGHT" for comments on NEW or MODIFIED code (what the PR adds/changes)  
-- Use side="LEFT" ONLY when commenting on code being REMOVED (only if you need to reference the old implementation)  
-- The 'line' parameter refers to the line number on the specified side of the diff  
-- Ensure the line numbers you use correspond to the side you choose;
+* **Full PR Diff**: \`${diffPath}\` - Contains the COMPLETE diff of ALL changed files (already computed via \`git merge-base\` and \`git diff\`)
+* **Existing Comments**: \`${commentsPath}\` - Contains all existing PR comments and reviews in JSON format
 
-How Many Findings to Return:
-Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
+**IMPORTANT**: Use these pre-computed files instead of running git or gh commands to fetch diff/comments. This ensures you have access to the COMPLETE data without truncation.
 
-Key Guidelines for Bug Detection:
-Only flag an issue as a bug if:
-1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
-2. The bug is discrete and actionable (not a general issue).
-3. Fixing the bug does not demand a level of rigor not present in the rest of the codebase.
-4. The bug was introduced in the PR (pre-existing bugs should not be flagged).
-5. The author would likely fix the issue if made aware of it.
-6. The bug does not rely on unstated assumptions.
-7. Must identify provably affected code parts (not speculation).
-8. The bug is clearly not intentional.
+---
 
-Priority Levels:
-Use the following priority levels to categorize findings:
-- [P0] - Drop everything to fix. Blocking release/operations
-- [P1] - Urgent. Should be addressed in next cycle
-- [P2] - Normal. To be fixed eventually
-- [P3] - Low. Nice to have
+## CRITICAL INSTRUCTION
 
-Comment Guidelines:
-Your review comments should be:
-1. Clear about why the issue is a bug
-2. Appropriately communicate severity
-3. Brief - at most 1 paragraph
-4. Code chunks max 3 lines, wrapped in markdown
-5. Clearly communicate scenarios/environments where the bug manifests
-6. Matter-of-fact tone without being accusatory
-7. Immediately graspable by the original author
-8. Avoid excessive flattery
+**DO NOT STOP UNTIL YOU HAVE REVIEWED EVERY SINGLE CHANGED FILE IN THE DIFF.**
 
-Output Format:
-Structure each inline comment as:
-**[P0/P1] Clear title (≤ 80 chars, imperative mood)**
+You MUST:
+1. Read the ENTIRE \`${diffPath}\` file first (use offset/limit if needed for large files)
+2. Create a mental checklist of ALL files that were changed
+3. Review EACH file systematically - do not skip any file
+4. Only submit your review AFTER you have analyzed every single changed file
+
+If the diff is large, work through it methodically. Do not rush. Do not skip files. The quality of your review depends on thoroughness.
+
+---
+
+## Objectives
+
+1. Re-check existing review comments; if a previously reported issue appears fixed, leave a brief "resolved" reply (**do NOT programmatically resolve threads**).
+2. Review the PR diff and identify **high-confidence, actionable bugs** introduced by this PR.
+3. Leave concise **inline comments (1-2 sentences)** for qualifying bugs. You may comment on unchanged lines *only* if the PR clearly triggers the issue—explain the trigger path.
+
+---
+
+## Procedure
+
+Follow these phases **in order**. Do not submit findings until Phase 1 and Phase 2 are complete.
+
+---
+
+## Phase 1: Context Gathering (REQUIRED — do not report bugs yet)
+
+1. **Read existing comments** from the pre-computed file:
+   \`Read ${commentsPath}\`
+
+2. **Read the COMPLETE diff** from the pre-computed file:
+   \`Read ${diffPath}\`
+   
+   If the file is large (>2400 lines), read it in chunks using offset/limit parameters.
+   **DO NOT proceed until you have read the ENTIRE diff.**
+
+3. **List all changed files** - After reading the diff, explicitly list every file that was changed. This is your checklist.
+
+4. For **each file in the diff**, gather context:
+
+   * New imports → Grep to confirm the symbol exists
+   * New/modified functions → Grep for callers to understand usage
+   * Data-processing code → Read surrounding code to infer expected types
+
+5. Do **not** identify or report bugs yet. This phase is for understanding only.
+
+---
+
+## Phase 2: Issue Identification (ONLY after Phase 1)
+
+Review **every changed line**. You must complete the review even if you find issues early.
+
+### Analysis discipline
+
+* Verify with Grep/Read before flagging (no speculation)
+* Trace data flow to confirm a **real trigger path**
+* Check whether the pattern exists elsewhere (may be intentional)
+
+### Cross-reference checks
+
+* When reviewing tests, search for related constants, configs, or environment variables
+* Verify test assumptions match production behavior
+  *Example:* if a test sets an env var, Grep where it is consumed to confirm behavior matches prod
+
+### Import verification
+
+* Any import referencing a non-existent symbol is a bug (runtime ImportError)
+
+---
+
+## Systematic Analysis Patterns
+
+Apply these patterns during your review. These target common bug classes:
+
+### Logic & Variable Usage
+
+* When reviewing conditionals, verify the correct variable is referenced in each clause
+* Check for AND vs OR confusion in permission/validation logic (especially security-critical paths)
+* Verify return statements return the intended value:
+  - Not wrapper objects when data is expected (e.g., \`safeParse()\` result vs \`.data\`)
+  - Not intermediate variables when final result is expected
+  - Not wrong object properties (e.g., \`obj.original\` vs \`obj.modified\`)
+* In loops or transformations, confirm variable names match semantic purpose
+* Flag operations where variable names suggest type mismatches (e.g., \`*Time\` used where \`*Date\` expected)
+
+### Null/Undefined Safety
+
+* For each property access chain (\`a.b.c\`), verify none of the intermediate values can be null/undefined/None:
+  - Check API responses that might return null
+  - Check database queries that might return no results
+  - Check array operations like \`array[0]\` or \`array.find()\`
+* When Optional types are unwrapped (\`.get()\`, \`!\`, non-null assertions), verify presence is checked first
+* In conditional branches, verify null handling exists for all code paths
+* Pay special attention to:
+  - Authentication/authorization contexts (user might not be authenticated)
+  - Optional relationships (foreign keys, joined data)
+  - Map/dictionary lookups
+  - Configuration values that might not be set
+
+### Type Compatibility & Data Flow
+
+* Trace what types flow into math operations:
+  - \`floor\`, \`ceil\`, \`round\`, modulo on datetime/string inputs cause errors
+  - Arithmetic operations on mixed types
+* Verify comparison operators match types:
+  - Object reference equality (\`===\`, \`==\`) on different instances always false
+  - Comparing object types when value comparison intended (e.g., dayjs objects)
+* Check function parameters receive expected types after transformations:
+  - Serialization/deserialization boundary crossings
+  - Database field type conversions
+  - API request/response parsing
+* Flag string operations on numbers or vice versa without explicit conversion
+* When data flows through multiple functions, verify type consistency at each step
+
+### Async/Await Patterns (JavaScript/TypeScript)
+
+* **CRITICAL**: Flag \`forEach\`/\`map\`/\`filter\` with async callbacks - these don't await:
+  \`\`\`javascript
+  // BUG: async callbacks are fire-and-forget
+  items.forEach(async (item) => await process(item));
+  
+  // CORRECT: use for...of or Promise.all
+  for (const item of items) await process(item);
+  \`\`\`
+* Verify all async function calls are awaited when their result or side-effect is needed:
+  - Database writes that must complete before continuing
+  - API calls whose responses are used
+  - File operations that affect subsequent code
+* Check promise chains have proper error handling (\`.catch()\` or try/catch)
+* Verify parallel operations use \`Promise.all\`/\`Promise.allSettled\` appropriately
+
+### Security Vulnerabilities
+
+* **SSRF (Server-Side Request Forgery)**:
+  - Flag unvalidated URL fetching: \`open(url)\`, \`fetch(user_input)\`, \`curl\` with user input
+  - Verify URL allowlists exist for external requests
+* **XSS (Cross-Site Scripting)**:
+  - Check for unescaped user input in HTML/template contexts
+  - Verify template engines auto-escape by default
+* **Authentication & Session State**:
+  - OAuth state/nonce must be per-request random, not static or reused
+  - CSRF tokens must be unpredictable and verified
+  - Session data must not leak between requests
+* **Input Validation Bypasses**:
+  - \`indexOf()\`/\`startsWith()\` for origin validation can be bypassed (use exact allowlist matching)
+  - Case sensitivity in security checks (email blacklists, domain checks)
+* **Timing Attacks**:
+  - Secret/token comparison should use constant-time comparison functions
+* **Cache Poisoning**:
+  - Verify security decisions (permissions, auth) aren't cached asymmetrically
+  - If grants are cached, denials must also be cached (or neither)
+
+### Concurrency Issues (when applicable)
+
+* Check if shared state is modified without synchronization:
+  - Global variables or class fields accessed by multiple threads/goroutines
+  - Database records that can be modified concurrently
+* Verify double-checked locking re-checks condition after acquiring lock:
+  \`\`\`go
+  // BUG: doesn't re-check after lock
+  if !initialized {
+      lock.Lock()
+      initialize()
+      lock.Unlock()
+  }
+  
+  // CORRECT: re-check after acquiring lock
+  if !initialized {
+      lock.Lock()
+      if !initialized {
+          initialize()
+      }
+      lock.Unlock()
+  }
+  \`\`\`
+* Flag non-atomic operations on shared counters:
+  - \`count = count + 1\` in concurrent code (use atomic operations)
+  - Read-modify-write without locks
+* Check that resources accessed by multiple threads have proper synchronization
+
+### API Contract & Breaking Changes
+
+* When serializers/validators/response formatters change:
+  - Use Grep to find API consumers and test files
+  - Verify response structure remains compatible (field names, types, nesting)
+  - Check for removed fields, changed types, or new required fields
+* When database models/schemas change:
+  - Verify migrations include data backfill for existing records
+  - Check that existing queries still work with new schema
+* When function signatures change:
+  - Grep for all callers to verify compatibility
+  - Check if return type changes break caller assumptions
+* Review test files for expected API shapes and verify changes match tests
+
+---
+
+## **Reporting Gate (CRITICAL)**
+
+Only report findings that meet **at least one** of the following:
+
+### Reportable bugs
+
+* **Definite runtime failures** (TypeError, KeyError, AttributeError, ImportError)
+* **Incorrect logic** with a clear trigger path and observable wrong result
+* **Security vulnerabilities** with a realistic exploit path
+* **Data corruption or loss**
+* **Breaking contract changes** (API / response / schema / validator behavior) where the contract is discoverable in code, tests, or docs
+
+### Do NOT report
+
+* Test code hygiene (unused vars, setup patterns) unless it causes test failure
+* Defensive "what-if" scenarios without a realistic trigger
+* Cosmetic issues (message text, naming, formatting)
+* Suggestions to "add guards," "add try/catch," or "be safer" without a concrete failure
+
+### Confidence rule
+
+* Prefer **DEFINITE** bugs over **POSSIBLE** bugs
+* Report POSSIBLE bugs **only** if you can identify a realistic execution path
+
+---
+
+## Targeted semantic passes (apply when relevant)
+
+* **API / validator / serializer changes**
+  Explicitly check for response-format or contract breakage
+  *(e.g., changed error response structure, removed or renamed fields, different status codes, altered required keys)*
+
+* **Auth / OAuth / session / state changes**
+  Check null-state handling, per-request randomness (state/nonce), and failure paths
+
+---
+
+## Deduplication
+
+* Never open a new finding for an issue previously reported by this bot on this PR
+* If an issue appears fixed, reply "resolved" in the existing thread
+
+---
+
+## Priority Levels
+
+* [P0] Blocking / crash / exploit
+* [P1] Urgent correctness or security issue
+* [P2] Real bug with limited impact
+* [P3] Minor but real bug
+
+---
+
+## Comment format
+
+Each inline comment must be:
+
+**[P0-P3] Clear imperative title (≤80 chars)**
+
+
 (blank line)
-Explanation of why this is a problem (1 paragraph max).
 
-In the review summary body (submitted via github_pr___submit_review), provide an overall assessment:
-- Whether the changes are correct or incorrect
-- 1-3 sentence overall explanation
+One short paragraph explaining *why* this is a bug and *how* it manifests.
 
-Cross-reference capability:
-- When reviewing tests, search for related constants and configurations (e.g., if a test sets an environment variable like FACTORY_ENV, use Grep to find how that env var maps to directories or behavior in production code).
-- Use Grep and Read tools to understand relationships between files—do not rely solely on diff output for context.
-- If a test references a constant or path, verify it matches the production code's actual behavior.
-- For any suspicious pattern, search the codebase to confirm your understanding before flagging an issue.
+* Max 1 paragraph
+* Code snippets ≤3 lines, Markdown fenced
+* Matter-of-fact, non-accusatory tone
 
-Accuracy gates:
-- Base findings strictly on the current diff and repo context available via gh/MCP; avoid speculation.
-- If confidence is low, phrase a single concise clarifying question instead of asserting a bug.
-- Never raise purely stylistic or preference-only concerns.
+---
 
-Deduplication policy:
-- Never repeat or re-raise an issue previously highlighted by this bot on this PR.
-- Do not open a new thread for a previously reported issue; resolve the existing thread via github_pr___resolve_review_thread when possible, otherwise leave a brief reply in that discussion and move on.
+## Phase 3: Submit Review
 
-Commenting rules:
-- One issue per comment.
-- Anchor findings to the relevant diff hunk so reviewers see the context immediately.
-- Focus on defects introduced or exposed by the PR's changes; if a new bug manifests on an unchanged line, you may post inline comments on those unchanged lines but clearly explain how the submitted changes trigger it.
-- Match the side parameter to the code segment you're referencing (default to RIGHT for new code) and provide line numbers from that same side
-- Keep comments concise and immediately graspable.
-- For low confidence findings, ask a question; for medium/high confidence, state the issue concretely.
-- Only include explicit code suggestions when you are absolutely certain the replacement is correct and safe.
+### When NOT to submit
 
-Output:
-1. Analyze the PR to generate:
-   - A concise 1-2 sentence summary of what the PR does
-   - 3-5 key changes extracted from the diff
-   - The most important files changed (up to 5-7 files)
+* PR is formatting-only
+* You cannot anchor a high-confidence issue to a specific changed line
+* All findings are low-severity (P2/P3)
+* All findings fail the Reporting Gate above
 
-2. Write findings to \`code-review-results.json\` with this structure:
-\`\`\`json
-{
-  "type": "code",
-  "summary": "Brief 1-2 sentence description of what this PR does",
-  "keyChanges": [
-    "Added new authentication flow",
-    "Refactored database queries for performance",
-    "Fixed validation bug in user input"
-  ],
-  "importantFiles": [
-    { "path": "src/auth/login.ts", "description": "New OAuth implementation" },
-    { "path": "src/db/queries.ts", "description": "Query optimization" }
-  ],
-  "findings": [
-    {
-      "id": "CR-001",
-      "type": "bug|issue|suggestion",
-      "severity": "high|medium|low",
-      "file": "path/to/file.ts",
-      "line": 45,
-      "side": "RIGHT",
-      "description": "Brief description of the issue",
-      "suggestion": "Optional code fix"
-    }
-  ]
-}
-\`\`\`
+### Tools & mechanics
 
-3. Update the tracking comment with a summary using \`github_comment___update_droid_comment\`:
-\`\`\`markdown
-## Code review completed
+* Use \`github_inline_comment___create_inline_comment\`
+  * Anchor using **path + side + line**
+  * RIGHT = new/modified code, LEFT = removed code
+  * Line numbers must correspond to the chosen side
+* Use \`github_pr___submit_review\` for the summary
+* Use \`github_pr___delete_comment\` or \`github_pr___minimize_comment\` for outdated "no issues" comments
+* Use \`github_pr___reply_to_comment\` to acknowledge resolved issues
+* **Do NOT call** \`github_pr___resolve_review_thread\`
+* Do **not** approve or request changes
 
-### Summary
-{Brief 1-2 sentence description of what this PR does}
+### "No issues" handling
 
-### Key Changes
-- {Change 1}
-- {Change 2}
-- {Change 3}
+* If no issues and a prior "no issues" comment exists → skip
+* If no issues and no prior comment exists → post a brief summary
+* If issues exist and a prior "no issues" comment exists → delete/minimize it
+* **Do NOT delete** comment ID ${context.droidCommentId}
 
-### Important Files Changed
-- \`path/to/file1.ts\` - {Brief description of changes}
-- \`path/to/file2.ts\` - {Brief description of changes}
+---
 
-### Review Findings
-| ID | Type | Severity | File | Description |
-|----|------|----------|------|-------------|
-| CR-001 | Bug | high | auth.ts:45 | Null pointer exception |
+## Review summary
 
-*Inline comments will be posted after all reviews complete.*
-\`\`\`
+In the submitted review body:
 
-Submission:
-- Do not submit inline comments when:
-  - the PR appears formatting-only, or
-  - all findings are low-severity (P2/P3), or
-  - you cannot anchor a high-confidence issue to a specific changed line.
-- Do not escalate style/formatting into P0/P1 just to justify leaving an inline comment.
-- If no issues are found and a prior "no issues" comment from this bot already exists, skip submitting another comment to avoid redundancy.
-- If no issues are found and no prior "no issues" comment exists, post a single brief top-level summary noting no issues.
-- If issues are found, delete/minimize/supersede any prior "no issues" comment before submitting.
-- Prefer github_inline_comment___create_inline_comment for inline findings and submit the overall review via github_pr___submit_review (fall back to gh api repos/${repoFullName}/pulls/${prNumber}/reviews -f event=COMMENT -f body="$SUMMARY" -f comments='[$COMMENTS_JSON]' when MCP tools are unavailable).
-- Do not approve or request changes; submit a comment-only review with inline feedback.
+* State whether the changes are correct or incorrect
+* Provide a 1-3 sentence overall assessment
 `;
 }

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -1,0 +1,170 @@
+import type { PreparedContext } from "../types";
+
+export function generateReviewValidatorPrompt(context: PreparedContext): string {
+  const prNumber = context.eventData.isPR
+    ? context.eventData.prNumber
+    : context.githubContext && "entityNumber" in context.githubContext
+      ? String(context.githubContext.entityNumber)
+      : "unknown";
+
+  const repoFullName = context.repository;
+  const prHeadRef = context.prBranchData?.headRefName ?? "unknown";
+  const prHeadSha = context.prBranchData?.headRefOid ?? "unknown";
+  const prBaseRef = context.eventData.baseBranch ?? "unknown";
+
+  const diffPath =
+    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
+  const commentsPath =
+    context.reviewArtifacts?.commentsPath ??
+    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
+
+  const reviewCandidatesPath =
+    process.env.REVIEW_CANDIDATES_PATH ??
+    "$RUNNER_TEMP/droid-prompts/review_candidates.json";
+  const reviewValidatedPath =
+    process.env.REVIEW_VALIDATED_PATH ??
+    "$RUNNER_TEMP/droid-prompts/review_validated.json";
+
+  return `You are validating candidate review comments for PR #${prNumber} in ${repoFullName}.
+
+IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
+
+### Context
+
+* Repo: ${repoFullName}
+* PR Number: ${prNumber}
+* PR Head Ref: ${prHeadRef}
+* PR Head SHA: ${prHeadSha}
+* PR Base Ref: ${prBaseRef}
+
+### Inputs
+
+Read:
+* Candidates: \`${reviewCandidatesPath}\`
+* Full PR Diff: \`${diffPath}\`
+* Existing Comments: \`${commentsPath}\`
+
+### Outputs
+
+1) Write validated results to: \`${reviewValidatedPath}\`
+2) Post ONLY the approved inline comments to the PR
+3) Submit a PR review summary (if applicable)
+
+=======================
+
+## CRITICAL REQUIREMENTS
+
+1. You MUST read and validate **every** candidate before posting anything.
+2. For each candidate, confirm:
+   * It is a real, actionable bug (not speculative)
+   * There is a realistic trigger path and observable wrong behavior
+   * The anchor is valid (path + side + line/startLine correspond to the diff)
+3. **Posting rule (STRICT):**
+   * Only post comments where \`status === "approved"\`.
+   * Never post rejected items.
+4. Preserve ordering: keep results in the same order as candidates.
+
+=======================
+
+## Phase 1: Load context (REQUIRED)
+
+1. Read existing comments:
+   Read \`${commentsPath}\`
+
+2. Read the COMPLETE diff:
+   Read \`${diffPath}\`
+   If large, read in chunks (offset/limit). **Do not proceed until you have read the ENTIRE diff.**
+
+3. Read candidates:
+   Read \`${reviewCandidatesPath}\`
+
+=======================
+
+## Phase 2: Validate candidates
+
+Apply the same Reporting Gate as review:
+
+### Approve ONLY if at least one is true
+* Definite runtime failure
+* Incorrect logic with a concrete trigger path and wrong outcome
+* Security vulnerability with realistic exploit
+* Data corruption/loss
+* Breaking contract change (discoverable in code/tests)
+
+Reject if:
+* It's speculative / "might" without a concrete trigger
+* It's stylistic / naming / formatting
+* It's not anchored to a valid changed line
+* It's already reported (dedupe against existing comments)
+
+When rejecting, write a concise reason.
+
+=======================
+
+## Phase 3: Write review_validated.json (REQUIRED)
+
+Write \`${reviewValidatedPath}\` with this schema:
+
+\`\`\`json
+{
+  "version": 1,
+  "meta": {
+    "repo": "owner/repo",
+    "prNumber": 123,
+    "headSha": "<head sha>",
+    "baseRef": "main",
+    "validatedAt": "<ISO timestamp>"
+  },
+  "results": [
+    {
+      "status": "approved",
+      "comment": {
+        "path": "src/index.ts",
+        "body": "[P1] Title\n\n1 paragraph.",
+        "line": 42,
+        "startLine": null,
+        "side": "RIGHT",
+        "commit_id": "<head sha>"
+      }
+    },
+    {
+      "status": "rejected",
+      "candidate": {
+        "path": "src/other.ts",
+        "body": "[P2] ...",
+        "line": 10,
+        "startLine": null,
+        "side": "RIGHT",
+        "commit_id": "<head sha>"
+      },
+      "reason": "Not a real bug because ..."
+    }
+  ],
+  "reviewSummary": {
+    "status": "approved",
+    "body": "1–3 sentence overall assessment"
+  }
+}
+\`\`\`
+
+Notes:
+* Use \`commit_id\` = \`${prHeadSha}\`.
+* \`results\` MUST have exactly one entry per candidate, in the same order.
+
+Then write the file using the local file tool.
+
+Tooling note:
+* If the tools list includes \`ApplyPatch\` (common for OpenAI models like GPT-5.2), use \`ApplyPatch\` to create/update the file at the exact path.
+* Otherwise, use \`Create\` (or \`Edit\` if overwriting) to write the file.
+
+=======================
+
+## Phase 4: Post approved items
+
+After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "approved"\`:
+
+* For each approved entry, call \`github_inline_comment___create_inline_comment\` with the \`comment\` object.
+* Submit a review via \`github_pr___submit_review\` using the summary body (if there are any approved items OR a meaningful overall assessment).
+* Do not approve or request changes.
+`;
+}

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -103,6 +103,11 @@ export type EventData =
   | PullRequestEvent
   | PullRequestTargetEvent;
 
+export type ReviewArtifacts = {
+  diffPath: string;
+  commentsPath: string;
+};
+
 export type PreparedContext = CommonFields & {
   eventData: EventData;
   githubContext?: GitHubContext;
@@ -110,4 +115,5 @@ export type PreparedContext = CommonFields & {
     headRefName: string;
     headRefOid: string;
   };
+  reviewArtifacts?: ReviewArtifacts;
 };

--- a/src/entrypoints/prepare-validator.ts
+++ b/src/entrypoints/prepare-validator.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+
+import * as core from "@actions/core";
+import { setupGitHubToken } from "../github/token";
+import { createOctokit } from "../github/api/client";
+import { parseGitHubContext, isEntityContext } from "../github/context";
+import { prepareReviewValidatorMode } from "../tag/commands/review-validator";
+
+async function run() {
+  try {
+    const context = parseGitHubContext();
+
+    if (!isEntityContext(context) || !context.isPR) {
+      throw new Error("prepare-validator requires a pull request context");
+    }
+
+    // This entrypoint only makes sense when the workflow input is enabled.
+    if ((process.env.REVIEW_USE_VALIDATOR ?? "").trim() !== "true") {
+      throw new Error("reviewUseValidator must be true to run prepare-validator");
+    }
+
+    const githubToken = await setupGitHubToken();
+    const octokit = createOctokit(githubToken);
+
+    const trackingCommentId = Number(process.env.DROID_COMMENT_ID);
+    if (!trackingCommentId || Number.isNaN(trackingCommentId)) {
+      throw new Error("DROID_COMMENT_ID is required for validator run");
+    }
+
+    const result = await prepareReviewValidatorMode({
+      context,
+      octokit,
+      githubToken,
+      trackingCommentId,
+    });
+
+    core.setOutput("github_token", githubToken);
+    if (result?.mcpTools) core.setOutput("mcp_tools", result.mcpTools);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    core.setFailed(`Prepare validator step failed with error: ${errorMessage}`);
+    core.setOutput("prepare_error", errorMessage);
+    process.exit(1);
+  }
+}
+
+export default run;
+
+if (import.meta.main) {
+  run();
+}

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -1,0 +1,222 @@
+import * as core from "@actions/core";
+import type { GitHubContext } from "../../github/context";
+import { isEntityContext } from "../../github/context";
+import type { Octokits } from "../../github/api/client";
+import { fetchPRBranchData } from "../../github/data/pr-fetcher";
+import { createPrompt } from "../../create-prompt";
+import type { ReviewArtifacts } from "../../create-prompt";
+import { prepareMcpTools } from "../../mcp/install-mcp-server";
+import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
+import type { PrepareResult } from "../../prepare/types";
+import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
+import { execSync } from "child_process";
+import { mkdir, writeFile } from "fs/promises";
+
+const DIFF_MAX_BUFFER = 50 * 1024 * 1024;
+
+async function computeAndStoreDiff(
+  baseRef: string,
+  tempDir: string,
+): Promise<string> {
+  const promptsDir = `${tempDir}/droid-prompts`;
+  await mkdir(promptsDir, { recursive: true });
+
+  try {
+    execSync("git fetch --unshallow", { encoding: "utf8", stdio: "pipe" });
+    console.log("Unshallowed repository");
+  } catch {
+    console.log("Repository already has full history");
+  }
+
+  try {
+    execSync(`git fetch origin ${baseRef}:refs/remotes/origin/${baseRef}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    console.log(`Fetched base branch: ${baseRef}`);
+  } catch (e) {
+    console.error(`Failed to fetch base branch ${baseRef}: ${e}`);
+    throw new Error(`Failed to fetch base branch ${baseRef} for review`);
+  }
+
+  const mergeBase = execSync(`git merge-base HEAD origin/${baseRef}`, {
+    encoding: "utf8",
+    stdio: "pipe",
+  }).trim();
+
+  const diff = execSync(`git --no-pager diff ${mergeBase}..HEAD`, {
+    encoding: "utf8",
+    stdio: "pipe",
+    maxBuffer: DIFF_MAX_BUFFER,
+  });
+
+  const diffPath = `${promptsDir}/pr.diff`;
+  await writeFile(diffPath, diff);
+  console.log(`Stored PR diff (${diff.length} bytes) at ${diffPath}`);
+
+  return diffPath;
+}
+
+async function fetchAndStoreComments(
+  octokit: Octokits,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  tempDir: string,
+): Promise<string> {
+  const promptsDir = `${tempDir}/droid-prompts`;
+  await mkdir(promptsDir, { recursive: true });
+
+  const [issueComments, reviewComments] = await Promise.all([
+    octokit.rest.issues.listComments({ owner, repo, issue_number: prNumber }),
+    octokit.rest.pulls.listReviewComments({ owner, repo, pull_number: prNumber }),
+  ]);
+
+  const commentsPath = `${promptsDir}/existing_comments.json`;
+  const payload = {
+    issueComments: issueComments.data,
+    reviewComments: reviewComments.data,
+  };
+  await writeFile(commentsPath, JSON.stringify(payload, null, 2));
+  console.log(
+    `Stored existing comments (${issueComments.data.length} issue, ${reviewComments.data.length} review) at ${commentsPath}`,
+  );
+
+  return commentsPath;
+}
+
+export async function prepareReviewValidatorMode({
+  context,
+  octokit,
+  githubToken,
+  trackingCommentId,
+}: {
+  context: GitHubContext;
+  octokit: Octokits;
+  githubToken: string;
+  trackingCommentId: number;
+}): Promise<PrepareResult> {
+  if (!isEntityContext(context) || !context.isPR) {
+    throw new Error("review validator mode requires pull request context");
+  }
+
+  const prData = await fetchPRBranchData({
+    octokits: octokit,
+    repository: { owner: context.repository.owner, repo: context.repository.repo },
+    prNumber: context.entityNumber,
+  });
+
+  const tempDir = process.env.RUNNER_TEMP || "/tmp";
+
+  // Ensure PR branch is checked out (same as review mode)
+  try {
+    execSync("git reset --hard HEAD", { encoding: "utf8", stdio: "pipe" } as any);
+    execSync(`gh pr checkout ${context.entityNumber}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+      env: { ...process.env, GH_TOKEN: githubToken },
+    });
+    console.log(
+      `Successfully checked out PR branch: ${execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" } as any).trim()}`,
+    );
+  } catch (e) {
+    console.error(`Failed to checkout PR branch: ${e}`);
+    throw new Error(`Failed to checkout PR #${context.entityNumber} branch for review`);
+  }
+
+  const [diffPath, commentsPath] = await Promise.all([
+    computeAndStoreDiff(prData.baseRefName, tempDir),
+    fetchAndStoreComments(
+      octokit,
+      context.repository.owner,
+      context.repository.repo,
+      context.entityNumber,
+      tempDir,
+    ),
+  ]);
+
+  const reviewArtifacts: ReviewArtifacts = { diffPath, commentsPath };
+
+  await createPrompt({
+    githubContext: context,
+    commentId: trackingCommentId,
+    baseBranch: prData.baseRefName,
+    droidBranch: prData.headRefName,
+    prBranchData: {
+      headRefName: prData.headRefName,
+      headRefOid: prData.headRefOid,
+    },
+    generatePrompt: generateReviewValidatorPrompt,
+    reviewArtifacts,
+  });
+
+  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
+
+  const rawUserArgs = process.env.DROID_ARGS || "";
+  const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
+  const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
+    (tool) => tool.startsWith("github_") && tool.includes("___"),
+  );
+
+  const baseTools = [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Execute",
+    "ApplyPatch",
+    "Create",
+    "Edit",
+    "github_comment___update_droid_comment",
+    "github_inline_comment___create_inline_comment",
+  ];
+
+  const validatorTools = ["github_pr___submit_review"];
+
+  const allowedTools = Array.from(
+    new Set([...baseTools, ...validatorTools, ...userAllowedMCPTools]),
+  );
+
+  const mcpTools = await prepareMcpTools({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    droidCommentId: trackingCommentId.toString(),
+    allowedTools,
+    mode: "tag",
+    context,
+  });
+
+  const droidArgParts: string[] = [];
+  droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+
+  const reviewModel = process.env.REVIEW_MODEL?.trim();
+  const reasoningEffort = process.env.REASONING_EFFORT?.trim();
+
+  if (!reviewModel && !reasoningEffort) {
+    droidArgParts.push(`--model "gpt-5.2"`);
+    droidArgParts.push(`--reasoning-effort "high"`);
+  } else {
+    if (reviewModel) droidArgParts.push(`--model "${reviewModel}"`);
+    if (reasoningEffort) droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
+  }
+
+  if (normalizedUserArgs) {
+    droidArgParts.push(normalizedUserArgs);
+  }
+
+  core.setOutput("droid_args", droidArgParts.join(" ").trim());
+  core.setOutput("mcp_tools", mcpTools);
+  core.setOutput("review_pr_number", context.entityNumber.toString());
+  core.setOutput("droid_comment_id", trackingCommentId.toString());
+
+  return {
+    commentId: trackingCommentId,
+    branchInfo: {
+      baseBranch: prData.baseRefName,
+      droidBranch: prData.headRefName,
+      currentBranch: prData.headRefName,
+    },
+    mcpTools,
+  };
+}

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -1,14 +1,102 @@
 import * as core from "@actions/core";
+import { execSync } from "child_process";
+import { writeFile, mkdir } from "fs/promises";
 import type { GitHubContext } from "../../github/context";
 import { fetchPRBranchData } from "../../github/data/pr-fetcher";
 import { createPrompt } from "../../create-prompt";
+import type { ReviewArtifacts } from "../../create-prompt";
 import { prepareMcpTools } from "../../mcp/install-mcp-server";
 import { createInitialComment } from "../../github/operations/comments/create-initial";
 import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import { isEntityContext } from "../../github/context";
 import { generateReviewPrompt } from "../../create-prompt/templates/review-prompt";
+import { generateReviewCandidatesPrompt } from "../../create-prompt/templates/review-candidates-prompt";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
+
+const DIFF_MAX_BUFFER = 50 * 1024 * 1024; // 50MB buffer for large diffs
+
+async function computeAndStoreDiff(
+  baseRef: string,
+  tempDir: string,
+): Promise<string> {
+  const promptsDir = `${tempDir}/droid-prompts`;
+  await mkdir(promptsDir, { recursive: true });
+
+  // Unshallow the repo if it's a shallow clone (needed for merge-base to work)
+  try {
+    execSync("git fetch --unshallow", { encoding: "utf8", stdio: "pipe" });
+    console.log("Unshallowed repository");
+  } catch (e) {
+    // Already unshallowed or not a shallow clone, continue
+    console.log("Repository already has full history");
+  }
+
+  // Fetch the base branch (it may not exist locally yet)
+  try {
+    execSync(
+      `git fetch origin ${baseRef}:refs/remotes/origin/${baseRef}`,
+      { encoding: "utf8", stdio: "pipe" },
+    );
+    console.log(`Fetched base branch: ${baseRef}`);
+  } catch (e) {
+    // Branch might already exist, continue
+    console.log(`Base branch fetch skipped (may already exist): ${baseRef}`);
+  }
+
+  const mergeBase = execSync(
+    `git merge-base HEAD refs/remotes/origin/${baseRef}`,
+    { encoding: "utf8" },
+  ).trim();
+
+  const diff = execSync(`git --no-pager diff ${mergeBase}..HEAD`, {
+    encoding: "utf8",
+    maxBuffer: DIFF_MAX_BUFFER,
+  });
+
+  const diffPath = `${promptsDir}/pr.diff`;
+  await writeFile(diffPath, diff);
+  console.log(`Stored PR diff (${diff.length} bytes) at ${diffPath}`);
+  return diffPath;
+}
+
+async function fetchAndStoreComments(
+  octokit: Octokits,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  tempDir: string,
+): Promise<string> {
+  const promptsDir = `${tempDir}/droid-prompts`;
+  await mkdir(promptsDir, { recursive: true });
+
+  const [issueComments, reviewComments] = await Promise.all([
+    octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    }),
+    octokit.rest.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100,
+    }),
+  ]);
+
+  const comments = {
+    issueComments: issueComments.data,
+    reviewComments: reviewComments.data,
+  };
+
+  const commentsPath = `${promptsDir}/existing_comments.json`;
+  await writeFile(commentsPath, JSON.stringify(comments, null, 2));
+  console.log(
+    `Stored existing comments (${issueComments.data.length} issue, ${reviewComments.data.length} review) at ${commentsPath}`,
+  );
+  return commentsPath;
+}
 
 type ReviewCommandOptions = {
   context: GitHubContext;
@@ -46,6 +134,49 @@ export async function prepareReviewMode({
     currentBranch: prData.headRefName,
   };
 
+  // Checkout the PR branch before computing diff
+  // This ensures HEAD points to the PR head commit, not the merge commit or default branch
+  console.log(
+    `Checking out PR #${context.entityNumber} branch for diff computation...`,
+  );
+  try {
+    execSync("git reset --hard HEAD", { encoding: "utf8", stdio: "pipe" });
+    execSync(`gh pr checkout ${context.entityNumber}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+      env: { ...process.env, GH_TOKEN: githubToken },
+    });
+    console.log(
+      `Successfully checked out PR branch: ${execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim()}`,
+    );
+  } catch (e) {
+    console.error(`Failed to checkout PR branch: ${e}`);
+    throw new Error(
+      `Failed to checkout PR #${context.entityNumber} branch for review`,
+    );
+  }
+
+  // Pre-compute review artifacts (diff and existing comments)
+  const tempDir = process.env.RUNNER_TEMP || "/tmp";
+  const [diffPath, commentsPath] = await Promise.all([
+    computeAndStoreDiff(prData.baseRefName, tempDir),
+    fetchAndStoreComments(
+      octokit,
+      context.repository.owner,
+      context.repository.repo,
+      context.entityNumber,
+      tempDir,
+    ),
+  ]);
+
+  const reviewArtifacts: ReviewArtifacts = {
+    diffPath,
+    commentsPath,
+  };
+
+  const reviewUseValidator =
+    (process.env.REVIEW_USE_VALIDATOR ?? "").trim() === "true";
+
   await createPrompt({
     githubContext: context,
     commentId,
@@ -55,7 +186,10 @@ export async function prepareReviewMode({
       headRefName: prData.headRefName,
       headRefOid: prData.headRefOid,
     },
-    generatePrompt: generateReviewPrompt,
+    generatePrompt: reviewUseValidator
+      ? generateReviewCandidatesPrompt
+      : generateReviewPrompt,
+    reviewArtifacts,
   });
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
 
@@ -71,21 +205,42 @@ export async function prepareReviewMode({
     "Glob",
     "LS",
     "Execute",
+    "Create",
+    "ApplyPatch",
     "github_comment___update_droid_comment",
-    "github_inline_comment___create_inline_comment",
   ];
 
-  const reviewTools = [
-    "github_pr___list_review_comments",
-    "github_pr___submit_review",
-    "github_pr___delete_comment",
-    "github_pr___minimize_comment",
-    "github_pr___reply_to_comment",
-    "github_pr___resolve_review_thread",
-  ];
+  // Task tool is needed for parallel subagent reviews in candidate generation phase
+  const candidateGenerationTools = reviewUseValidator ? ["Task"] : [];
+
+  const reviewTools = reviewUseValidator
+    ? []
+    : [
+        "github_inline_comment___create_inline_comment",
+        "github_pr___list_review_comments",
+        "github_pr___submit_review",
+        "github_pr___delete_comment",
+        "github_pr___minimize_comment",
+        "github_pr___reply_to_comment",
+        "github_pr___resolve_review_thread",
+      ];
+
+  const safeUserAllowedMCPTools = reviewUseValidator
+    ? userAllowedMCPTools.filter(
+        (tool) =>
+          tool === "github_comment___update_droid_comment" ||
+          (!tool.startsWith("github_pr___") &&
+            tool !== "github_inline_comment___create_inline_comment"),
+      )
+    : userAllowedMCPTools;
 
   const allowedTools = Array.from(
-    new Set([...baseTools, ...reviewTools, ...userAllowedMCPTools]),
+    new Set([
+      ...baseTools,
+      ...candidateGenerationTools,
+      ...reviewTools,
+      ...safeUserAllowedMCPTools,
+    ]),
   );
 
   const mcpTools = await prepareMcpTools({

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -27,75 +27,81 @@ describe("generateReviewPrompt", () => {
 
     const prompt = generateReviewPrompt(context);
 
-    expect(prompt).toContain("Objectives:");
+    expect(prompt).toContain("## Objectives");
     expect(prompt).toContain("Re-check existing review comments");
-    expect(prompt).toContain("Review the PR diff");
-    expect(prompt).toContain("git merge-base");
-    expect(prompt).toContain("git diff");
-    expect(prompt).toContain("gh pr diff 42 --repo test-owner/test-repo");
-    expect(prompt).toContain(
-      "gh api repos/test-owner/test-repo/pulls/42/files",
-    );
     expect(prompt).toContain("github_inline_comment___create_inline_comment");
-    expect(prompt).toContain("every substantive comment must be inline");
-    expect(prompt).toContain("Thread resolution rule (CRITICAL)");
-    expect(prompt).toContain("NEVER resolve review threads");
+    expect(prompt).toContain(
+      "**Do NOT call** `github_pr___resolve_review_thread`",
+    );
+  });
+
+  it("includes pre-computed artifact references when provided", () => {
+    const context = createBaseContext({
+      reviewArtifacts: {
+        diffPath: "/tmp/test/pr.diff",
+        commentsPath: "/tmp/test/existing_comments.json",
+      },
+    });
+
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).toContain("### Pre-computed Review Artifacts");
+    expect(prompt).toContain("/tmp/test/pr.diff");
+    expect(prompt).toContain("/tmp/test/existing_comments.json");
+    expect(prompt).toContain("COMPLETE diff");
+  });
+
+  it("includes critical instruction to review all files", () => {
+    const context = createBaseContext();
+
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).toContain("## CRITICAL INSTRUCTION");
+    expect(prompt).toContain(
+      "DO NOT STOP UNTIL YOU HAVE REVIEWED EVERY SINGLE CHANGED FILE",
+    );
+    expect(prompt).toContain("Review EACH file systematically");
+  });
+
+  it("instructs to read from pre-computed files in Phase 1", () => {
+    const context = createBaseContext({
+      reviewArtifacts: {
+        diffPath: "/tmp/droid/pr.diff",
+        commentsPath: "/tmp/droid/comments.json",
+      },
+    });
+
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).toContain(
+      "Read existing comments** from the pre-computed file",
+    );
+    expect(prompt).toContain("Read /tmp/droid/comments.json");
+    expect(prompt).toContain(
+      "Read the COMPLETE diff** from the pre-computed file",
+    );
+    expect(prompt).toContain("Read /tmp/droid/pr.diff");
   });
 
   it("emphasizes accuracy gates and bug detection guidelines", () => {
     const prompt = generateReviewPrompt(createBaseContext());
 
-    expect(prompt).toContain("How Many Findings to Return:");
-    expect(prompt).toContain(
-      "Output all findings that the original author would fix",
-    );
-    expect(prompt).toContain("Key Guidelines for Bug Detection:");
-    expect(prompt).toContain("Priority Levels:");
+    expect(prompt).toContain("## Priority Levels");
     expect(prompt).toContain("[P0]");
-    expect(prompt).toContain("Do not escalate style/formatting into P0/P1");
-    expect(prompt).toContain("Never raise purely stylistic");
     expect(prompt).toContain(
-      "Never repeat or re-raise an issue previously highlighted",
+      "Never open a new finding for an issue previously reported by this bot",
     );
-  });
-
-  it("describes MCP tools and diff side selection", () => {
-    const prompt = generateReviewPrompt(createBaseContext());
-
-    expect(prompt).toContain("Preferred MCP tools");
-    expect(prompt).toContain("github_inline_comment___create_inline_comment");
-    expect(prompt).toContain("github_pr___submit_review");
-    expect(prompt).toContain("github_pr___delete_comment");
-    expect(prompt).toContain("github_pr___resolve_review_thread");
-    expect(prompt).toContain("Diff Side Selection (CRITICAL)");
-    expect(prompt).toContain('side="RIGHT"');
-    expect(prompt).toContain('side="LEFT"');
-  });
-
-  it("describes JSON output format with summary", () => {
-    const prompt = generateReviewPrompt(createBaseContext());
-
-    expect(prompt).toContain("code-review-results.json");
-    expect(prompt).toContain("github_comment___update_droid_comment");
-    expect(prompt).toContain(
-      "Inline comments will be posted after all reviews complete",
-    );
-    expect(prompt).toContain("### Summary");
-    expect(prompt).toContain("### Key Changes");
-    expect(prompt).toContain("### Important Files Changed");
-    expect(prompt).toContain("### Review Findings");
   });
 
   it("describes submission guidance", () => {
     const prompt = generateReviewPrompt(createBaseContext());
 
-    expect(prompt).toContain("Submission:");
-    expect(prompt).toContain("Do not submit inline comments when");
-    expect(prompt).toContain("all findings are low-severity (P2/P3)");
     expect(prompt).toContain(
-      "gh api repos/test-owner/test-repo/pulls/42/reviews",
+      "Use `github_inline_comment___create_inline_comment`",
     );
-    expect(prompt).toContain("Do not approve or request changes");
-    expect(prompt).toContain("submit a comment-only review");
+    expect(prompt).toContain("Do **not** approve or request changes");
+    expect(prompt).toContain("github_pr___submit_review");
+    expect(prompt).toContain("### When NOT to submit");
+    expect(prompt).toContain("All findings are low-severity (P2/P3)");
   });
 });

--- a/test/entrypoints/prepare-validator.test.ts
+++ b/test/entrypoints/prepare-validator.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import * as core from "@actions/core";
+import * as token from "../../src/github/token";
+import * as client from "../../src/github/api/client";
+import * as contextMod from "../../src/github/context";
+import * as validator from "../../src/tag/commands/review-validator";
+
+describe("prepare-validator entrypoint", () => {
+  it("fails when reviewUseValidator is false", async () => {
+    const setFailedSpy = spyOn(core, "setFailed").mockImplementation(() => {});
+    const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as any);
+
+    spyOn(contextMod, "parseGitHubContext").mockReturnValue({
+      eventName: "issue_comment",
+      runId: "1",
+      repository: { owner: "o", repo: "r", full_name: "o/r" },
+      actor: "a",
+      inputs: {
+        triggerPhrase: "@droid",
+        assigneeTrigger: "",
+        labelTrigger: "droid",
+        useStickyComment: false,
+        allowedBots: "",
+        allowedNonWriteUsers: "",
+        trackProgress: false,
+        automaticReview: false,
+      },
+      payload: {} as any,
+      entityNumber: 1,
+      isPR: true,
+    } as any);
+
+    process.env.REVIEW_USE_VALIDATOR = "false";
+    process.env.DROID_COMMENT_ID = "123";
+
+    spyOn(token, "setupGitHubToken").mockResolvedValue("token");
+    spyOn(client, "createOctokit").mockReturnValue({} as any);
+    spyOn(validator, "prepareReviewValidatorMode").mockResolvedValue({
+      commentId: 123,
+      branchInfo: { baseBranch: "main", droidBranch: "feat" },
+      mcpTools: "{}",
+    } as any);
+
+    const mod = await import(
+      `../../src/entrypoints/prepare-validator.ts?test=${Math.random()}`,
+    );
+
+    await expect(mod.default()).rejects.toBeTruthy();
+
+    expect(setFailedSpy).toHaveBeenCalled();
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "prepare_error",
+      expect.stringContaining("reviewUseValidator"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    setFailedSpy.mockRestore();
+    setOutputSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -9,6 +9,7 @@ import * as mcpInstaller from "../../src/mcp/install-mcp-server";
 import * as actorValidation from "../../src/github/validation/actor";
 import * as promptModule from "../../src/create-prompt";
 import * as core from "@actions/core";
+import * as childProcess from "node:child_process";
 
 describe("review command integration", () => {
   const originalRunnerTemp = process.env.RUNNER_TEMP;
@@ -21,6 +22,7 @@ describe("review command integration", () => {
   let setOutputSpy: ReturnType<typeof spyOn>;
   let exportVarSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
+  let execSyncSpy: ReturnType<typeof spyOn>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "review-int-"));
@@ -37,6 +39,16 @@ describe("review command integration", () => {
     promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
     setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
     exportVarSpy = spyOn(core, "exportVariable").mockImplementation(() => {});
+
+    execSyncSpy = spyOn(childProcess, "execSync").mockImplementation(
+      ((cmd: string) => {
+        if (cmd.includes("merge-base")) return "abc123def456\n";
+        if (cmd.includes("git --no-pager diff")) {
+          return "diff --git a/file.ts b/file.ts\n+added line\n";
+        }
+        return "";
+      }) as typeof childProcess.execSync,
+    );
   });
 
   afterEach(async () => {
@@ -47,6 +59,7 @@ describe("review command integration", () => {
     promptSpy.mockRestore();
     setOutputSpy.mockRestore();
     exportVarSpy.mockRestore();
+    execSyncSpy.mockRestore();
 
     if (process.env.RUNNER_TEMP) {
       await rm(process.env.RUNNER_TEMP, { recursive: true, force: true });
@@ -90,18 +103,24 @@ describe("review command integration", () => {
       } as any,
     });
 
-    const octokit = {
-      rest: {},
-      graphql: () =>
-        Promise.resolve({
-          repository: {
-            pullRequest: {
-              baseRefName: "main",
-              headRefName: "feature/review",
-              headRefOid: "def456",
-            },
-          },
-        }),
+    const octokit = { 
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve({ data: [] }),
+        },
+        pulls: {
+          listReviewComments: () => Promise.resolve({ data: [] }),
+        },
+      }, 
+      graphql: () => Promise.resolve({
+        repository: {
+          pullRequest: {
+            baseRefName: "main",
+            headRefName: "feature/review",
+            headRefOid: "def456",
+          }
+        }
+      })
     } as any;
 
     graphqlSpy = spyOn(octokit, "graphql").mockResolvedValue({

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -6,6 +6,8 @@ import { createMockContext } from "../../mockContext";
 import * as promptModule from "../../../src/create-prompt";
 import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
 import * as comments from "../../../src/github/operations/comments/create-initial";
+import * as childProcess from "child_process";
+import * as fsPromises from "fs/promises";
 
 const MOCK_PR_DATA = {
   title: "PR for review",
@@ -27,16 +29,21 @@ const MOCK_PR_DATA = {
 describe("prepareReviewMode", () => {
   const originalArgs = process.env.DROID_ARGS;
   const originalReviewModel = process.env.REVIEW_MODEL;
+  const originalRunnerTemp = process.env.RUNNER_TEMP;
   let graphqlSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
   let mcpSpy: ReturnType<typeof spyOn>;
   let setOutputSpy: ReturnType<typeof spyOn>;
   let createInitialSpy: ReturnType<typeof spyOn>;
   let exportVariableSpy: ReturnType<typeof spyOn>;
+  let execSyncSpy: ReturnType<typeof spyOn>;
+  let writeFileSpy: ReturnType<typeof spyOn>;
+  let mkdirSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     process.env.DROID_ARGS = "";
     delete process.env.REVIEW_MODEL;
+    process.env.RUNNER_TEMP = "/tmp/test-runner";
 
     promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
     mcpSpy = spyOn(mcpInstaller, "prepareMcpTools").mockResolvedValue(
@@ -50,6 +57,21 @@ describe("prepareReviewMode", () => {
     exportVariableSpy = spyOn(core, "exportVariable").mockImplementation(
       () => {},
     );
+    // Mock execSync for git commands
+    execSyncSpy = spyOn(childProcess, "execSync").mockImplementation(
+      ((cmd: string) => {
+        if (cmd.includes("merge-base")) {
+          return "abc123def456\n";
+        }
+        if (cmd.includes("diff")) {
+          return "diff --git a/file.ts b/file.ts\n+added line\n";
+        }
+        return "";
+      }) as typeof childProcess.execSync,
+    );
+    // Mock file system operations
+    writeFileSpy = spyOn(fsPromises, "writeFile").mockResolvedValue();
+    mkdirSpy = spyOn(fsPromises, "mkdir").mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -59,11 +81,19 @@ describe("prepareReviewMode", () => {
     setOutputSpy.mockRestore();
     createInitialSpy.mockRestore();
     exportVariableSpy.mockRestore();
+    execSyncSpy.mockRestore();
+    writeFileSpy.mockRestore();
+    mkdirSpy.mockRestore();
     process.env.DROID_ARGS = originalArgs;
     if (originalReviewModel !== undefined) {
       process.env.REVIEW_MODEL = originalReviewModel;
     } else {
       delete process.env.REVIEW_MODEL;
+    }
+    if (originalRunnerTemp !== undefined) {
+      process.env.RUNNER_TEMP = originalRunnerTemp;
+    } else {
+      delete process.env.RUNNER_TEMP;
     }
   });
 
@@ -81,7 +111,14 @@ describe("prepareReviewMode", () => {
     });
 
     const octokit = {
-      rest: {},
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve({ data: [] }),
+        },
+        pulls: {
+          listReviewComments: () => Promise.resolve({ data: [] }),
+        },
+      },
       graphql: () =>
         Promise.resolve({
           repository: {
@@ -166,7 +203,14 @@ describe("prepareReviewMode", () => {
     });
 
     const octokit = {
-      rest: {},
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve({ data: [] }),
+        },
+        pulls: {
+          listReviewComments: () => Promise.resolve({ data: [] }),
+        },
+      },
       graphql: () =>
         Promise.resolve({
           repository: {
@@ -227,7 +271,14 @@ describe("prepareReviewMode", () => {
     });
 
     const octokit = {
-      rest: {},
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve({ data: [] }),
+        },
+        pulls: {
+          listReviewComments: () => Promise.resolve({ data: [] }),
+        },
+      },
       graphql: () =>
         Promise.resolve({
           repository: {
@@ -282,7 +333,14 @@ describe("prepareReviewMode", () => {
     });
 
     const octokit = {
-      rest: {},
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve({ data: [] }),
+        },
+        pulls: {
+          listReviewComments: () => Promise.resolve({ data: [] }),
+        },
+      },
       graphql: () =>
         Promise.resolve({
           repository: {
@@ -315,7 +373,7 @@ describe("prepareReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    // When neither REVIEW_MODEL nor REASONING_EFFORT is provided, we default to gpt-5.2 at high reasoning.
+    // When neither REVIEW_MODEL nor REASONING_EFFORT is provided, we default to gpt-5.2 at xhigh reasoning.
     expect(droidArgsCall?.[1]).toContain('--model "gpt-5.2"');
     expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });


### PR DESCRIPTION
## Summary

This PR introduces a **two-pass review validator architecture** for the Droid code review system. Instead of a single Droid Exec pass that reviews and posts comments directly, the review now optionally runs in two phases:

1. **Pass 1 (Candidate Generation):** Droid reviews the PR diff using parallel sub-agents (one per file group), generates candidate review comments, and writes them to a JSON file -- without posting anything to GitHub.
2. **Pass 2 (Validation):** A second Droid Exec run reads the candidate comments, validates each one against the actual code, filters out false positives, and only then posts the approved comments to GitHub.

---

### Architecture

```
PR event → prepare.ts → review.ts (pre-computes diff + comments to files)
  ├─ If validator enabled: generates candidates prompt → Droid Pass 1 (parallel sub-agents) → candidates.json
  │   → prepare-validator.ts → validator prompt → Droid Pass 2 → validates & posts comments
  └─ If validator disabled: generates direct review prompt → Droid single pass → posts comments
```

The validator is enabled by default (`review_use_validator: "true"`).

---

### Pass 1: Candidate Generation (Detail)

The candidate generation step is orchestrated by the prompt in `review-candidates-prompt.ts`. It works in three phases:

**Phase 1 -- Triage:** The main review agent reads the full PR diff from a pre-computed file (`pr.diff`) and groups modified files into 3-6 logical clusters based on:
- **Related functionality** -- files in the same module or feature area
- **File relationships** -- a component and its tests, a class and its interface
- **Risk profile** -- security-sensitive files together, DB/migration files together
- **Dependencies** -- files that import each other or share types

**Phase 2 -- Parallel Review:** Each file group is reviewed independently by spawning a `file-group-reviewer` sub-agent via the `Task` tool. All sub-agents are spawned in a single response for parallel execution. Each sub-agent:
- Receives the PR context (repo, PR number, base/head refs), its assigned file list, and the relevant diff sections
- Reads each assigned file in full, plus related files (imports, interfaces, callers, tests) for context
- Analyzes changes against a defined set of high-signal bug patterns (null dereferences, resource leaks, injection vulnerabilities, concurrency hazards, type-assumption bugs, etc.)
- Returns a JSON array of findings with priority tags (P0/P1/P2), file path, line numbers, and explanation
- Has access only to read-only tools: `Read`, `Grep`, `Glob`, `LS`

**Phase 3 -- Aggregation:** After all sub-agents complete, the main agent merges all result arrays, adds `commit_id` to each comment, deduplicates (same path+line, keeping highest priority), filters out issues already present in existing PR comments, synthesizes a 1-3 sentence review summary, and writes everything to `review_candidates.json` in a structured schema.

Pass 1 is explicitly forbidden from posting anything to GitHub or invoking any PR mutation tools.

---

### Pass 2: Validation (Detail)

The validator runs as a separate Droid Exec invocation, orchestrated by `prepare-validator.ts` and prompted by `review-validator-prompt.ts`. For each candidate comment from Pass 1, the validator:

1. Re-reads the actual source code at the referenced file and line
2. Checks whether the issue is real: Does the code actually have the described problem? Is the line number correct? Is this a genuine bug vs. a false positive or stylistic nitpick? Does it duplicate an existing comment?
3. Assigns a confidence assessment to each candidate
4. Filters out comments that fail validation (false positives, low-confidence, duplicates)
5. Posts only the surviving validated comments to GitHub as inline review comments via MCP tools

The validator also writes its results to `review_validated.json` for artifact upload and debugging. The key architectural benefit is separation of concerns: Pass 1 optimizes for **recall** (find everything), Pass 2 optimizes for **precision** (filter out noise).

---

### Key Changes

**New files:**
- **`.factory/droids/file-group-reviewer.md`** -- Custom droid definition for parallel sub-agent file review
- **`src/create-prompt/templates/review-candidates-prompt.ts`** -- Prompt template for Pass 1
- **`src/create-prompt/templates/review-validator-prompt.ts`** -- Prompt template for Pass 2
- **`src/entrypoints/prepare-validator.ts`** -- Entrypoint that prepares the validator pass
- **`src/tag/commands/review-validator.ts`** -- Command module for the validator pass

**Modified files:**
- **`action.yml`** -- Adds `review_use_validator`, `review_candidates_path`, `review_validated_path` inputs; adds "Setup Custom Droids", "Prepare validator", and "Run Droid Exec (validator)" steps; updates `DROID_SUCCESS` logic; removes "Revoke app token" step
- **`src/create-prompt/index.ts`** -- Adds `ReviewArtifacts` type support and `ApplyPatch` to base allowed tools
- **`src/create-prompt/types.ts`** -- Adds `ReviewArtifacts` type
- **`src/create-prompt/templates/review-prompt.ts`** -- Major rewrite to use pre-computed diff/comments files and more detailed review guidelines
- **`src/tag/commands/review.ts`** -- Refactored to pre-compute diff/comments, conditionally use candidates vs. direct review prompt

**Test updates:**
- **`test/create-prompt/templates/review-prompt.test.ts`** -- Updated for new prompt format
- **`test/entrypoints/prepare-validator.test.ts`** -- New test suite for validator entrypoint
- **`test/integration/review-flow.test.ts`** -- Updated integration test
- **`test/modes/tag/review-command.test.ts`** -- Updated for refactored review command
- **`base-action/test/run-droid-mcp.test.ts`** -- Adds `execSync` mock