### PR TITLE
feat: add size cap and truncation for review guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Set `automatic_review: true` to run code reviews automatically on non-draft PRs.
 | `security_scan_schedule`      | `false`  | Configuration for scheduled security scans (when invoked from scheduled workflows).                               |
 | `security_scan_days`          | `7`      | Number of days of commits to scan for scheduled security scans.                                                   |
 
+## Custom Review Guidelines
+
+You can add repository-specific review guidelines by creating a `.factory/skills/review-guidelines/SKILL.md` file:
+
+```markdown
+Additional checks for this codebase:
+- React hooks rules violations
+- Missing TypeScript types on public APIs
+- Prisma query performance issues
+```
+
+These guidelines are automatically loaded and injected into all review prompts (code review, security review, and validation passes). No workflow changes needed.
+
 ## Security Skills
 
 The security review uses specialized Factory skills installed from the public `Factory-AI/skills` repository:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ You can add repository-specific review guidelines by creating a `.factory/skills
 
 ```markdown
 Additional checks for this codebase:
+
 - React hooks rules violations
 - Missing TypeScript types on public APIs
 - Prisma query performance issues

--- a/src/utils/review-guidelines.ts
+++ b/src/utils/review-guidelines.ts
@@ -15,13 +15,18 @@ export async function loadReviewGuidelines(): Promise<string | undefined> {
     if (!trimmed) return undefined;
 
     if (trimmed.length > MAX_GUIDELINES_SIZE) {
+      const truncationMarker = `\n\n... [truncated - guidelines exceed ${MAX_GUIDELINES_SIZE} character limit. Use your tools to read the full file at ${REVIEW_GUIDELINES_PATH}]`;
+      const availableSpace = MAX_GUIDELINES_SIZE - truncationMarker.length;
+
       console.warn(
         `Review guidelines exceed ${MAX_GUIDELINES_SIZE} character limit (${trimmed.length} chars), truncating`,
       );
-      return (
-        trimmed.slice(0, MAX_GUIDELINES_SIZE) +
-        `\n\n... [truncated - guidelines exceed ${MAX_GUIDELINES_SIZE} character limit. Read the full file at ${REVIEW_GUIDELINES_PATH}]`
-      );
+
+      if (availableSpace > 200) {
+        return trimmed.slice(0, availableSpace) + truncationMarker;
+      }
+
+      return truncationMarker.trim();
     }
 
     console.log(

--- a/src/utils/review-guidelines.ts
+++ b/src/utils/review-guidelines.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 export const REVIEW_GUIDELINES_PATH =
   ".factory/skills/review-guidelines/SKILL.md";
 export const MAX_GUIDELINES_SIZE = 80_000;
+const MIN_TRUNCATED_CONTENT_CHARS = 200;
 
 export async function loadReviewGuidelines(): Promise<string | undefined> {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
@@ -22,7 +23,7 @@ export async function loadReviewGuidelines(): Promise<string | undefined> {
         `Review guidelines exceed ${MAX_GUIDELINES_SIZE} character limit (${trimmed.length} chars), truncating`,
       );
 
-      if (availableSpace > 200) {
+      if (availableSpace > MIN_TRUNCATED_CONTENT_CHARS) {
         return trimmed.slice(0, availableSpace) + truncationMarker;
       }
 

--- a/src/utils/review-guidelines.ts
+++ b/src/utils/review-guidelines.ts
@@ -1,7 +1,9 @@
 import { readFile } from "fs/promises";
 import { resolve } from "path";
 
-const REVIEW_GUIDELINES_PATH = ".factory/skills/review-guidelines/SKILL.md";
+export const REVIEW_GUIDELINES_PATH =
+  ".factory/skills/review-guidelines/SKILL.md";
+export const MAX_GUIDELINES_SIZE = 80_000;
 
 export async function loadReviewGuidelines(): Promise<string | undefined> {
   const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
@@ -11,6 +13,17 @@ export async function loadReviewGuidelines(): Promise<string | undefined> {
     const content = await readFile(filePath, "utf8");
     const trimmed = content.trim();
     if (!trimmed) return undefined;
+
+    if (trimmed.length > MAX_GUIDELINES_SIZE) {
+      console.warn(
+        `Review guidelines exceed ${MAX_GUIDELINES_SIZE} character limit (${trimmed.length} chars), truncating`,
+      );
+      return (
+        trimmed.slice(0, MAX_GUIDELINES_SIZE) +
+        `\n\n... [truncated - guidelines exceed ${MAX_GUIDELINES_SIZE} character limit. Read the full file at ${REVIEW_GUIDELINES_PATH}]`
+      );
+    }
+
     console.log(
       `Loaded review guidelines from ${REVIEW_GUIDELINES_PATH} (${trimmed.length} bytes)`,
     );

--- a/test/utils/review-guidelines.test.ts
+++ b/test/utils/review-guidelines.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   loadReviewGuidelines,
   formatGuidelinesSection,
+  MAX_GUIDELINES_SIZE,
 } from "../../src/utils/review-guidelines";
 import { writeFile, mkdir, rm } from "fs/promises";
 import { join } from "path";
@@ -68,6 +69,28 @@ describe("loadReviewGuidelines", () => {
     const result = await loadReviewGuidelines();
 
     expect(result).toBe("Some guidelines");
+  });
+
+  it("truncates content exceeding MAX_GUIDELINES_SIZE", async () => {
+    const largeContent = "x".repeat(MAX_GUIDELINES_SIZE + 1000);
+    await writeFile(guidelinesPath, largeContent);
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBeDefined();
+    expect(result!.startsWith("x".repeat(MAX_GUIDELINES_SIZE))).toBe(true);
+    expect(result).toContain("[truncated");
+    expect(result).toContain(`${MAX_GUIDELINES_SIZE} character limit`);
+  });
+
+  it("does not truncate content at exactly MAX_GUIDELINES_SIZE", async () => {
+    const exactContent = "y".repeat(MAX_GUIDELINES_SIZE);
+    await writeFile(guidelinesPath, exactContent);
+
+    const result = await loadReviewGuidelines();
+
+    expect(result).toBe(exactContent);
+    expect(result).not.toContain("[truncated");
   });
 });
 

--- a/test/utils/review-guidelines.test.ts
+++ b/test/utils/review-guidelines.test.ts
@@ -78,9 +78,10 @@ describe("loadReviewGuidelines", () => {
     const result = await loadReviewGuidelines();
 
     expect(result).toBeDefined();
-    expect(result!.startsWith("x".repeat(MAX_GUIDELINES_SIZE))).toBe(true);
+    expect(result!.length).toBeLessThanOrEqual(MAX_GUIDELINES_SIZE);
     expect(result).toContain("[truncated");
     expect(result).toContain(`${MAX_GUIDELINES_SIZE} character limit`);
+    expect(result).toContain("Use your tools to read the full file");
   });
 
   it("does not truncate content at exactly MAX_GUIDELINES_SIZE", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #49. Adds a size cap (80k characters, matching the AGENTS.md handling in factory-mono) to prevent oversized review guidelines from blowing up prompts.

Updated the readme to describe how to use the new review-guidelines flow

## Changes

- **`src/utils/review-guidelines.ts`**: Added `MAX_GUIDELINES_SIZE = 80_000`. When content exceeds the limit, it's truncated with a note directing the model to read the full file at `.factory/skills/review-guidelines/SKILL.md`.
- **`test/utils/review-guidelines.test.ts`**: Added 2 tests for truncation behavior (exceeds limit, at exactly limit).

## Context

Requested by @jonathan-factory in https://github.com/Factory-AI/droid-action/pull/49#pullrequestreview-2875291330

Ref: [factory-mono AGENTS.md truncation logic](https://github.com/Factory-AI/factory-mono/blob/48f869db1d66bf1c41325d5c328f4773d4f2e13c/apps/cli/src/utils/getGuidelinesInfo.ts#L36)

Closes FAC-16733