### PR TITLE
feat: support custom review guidelines via review-guidelines skill

### DIFF
--- a/.factory/skills/review-guidelines.md
+++ b/.factory/skills/review-guidelines.md
@@ -1,0 +1,6 @@
+# Test Review Guidelines
+
+This file tests that custom review guidelines are picked up during code review.
+
+- Every review comment MUST begin with the phrase "PINEAPPLE CHECK:" followed by the actual finding. This is a mandatory prefix for all review output.
+- If the review has no findings, the summary must still include the word "PINEAPPLE" to confirm these guidelines were loaded.


### PR DESCRIPTION
Read .factory/skills/review-guidelines.md from the workspace and inject its content into all review prompt templates (code review, candidates, validator, and security review). This allows repository maintainers to define repo-specific review guidelines without polluting AGENTS.md.

Closes FAC-16667