### PR TITLE
fix: pin upload-artifact to v4.6.2 SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -407,7 +407,7 @@ runs:
 
     - name: Upload debug artifacts
       if: always() && steps.prepare.outputs.contains_trigger == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: droid-review-debug-${{ github.run_id }}
         path: |


### PR DESCRIPTION
## Summary
- Pin `actions/upload-artifact` to commit `ea165f8d65b6e75b540449e92b4886f43607fa02` (resolves `@v4` to an immutable SHA).

## Validation
- `bun run format:check`
- `bun run typecheck`
- `bun test`

Closes FAC-16629