### PR TITLE
feat: update tracking comment after review completes

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -54,13 +54,22 @@ jobs:
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}
           output_file: ${{ runner.temp }}/code-review-results.json
 
+      - name: Collect .factory debug files
+        if: always()
+        shell: bash
+        run: |
+          if [ -d "$HOME/.factory" ]; then
+            mkdir -p "${{ runner.temp }}/droid-debug/.factory"
+            cp -r "$HOME/.factory/." "${{ runner.temp }}/droid-debug/.factory/"
+          fi
+
       - name: Upload debug artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: droid-review-debug-${{ github.run_id }}
           path: |
-            ~/.factory/**
+            ${{ runner.temp }}/droid-debug/.factory/**
             ${{ runner.temp }}/droid-prompts/**
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -59,8 +59,7 @@ jobs:
         shell: bash
         run: |
           if [ -d "$HOME/.factory" ]; then
-            mkdir -p "${{ runner.temp }}/droid-debug/.factory"
-            cp -r "$HOME/.factory/." "${{ runner.temp }}/droid-debug/.factory/"
+            cp -r "$HOME/.factory" "${{ runner.temp }}/.factory"
           fi
 
       - name: Upload debug artifacts
@@ -69,7 +68,8 @@ jobs:
         with:
           name: droid-review-debug-${{ github.run_id }}
           path: |
-            ${{ runner.temp }}/droid-debug/.factory/**
+            ${{ runner.temp }}/.factory/**
             ${{ runner.temp }}/droid-prompts/**
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Prepare
         id: prepare
-        uses: Factory-AI/droid-action/prepare@vn/bug-fixes
+        uses: Factory-AI/droid-action/prepare@vn/update-tracking-comment
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Code Review
-        uses: Factory-AI/droid-action/review@vn/bug-fixes
+        uses: Factory-AI/droid-action/review@vn/update-tracking-comment
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           tracking_comment_id: ${{ needs.prepare.outputs.comment_id }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -36,6 +36,6 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@vn/bug-fixes
+        uses: Factory-AI/droid-action@vn/update-tracking-comment
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -395,13 +395,22 @@ runs:
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
 
+    - name: Collect .factory debug files
+      if: always() && steps.prepare.outputs.contains_trigger == 'true'
+      shell: bash
+      run: |
+        if [ -d "$HOME/.factory" ]; then
+          mkdir -p "${{ runner.temp }}/droid-debug/.factory"
+          cp -r "$HOME/.factory/." "${{ runner.temp }}/droid-debug/.factory/"
+        fi
+
     - name: Upload debug artifacts
       if: always() && steps.prepare.outputs.contains_trigger == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: droid-review-debug-${{ github.run_id }}
         path: |
-          ~/.factory/**
+          ${{ runner.temp }}/droid-debug/.factory/**
           ${{ runner.temp }}/droid-prompts/**
         if-no-files-found: ignore
         retention-days: 7

--- a/action.yml
+++ b/action.yml
@@ -400,8 +400,7 @@ runs:
       shell: bash
       run: |
         if [ -d "$HOME/.factory" ]; then
-          mkdir -p "${{ runner.temp }}/droid-debug/.factory"
-          cp -r "$HOME/.factory/." "${{ runner.temp }}/droid-debug/.factory/"
+          cp -r "$HOME/.factory" "${{ runner.temp }}/.factory"
         fi
 
     - name: Upload debug artifacts
@@ -410,7 +409,8 @@ runs:
       with:
         name: droid-review-debug-${{ github.run_id }}
         path: |
-          ${{ runner.temp }}/droid-debug/.factory/**
+          ${{ runner.temp }}/.factory/**
           ${{ runner.temp }}/droid-prompts/**
+        include-hidden-files: true
         if-no-files-found: ignore
         retention-days: 7

--- a/review/action.yml
+++ b/review/action.yml
@@ -141,6 +141,7 @@ runs:
 
     - name: Update tracking comment
       if: always() && inputs.tracking_comment_id
+      continue-on-error: true
       shell: bash
       run: |
         bun run ${{ github.action_path }}/../src/entrypoints/update-comment-link.ts

--- a/review/action.yml
+++ b/review/action.yml
@@ -138,3 +138,18 @@ runs:
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+
+    - name: Update tracking comment
+      if: always() && inputs.tracking_comment_id
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/update-comment-link.ts
+      env:
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        OUTPUT_FILE: ${{ inputs.output_file }}
+        TRIGGER_USERNAME: ${{ github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
+        PREPARE_SUCCESS: "true"
+        DROID_SUCCESS: ${{ (steps.prompt.outputs.review_use_validator == 'true' && steps.validator.outcome == 'success') || (steps.prompt.outputs.review_use_validator != 'true' && steps.review.outcome == 'success') }}


### PR DESCRIPTION
FAC-16278

### Summary

Adds an "Update tracking comment" step to the `review/action.yml` sub-action so that the tracking comment created during the prepare phase is updated with the final status after review completes, instead of staying stuck at "Droid is working..."

### Motivation

After the `combine` job was removed in PR #34, there was no step responsible for updating the tracking comment in the review sub-action. This left the comment permanently showing "Droid is working..." even after the review finished successfully or failed.

### Changes

**`review/action.yml`**
- Added "Update tracking comment" step at the end of the composite action
- Runs with `if: always()` so it executes on both success and failure
- Calls `update-comment-link.ts` which replaces "Droid is working..." with a completion message (e.g. "Droid finished @user's task in 3m 45s") and a link to the job run
- Determines `DROID_SUCCESS` based on whether the validator was used: if validator is enabled, success depends on the validator step outcome; otherwise, it depends on the review step outcome

**`.github/workflows/droid-review.yml` and `.github/workflows/droid.yml`**
- Updated action refs from `@vn/bug-fixes` to `@vn/update-tracking-comment` for testing