### PR TITLE
fix: forward review_model and reasoning_effort to validator step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -346,6 +346,8 @@ runs:
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
+        REVIEW_MODEL: ${{ inputs.review_model }}
+        REASONING_EFFORT: ${{ inputs.reasoning_effort }}
 
     - name: Run Droid Exec (validator)
       id: droid_validator


### PR DESCRIPTION
## Summary

The v3 refactor (b67781e) removed the hardcoded `gpt-5.2` / `high` fallback from `review-validator.ts` but didn't add `REVIEW_MODEL` and `REASONING_EFFORT` to the Prepare validator step's env block in `action.yml`. This causes the two-pass review pipeline's validator pass to silently fall back to the Droid CLI's internal default model instead of using the user's configured `review_model` and `reasoning_effort`.

In v2, a hardcoded fallback in `review-validator.ts` masked this — both passes defaulted to `gpt-5.2` when the env vars were absent. The v3 refactor replaced that with a clean conditional (matching `review.ts`), but the env vars were never wired through.

### Before (v3)
- Pass 1 (candidate generation): uses `--model "gpt-5.3-codex"` ✓
- Pass 2 (validator): no `--model` flag → falls back to CLI default (Opus 4.5) ✗

### After
- Pass 1: uses `--model "gpt-5.3-codex"` ✓
- Pass 2: uses `--model "gpt-5.3-codex"` ✓

## Changes

Adds `REVIEW_MODEL` and `REASONING_EFFORT` to the Prepare validator step's env block in `action.yml`, matching the Prepare action step.

## Test plan

- [x] Existing test suite passes (385 pass, 0 fail)
- [ ] Deploy to a repo with `review_model` override and verify both Droid Exec init logs show the configured model