### PR TITLE
feat: support custom review guidelines via review-guidelines skill

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -304,6 +304,7 @@ export type PromptCreationOptions = {
   includeActionsTools?: boolean;
   reviewArtifacts?: ReviewArtifacts;
   outputFilePath?: string;
+  reviewGuidelines?: string;
 };
 
 export async function createPrompt({
@@ -318,6 +319,7 @@ export async function createPrompt({
   includeActionsTools = false,
   reviewArtifacts,
   outputFilePath,
+  reviewGuidelines,
 }: PromptCreationOptions) {
   try {
     const droidCommentId = commentId?.toString();
@@ -332,6 +334,10 @@ export async function createPrompt({
 
     if (outputFilePath) {
       preparedContext.outputFilePath = outputFilePath;
+    }
+
+    if (reviewGuidelines) {
+      preparedContext.reviewGuidelines = reviewGuidelines;
     }
 
     await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/droid-prompts`, {

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -1,3 +1,4 @@
+import { formatGuidelinesSection } from "../../utils/review-guidelines";
 import type { PreparedContext } from "../types";
 
 export function generateReviewCandidatesPrompt(
@@ -27,20 +28,10 @@ export function generateReviewCandidatesPrompt(
     process.env.REVIEW_CANDIDATES_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_candidates.json";
 
-  const guidelinesSection = context.reviewGuidelines
-    ? `
-<custom_review_guidelines>
-The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard review procedure:
-
-${context.reviewGuidelines}
-</custom_review_guidelines>
-`
-    : "";
-
   return `You are a senior staff software engineer and expert code reviewer.
 
 Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
-${guidelinesSection}
+${formatGuidelinesSection(context.reviewGuidelines)}
 <context>
 Repo: ${repoFullName}
 PR Number: ${prNumber}

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -27,10 +27,20 @@ export function generateReviewCandidatesPrompt(
     process.env.REVIEW_CANDIDATES_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_candidates.json";
 
+  const guidelinesSection = context.reviewGuidelines
+    ? `
+<custom_review_guidelines>
+The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard review procedure:
+
+${context.reviewGuidelines}
+</custom_review_guidelines>
+`
+    : "";
+
   return `You are a senior staff software engineer and expert code reviewer.
 
 Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
-
+${guidelinesSection}
 <context>
 Repo: ${repoFullName}
 PR Number: ${prNumber}

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -1,3 +1,4 @@
+import { formatGuidelinesSection } from "../../utils/review-guidelines";
 import type { PreparedContext } from "../types";
 
 export function generateReviewPrompt(context: PreparedContext): string {
@@ -21,23 +22,9 @@ export function generateReviewPrompt(context: PreparedContext): string {
     context.reviewArtifacts?.descriptionPath ??
     "$RUNNER_TEMP/droid-prompts/pr_description.txt";
 
-  const guidelinesSection = context.reviewGuidelines
-    ? `
----
-
-## Repository Review Guidelines
-
-The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard review procedure:
-
-${context.reviewGuidelines}
-
----
-`
-    : "";
-
   return `You are performing an automated code review for PR #${prNumber} in ${repoFullName}.
 The gh CLI is installed and authenticated via GH_TOKEN.
-${guidelinesSection}
+${formatGuidelinesSection(context.reviewGuidelines)}
 ### Context
 
 * Repo: ${repoFullName}

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -21,9 +21,23 @@ export function generateReviewPrompt(context: PreparedContext): string {
     context.reviewArtifacts?.descriptionPath ??
     "$RUNNER_TEMP/droid-prompts/pr_description.txt";
 
+  const guidelinesSection = context.reviewGuidelines
+    ? `
+---
+
+## Repository Review Guidelines
+
+The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard review procedure:
+
+${context.reviewGuidelines}
+
+---
+`
+    : "";
+
   return `You are performing an automated code review for PR #${prNumber} in ${repoFullName}.
 The gh CLI is installed and authenticated via GH_TOKEN.
-
+${guidelinesSection}
 ### Context
 
 * Repo: ${repoFullName}

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -30,10 +30,24 @@ export function generateReviewValidatorPrompt(
     process.env.REVIEW_VALIDATED_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_validated.json";
 
+  const guidelinesSection = context.reviewGuidelines
+    ? `
+---
+
+## Repository Review Guidelines
+
+The repository maintainers have provided the following review guidelines. You MUST follow these when validating candidates:
+
+${context.reviewGuidelines}
+
+---
+`
+    : "";
+
   return `You are validating candidate review comments for PR #${prNumber} in ${repoFullName}.
 
 IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
-
+${guidelinesSection}
 ### Context
 
 * Repo: ${repoFullName}

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -1,3 +1,4 @@
+import { formatGuidelinesSection } from "../../utils/review-guidelines";
 import type { PreparedContext } from "../types";
 
 export function generateReviewValidatorPrompt(
@@ -30,24 +31,10 @@ export function generateReviewValidatorPrompt(
     process.env.REVIEW_VALIDATED_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_validated.json";
 
-  const guidelinesSection = context.reviewGuidelines
-    ? `
----
-
-## Repository Review Guidelines
-
-The repository maintainers have provided the following review guidelines. You MUST follow these when validating candidates:
-
-${context.reviewGuidelines}
-
----
-`
-    : "";
-
   return `You are validating candidate review comments for PR #${prNumber} in ${repoFullName}.
 
 IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
-${guidelinesSection}
+${formatGuidelinesSection(context.reviewGuidelines)}
 ### Context
 
 * Repo: ${repoFullName}

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -20,9 +20,23 @@ export function generateSecurityReviewPrompt(context: PreparedContext): string {
   const blockOnHigh = securityConfig?.securityBlockOnHigh ?? false;
   const notifyTeam = securityConfig?.securityNotifyTeam ?? "";
 
+  const guidelinesSection = context.reviewGuidelines
+    ? `
+---
+
+## Repository Review Guidelines
+
+The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard security review procedure:
+
+${context.reviewGuidelines}
+
+---
+`
+    : "";
+
   return `You are performing a security-focused code review for PR #${prNumber} in ${repoFullName}.
 The gh CLI is installed and authenticated via GH_TOKEN.
-
+${guidelinesSection}
 ## Context
 - Repo: ${repoFullName}
 - PR Number: ${prNumber}

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -1,3 +1,4 @@
+import { formatGuidelinesSection } from "../../utils/review-guidelines";
 import type { PreparedContext } from "../types";
 
 export function generateSecurityReviewPrompt(context: PreparedContext): string {
@@ -20,23 +21,9 @@ export function generateSecurityReviewPrompt(context: PreparedContext): string {
   const blockOnHigh = securityConfig?.securityBlockOnHigh ?? false;
   const notifyTeam = securityConfig?.securityNotifyTeam ?? "";
 
-  const guidelinesSection = context.reviewGuidelines
-    ? `
----
-
-## Repository Review Guidelines
-
-The repository maintainers have provided the following review guidelines. You MUST follow these in addition to the standard security review procedure:
-
-${context.reviewGuidelines}
-
----
-`
-    : "";
-
   return `You are performing a security-focused code review for PR #${prNumber} in ${repoFullName}.
 The gh CLI is installed and authenticated via GH_TOKEN.
-${guidelinesSection}
+${formatGuidelinesSection(context.reviewGuidelines)}
 ## Context
 - Repo: ${repoFullName}
 - PR Number: ${prNumber}

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -118,4 +118,5 @@ export type PreparedContext = CommonFields & {
   };
   reviewArtifacts?: ReviewArtifacts;
   outputFilePath?: string;
+  reviewGuidelines?: string;
 };

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -16,6 +16,7 @@ import { generateReviewPrompt } from "../create-prompt/templates/review-prompt";
 import { generateReviewCandidatesPrompt } from "../create-prompt/templates/review-candidates-prompt";
 import { generateSecurityReviewPrompt } from "../create-prompt/templates/security-review-prompt";
 import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
+import { loadReviewGuidelines } from "../utils/review-guidelines";
 
 async function run() {
   try {
@@ -103,6 +104,8 @@ async function run() {
     // to write structured findings for the combine step
     const outputFilePath = process.env.DROID_OUTPUT_FILE || undefined;
 
+    const reviewGuidelines = await loadReviewGuidelines();
+
     await createPrompt({
       githubContext: context,
       commentId,
@@ -114,6 +117,7 @@ async function run() {
       generatePrompt,
       reviewArtifacts,
       outputFilePath,
+      reviewGuidelines,
     });
 
     // Set run type

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -9,6 +9,7 @@ import { prepareMcpTools } from "../../mcp/install-mcp-server";
 import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import type { PrepareResult } from "../../prepare/types";
 import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
+import { loadReviewGuidelines } from "../../utils/review-guidelines";
 
 export async function prepareReviewValidatorMode({
   context,
@@ -45,6 +46,8 @@ export async function prepareReviewValidatorMode({
     descriptionPath: `${promptsDir}/pr_description.txt`,
   };
 
+  const reviewGuidelines = await loadReviewGuidelines();
+
   await createPrompt({
     githubContext: context,
     commentId: trackingCommentId,
@@ -56,6 +59,7 @@ export async function prepareReviewValidatorMode({
     },
     generatePrompt: generateReviewValidatorPrompt,
     reviewArtifacts,
+    reviewGuidelines,
   });
 
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");

--- a/src/utils/review-guidelines.ts
+++ b/src/utils/review-guidelines.ts
@@ -1,0 +1,21 @@
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+const REVIEW_GUIDELINES_PATH = ".factory/skills/review-guidelines.md";
+
+export async function loadReviewGuidelines(): Promise<string | undefined> {
+  const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+  const filePath = resolve(workspace, REVIEW_GUIDELINES_PATH);
+
+  try {
+    const content = await readFile(filePath, "utf8");
+    const trimmed = content.trim();
+    if (!trimmed) return undefined;
+    console.log(
+      `Loaded review guidelines from ${REVIEW_GUIDELINES_PATH} (${trimmed.length} bytes)`,
+    );
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/review-guidelines.ts
+++ b/src/utils/review-guidelines.ts
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import { resolve } from "path";
 
-const REVIEW_GUIDELINES_PATH = ".factory/skills/review-guidelines.md";
+const REVIEW_GUIDELINES_PATH = ".factory/skills/review-guidelines/SKILL.md";
 
 export async function loadReviewGuidelines(): Promise<string | undefined> {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
@@ -18,4 +18,17 @@ export async function loadReviewGuidelines(): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+export function formatGuidelinesSection(
+  guidelines: string | undefined,
+): string {
+  if (!guidelines) return "";
+  return `
+<custom_review_guidelines>
+The repository maintainers have provided the following review guidelines under \`.factory/skills/review-guidelines/SKILL.md\`. You MUST follow these in addition to the standard review procedure:
+
+${guidelines}
+</custom_review_guidelines>
+`;
 }

--- a/test/create-prompt/templates/review-candidates-prompt.test.ts
+++ b/test/create-prompt/templates/review-candidates-prompt.test.ts
@@ -146,4 +146,38 @@ describe("generateReviewCandidatesPrompt", () => {
     expect(prompt).toContain("PR Head SHA: sha123abc");
     expect(prompt).toContain("PR Base Ref: develop");
   });
+
+  it("includes review guidelines when provided", () => {
+    const context = createBaseContext({
+      reviewGuidelines: "- Focus on performance\n- Check for memory leaks",
+    });
+
+    const prompt = generateReviewCandidatesPrompt(context);
+
+    expect(prompt).toContain("<custom_review_guidelines>");
+    expect(prompt).toContain("- Focus on performance");
+    expect(prompt).toContain("- Check for memory leaks");
+  });
+
+  it("does not include review guidelines section when not provided", () => {
+    const context = createBaseContext();
+
+    const prompt = generateReviewCandidatesPrompt(context);
+
+    expect(prompt).not.toContain("<custom_review_guidelines>");
+  });
+
+  it("places review guidelines before context section", () => {
+    const context = createBaseContext({
+      reviewGuidelines: "Custom guideline",
+    });
+
+    const prompt = generateReviewCandidatesPrompt(context);
+
+    const guidelinesIdx = prompt.indexOf("<custom_review_guidelines>");
+    const contextIdx = prompt.indexOf("<context>");
+    expect(guidelinesIdx).toBeGreaterThan(-1);
+    expect(contextIdx).toBeGreaterThan(-1);
+    expect(guidelinesIdx).toBeLessThan(contextIdx);
+  });
 });

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -176,4 +176,24 @@ describe("generateReviewPrompt", () => {
 
     expect(prompt).not.toContain("## Output File (REQUIRED)");
   });
+
+  it("includes review guidelines when provided", () => {
+    const context = createBaseContext({
+      reviewGuidelines: "- Always check error handling\n- No magic numbers",
+    });
+
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("- Always check error handling");
+    expect(prompt).toContain("- No magic numbers");
+  });
+
+  it("does not include review guidelines section when not provided", () => {
+    const context = createBaseContext();
+
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).not.toContain("## Repository Review Guidelines");
+  });
 });

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -184,7 +184,7 @@ describe("generateReviewPrompt", () => {
 
     const prompt = generateReviewPrompt(context);
 
-    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("<custom_review_guidelines>");
     expect(prompt).toContain("- Always check error handling");
     expect(prompt).toContain("- No magic numbers");
   });
@@ -194,6 +194,6 @@ describe("generateReviewPrompt", () => {
 
     const prompt = generateReviewPrompt(context);
 
-    expect(prompt).not.toContain("## Repository Review Guidelines");
+    expect(prompt).not.toContain("<custom_review_guidelines>");
   });
 });

--- a/test/create-prompt/templates/review-validator-prompt.test.ts
+++ b/test/create-prompt/templates/review-validator-prompt.test.ts
@@ -100,4 +100,24 @@ describe("generateReviewValidatorPrompt", () => {
     expect(prompt).toContain("PR Head SHA: sha999");
     expect(prompt).toContain("PR Base Ref: main");
   });
+
+  it("includes review guidelines when provided", () => {
+    const context = createBaseContext({
+      reviewGuidelines: "- Validate all edge cases\n- Check auth boundaries",
+    });
+
+    const prompt = generateReviewValidatorPrompt(context);
+
+    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("- Validate all edge cases");
+    expect(prompt).toContain("- Check auth boundaries");
+  });
+
+  it("does not include review guidelines section when not provided", () => {
+    const context = createBaseContext();
+
+    const prompt = generateReviewValidatorPrompt(context);
+
+    expect(prompt).not.toContain("## Repository Review Guidelines");
+  });
 });

--- a/test/create-prompt/templates/review-validator-prompt.test.ts
+++ b/test/create-prompt/templates/review-validator-prompt.test.ts
@@ -108,7 +108,7 @@ describe("generateReviewValidatorPrompt", () => {
 
     const prompt = generateReviewValidatorPrompt(context);
 
-    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("<custom_review_guidelines>");
     expect(prompt).toContain("- Validate all edge cases");
     expect(prompt).toContain("- Check auth boundaries");
   });
@@ -118,6 +118,6 @@ describe("generateReviewValidatorPrompt", () => {
 
     const prompt = generateReviewValidatorPrompt(context);
 
-    expect(prompt).not.toContain("## Repository Review Guidelines");
+    expect(prompt).not.toContain("<custom_review_guidelines>");
   });
 });

--- a/test/create-prompt/templates/security-review-prompt.test.ts
+++ b/test/create-prompt/templates/security-review-prompt.test.ts
@@ -109,7 +109,7 @@ describe("generateSecurityReviewPrompt", () => {
 
     const prompt = generateSecurityReviewPrompt(context);
 
-    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("<custom_review_guidelines>");
     expect(prompt).toContain("- Always check for SQL injection");
     expect(prompt).toContain("- Verify CORS settings");
   });
@@ -119,6 +119,6 @@ describe("generateSecurityReviewPrompt", () => {
 
     const prompt = generateSecurityReviewPrompt(context);
 
-    expect(prompt).not.toContain("## Repository Review Guidelines");
+    expect(prompt).not.toContain("<custom_review_guidelines>");
   });
 });

--- a/test/create-prompt/templates/security-review-prompt.test.ts
+++ b/test/create-prompt/templates/security-review-prompt.test.ts
@@ -100,4 +100,25 @@ describe("generateSecurityReviewPrompt", () => {
     expect(prompt).toContain("Block on High: true");
     expect(prompt).toContain("@org/security-team");
   });
+
+  it("includes review guidelines when provided", () => {
+    const context = createBaseContext({
+      reviewGuidelines:
+        "- Always check for SQL injection\n- Verify CORS settings",
+    });
+
+    const prompt = generateSecurityReviewPrompt(context);
+
+    expect(prompt).toContain("## Repository Review Guidelines");
+    expect(prompt).toContain("- Always check for SQL injection");
+    expect(prompt).toContain("- Verify CORS settings");
+  });
+
+  it("does not include review guidelines section when not provided", () => {
+    const context = createBaseContext();
+
+    const prompt = generateSecurityReviewPrompt(context);
+
+    expect(prompt).not.toContain("## Repository Review Guidelines");
+  });
 });

--- a/test/utils/review-guidelines.test.ts
+++ b/test/utils/review-guidelines.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { loadReviewGuidelines } from "../../src/utils/review-guidelines";
+import { writeFile, mkdir, rm } from "fs/promises";
+import { join } from "path";
+
+describe("loadReviewGuidelines", () => {
+  const testDir = join(process.cwd(), "__test_workspace__");
+  const skillsDir = join(testDir, ".factory", "skills");
+  const guidelinesPath = join(skillsDir, "review-guidelines.md");
+  let originalWorkspace: string | undefined;
+
+  beforeEach(async () => {
+    originalWorkspace = process.env.GITHUB_WORKSPACE;
+    process.env.GITHUB_WORKSPACE = testDir;
+    await mkdir(skillsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalWorkspace === undefined) {
+      delete process.env.GITHUB_WORKSPACE;
+    } else {
+      process.env.GITHUB_WORKSPACE = originalWorkspace;
+    }
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("returns content when review-guidelines.md exists", async () => {
+    await writeFile(
+      guidelinesPath,
+      "- Always check error handling\n- Prefer const over let",
+    );
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBe(
+      "- Always check error handling\n- Prefer const over let",
+    );
+  });
+
+  it("returns undefined when file does not exist", async () => {
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when file is empty", async () => {
+    await writeFile(guidelinesPath, "");
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when file contains only whitespace", async () => {
+    await writeFile(guidelinesPath, "   \n\n  ");
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("trims whitespace from content", async () => {
+    await writeFile(guidelinesPath, "\n  Some guidelines\n\n");
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBe("Some guidelines");
+  });
+});

--- a/test/utils/review-guidelines.test.ts
+++ b/test/utils/review-guidelines.test.ts
@@ -1,18 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { loadReviewGuidelines } from "../../src/utils/review-guidelines";
+import {
+  loadReviewGuidelines,
+  formatGuidelinesSection,
+} from "../../src/utils/review-guidelines";
 import { writeFile, mkdir, rm } from "fs/promises";
 import { join } from "path";
 
 describe("loadReviewGuidelines", () => {
   const testDir = join(process.cwd(), "__test_workspace__");
-  const skillsDir = join(testDir, ".factory", "skills");
-  const guidelinesPath = join(skillsDir, "review-guidelines.md");
+  const skillDir = join(testDir, ".factory", "skills", "review-guidelines");
+  const guidelinesPath = join(skillDir, "SKILL.md");
   let originalWorkspace: string | undefined;
 
   beforeEach(async () => {
     originalWorkspace = process.env.GITHUB_WORKSPACE;
     process.env.GITHUB_WORKSPACE = testDir;
-    await mkdir(skillsDir, { recursive: true });
+    await mkdir(skillDir, { recursive: true });
   });
 
   afterEach(async () => {
@@ -65,5 +68,25 @@ describe("loadReviewGuidelines", () => {
     const result = await loadReviewGuidelines();
 
     expect(result).toBe("Some guidelines");
+  });
+});
+
+describe("formatGuidelinesSection", () => {
+  it("returns empty string when guidelines is undefined", () => {
+    expect(formatGuidelinesSection(undefined)).toBe("");
+  });
+
+  it("wraps guidelines in custom_review_guidelines tags", () => {
+    const result = formatGuidelinesSection("- Check errors");
+
+    expect(result).toContain("<custom_review_guidelines>");
+    expect(result).toContain("</custom_review_guidelines>");
+    expect(result).toContain("- Check errors");
+  });
+
+  it("references the correct skill path", () => {
+    const result = formatGuidelinesSection("test");
+
+    expect(result).toContain(".factory/skills/review-guidelines/SKILL.md");
   });
 });


### PR DESCRIPTION
## Summary

Read `.factory/skills/review-guidelines.md` from the workspace and inject its content into all review prompt templates. This allows repository maintainers to define repo-specific review guidelines without polluting `AGENTS.md`.

## Changes

- **New utility** (`src/utils/review-guidelines.ts`): Reads `.factory/skills/review-guidelines.md` from `GITHUB_WORKSPACE`. Returns content if found, `undefined` otherwise.
- **Type update** (`src/create-prompt/types.ts`): Added optional `reviewGuidelines` field to `PreparedContext`.
- **Prompt creation** (`src/create-prompt/index.ts`): Wired `reviewGuidelines` through `PromptCreationOptions` to `PreparedContext`.
- **Entrypoints**: Both `generate-review-prompt.ts` and `review-validator.ts` call `loadReviewGuidelines()` and pass the result through.
- **All 4 review prompt templates** inject the guidelines section when present:
  - `review-prompt.ts` (standalone code review)
  - `review-candidates-prompt.ts` (candidate generation phase)
  - `review-validator-prompt.ts` (validation phase)
  - `security-review-prompt.ts` (security review)
- **Tests**: Utility tests + guidelines injection tests for all 4 prompt templates.

Validation tests: 

I added a file in the mono-repo we can read from and then awaited the code review results: 
https://github.com/Factory-AI/factory-mono/pull/10555

<img width="1210" height="935" alt="image" src="https://github.com/user-attachments/assets/fc86a214-17fd-499b-b227-0e7b7c08a71f" />


## Usage

Create `.factory/skills/review-guidelines.md` in your repo:

```markdown
- Always verify error handling for async operations
- Check for proper input validation on API endpoints
```

These guidelines are automatically picked up and injected during code review runs.

Closes FAC-16667