### PR TITLE
Feat/review suggestion blocks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,10 @@ inputs:
     description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty and review_model is also empty, the action defaults internally to gpt-5.2 at high reasoning."
     required: false
     default: "high"
+  validator_model:
+    description: "Override the model used for the validator pass (phase 2) of code review. If empty, falls back to review_model."
+    required: false
+    default: ""
   review_candidates_path:
     description: "Path to write review candidates JSON (pass 1 of the two-pass review)."
     required: false
@@ -341,6 +345,7 @@ runs:
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
         REVIEW_MODEL: ${{ inputs.review_model }}
+        VALIDATOR_MODEL: ${{ inputs.validator_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
 
     - name: Run Droid Exec (validator)

--- a/action.yml
+++ b/action.yml
@@ -99,10 +99,6 @@ inputs:
     description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty and review_model is also empty, the action defaults internally to gpt-5.2 at high reasoning."
     required: false
     default: "high"
-  validator_model:
-    description: "Override the model used for the validator pass (phase 2) of code review. If empty, falls back to review_model."
-    required: false
-    default: ""
   include_suggestions:
     description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
     required: false
@@ -350,7 +346,6 @@ runs:
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
         REVIEW_MODEL: ${{ inputs.review_model }}
-        VALIDATOR_MODEL: ${{ inputs.validator_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
 

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,10 @@ inputs:
     description: "Override the model used for the validator pass (phase 2) of code review. If empty, falls back to review_model."
     required: false
     default: ""
+  include_suggestions:
+    description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
+    required: false
+    default: "true"
   review_candidates_path:
     description: "Path to write review candidates JSON (pass 1 of the two-pass review)."
     required: false
@@ -194,6 +198,7 @@ runs:
         FILL_MODEL: ${{ inputs.fill_model }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         DROID_ARGS: ${{ inputs.droid_args }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         ALL_INPUTS: ${{ toJson(inputs) }}
 
     - name: Install Base Action Dependencies
@@ -347,6 +352,7 @@ runs:
         REVIEW_MODEL: ${{ inputs.review_model }}
         VALIDATOR_MODEL: ${{ inputs.validator_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
 
     - name: Run Droid Exec (validator)
       id: droid_validator

--- a/review/action.yml
+++ b/review/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Path to write review validated JSON (pass 2)."
     required: false
     default: "${{ runner.temp }}/droid-prompts/review_validated.json"
+  include_suggestions:
+    description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
+    required: false
+    default: "true"
 
 outputs:
   conclusion:
@@ -82,6 +86,7 @@ runs:
         REVIEW_TYPE: "code"
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
 
     - name: Setup Custom Droids
@@ -117,6 +122,7 @@ runs:
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
 
     - name: Run Validator

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -304,6 +304,7 @@ export type PromptCreationOptions = {
   includeActionsTools?: boolean;
   reviewArtifacts?: ReviewArtifacts;
   outputFilePath?: string;
+  includeSuggestions?: boolean;
 };
 
 export async function createPrompt({
@@ -318,6 +319,7 @@ export async function createPrompt({
   includeActionsTools = false,
   reviewArtifacts,
   outputFilePath,
+  includeSuggestions,
 }: PromptCreationOptions) {
   try {
     const droidCommentId = commentId?.toString();
@@ -332,6 +334,10 @@ export async function createPrompt({
 
     if (outputFilePath) {
       preparedContext.outputFilePath = outputFilePath;
+    }
+
+    if (includeSuggestions !== undefined) {
+      preparedContext.includeSuggestions = includeSuggestions;
     }
 
     await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/droid-prompts`, {

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -27,6 +27,28 @@ export function generateReviewCandidatesPrompt(
     process.env.REVIEW_CANDIDATES_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_candidates.json";
 
+  const includeSuggestions = context.includeSuggestions !== false;
+
+  const bodyFieldDescription = includeSuggestions
+    ? "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation\n" +
+      "    If you have **high confidence** a fix will address the issue and won't break CI, append a GitHub suggestion block:\n" +
+      "\n" +
+      "    ```suggestion\n" +
+      "    <replacement code>\n" +
+      "    ```\n" +
+      "\n" +
+      "    **Suggestion rules:**\n" +
+      "    - Keep suggestion blocks ≤ 100 lines\n" +
+      "    - Preserve exact leading whitespace\n" +
+      "    - Use RIGHT-side anchors only; do not include removed/LEFT-side lines\n" +
+      "    - For insert-only suggestions, repeat the anchor line unchanged, then append new lines"
+    : "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation";
+
+  const sideFieldDescription = includeSuggestions
+    ? '  - `side`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.\n' +
+      "    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it."
+    : '  - `side`: "RIGHT" for new/modified code (default), "LEFT" only for removed code';
+
   return `You are a senior staff software engineer and expert code reviewer.
 
 Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
@@ -167,7 +189,7 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
   "comments": [
     {
       "path": "src/index.ts",
-      "body": "[P1] Title\n\n1 paragraph.",
+      "body": "[P1] Title\\n\\n1 paragraph.",
       "line": 42,
       "startLine": null,
       "side": "RIGHT",
@@ -192,22 +214,10 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
 
 - **comments**: Array of comment objects
   - \`path\`: Relative file path (e.g., "src/index.ts")
-  - \`body\`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation
-    If you have **high confidence** a fix will address the issue and won’t break CI, append a GitHub suggestion block:
-
-    \`\`\`suggestion
-    <replacement code>
-    \`\`\`
-
-    **Suggestion rules:**
-    - Keep suggestion blocks ≤ 100 lines
-    - Preserve exact leading whitespace
-    - Use RIGHT-side anchors only; do not include removed/LEFT-side lines
-    - For insert-only suggestions, repeat the anchor line unchanged, then append new lines
+${bodyFieldDescription}
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
-  - \`side\`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.
-    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it.
+${sideFieldDescription}
   - \`commit_id\`: "${prHeadSha}"
 
 - **reviewSummary**:

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -200,7 +200,8 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
     \`\`\`
 
     Keep suggestions minimal, scoped to the reported line range, preserve exact leading whitespace, and do not exceed 250 lines.
-    Only include replacement lines (no unchanged context, no duplicated original code), and do not include removed/LEFT-side lines.
+    Only include replacement lines (no unchanged context). For insert-only suggestions, include the anchor line unchanged plus the new lines (this is the only allowed duplication). Do not include removed/LEFT-side lines.
+    If you need to re-add deleted content, anchor on a nearby RIGHT-side line and replace that line with itself plus the added lines (insert-only via replacement).
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
   - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -199,9 +199,11 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
     <replacement code>
     \`\`\`
 
-    Keep suggestions minimal, scoped to the reported line range, preserve exact leading whitespace, and do not exceed 250 lines.
-    Only include replacement lines (no unchanged context). For insert-only suggestions: anchor on a RIGHT-side line and repeat it **unchanged**, then append the new lines. Do not modify the anchor line or include removed/LEFT-side lines.
-    If you need to re-add deleted content, anchor on a nearby RIGHT-side line and replace that line with itself plus the added lines (insert-only via replacement).
+    **Suggestion rules (minimal):**
+    - Keep suggestion blocks ≤ 250 lines
+    - Preserve exact leading whitespace
+    - Use RIGHT-side anchors only; do not include removed/LEFT-side lines
+    - For insert-only suggestions, repeat the anchor line unchanged, then append new lines
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
   - \`side\`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -193,6 +193,14 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
 - **comments**: Array of comment objects
   - \`path\`: Relative file path (e.g., "src/index.ts")
   - \`body\`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation
+    If you have **high confidence** a fix will address the issue and won’t break CI, append a GitHub suggestion block:
+
+    \`\`\`suggestion
+    <replacement code>
+    \`\`\`
+
+    Keep suggestions minimal, scoped to the reported line range, preserve exact leading whitespace, and do not exceed 250 lines.
+    Only include replacement lines (no unchanged context, no duplicated original code), and do not include removed/LEFT-side lines.
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
   - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -200,7 +200,7 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
     \`\`\`
 
     Keep suggestions minimal, scoped to the reported line range, preserve exact leading whitespace, and do not exceed 250 lines.
-    Only include replacement lines (no unchanged context). For insert-only suggestions, include the anchor line unchanged plus the new lines (this is the only allowed duplication). Do not include removed/LEFT-side lines.
+    Only include replacement lines (no unchanged context). For insert-only suggestions: anchor on a RIGHT-side line and repeat it **unchanged**, then append the new lines. Do not modify the anchor line or include removed/LEFT-side lines.
     If you need to re-add deleted content, anchor on a nearby RIGHT-side line and replace that line with itself plus the added lines (insert-only via replacement).
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -199,8 +199,8 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
     <replacement code>
     \`\`\`
 
-    **Suggestion rules (minimal):**
-    - Keep suggestion blocks ≤ 250 lines
+    **Suggestion rules:**
+    - Keep suggestion blocks ≤ 100 lines
     - Preserve exact leading whitespace
     - Use RIGHT-side anchors only; do not include removed/LEFT-side lines
     - For insert-only suggestions, repeat the anchor line unchanged, then append new lines

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -204,7 +204,8 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
     If you need to re-add deleted content, anchor on a nearby RIGHT-side line and replace that line with itself plus the added lines (insert-only via replacement).
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
-  - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code
+  - \`side\`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.
+    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it.
   - \`commit_id\`: "${prHeadSha}"
 
 - **reviewSummary**:

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -107,6 +107,13 @@ Reject if:
 * It's already reported (dedupe against existing comments)
 * The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead
 
+### Deduplication (STRICT)
+
+Before approving a candidate, check for duplicates:
+1. **Among candidates**: If two or more candidates describe the same underlying bug (same root cause, even if anchored to different lines or worded differently), approve only the ONE with the best anchor and clearest explanation. Reject the rest with reason "duplicate of candidate N".
+2. **Against existing comments**: If a candidate repeats an issue already covered by an existing PR comment (from \`${commentsPath}\`), reject it with reason "already reported in existing comments".
+3. Same file + overlapping line range + same issue = duplicate, even if the body text differs.
+
 Suggestion block rules (minimal):
 * Preserve exact leading whitespace and keep blocks ≤ 100 lines
 * Use RIGHT-side anchors only; do not include removed/LEFT-side lines

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -30,6 +30,20 @@ export function generateReviewValidatorPrompt(
     process.env.REVIEW_VALIDATED_PATH ??
     "$RUNNER_TEMP/droid-prompts/review_validated.json";
 
+  const includeSuggestions = context.includeSuggestions !== false;
+
+  const anchorRejectionRule = includeSuggestions
+    ? "\n* The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead"
+    : "";
+
+  const suggestionBlockRules = includeSuggestions
+    ? "\n\nSuggestion block rules (minimal):\n" +
+      "* Preserve exact leading whitespace and keep blocks ≤ 100 lines\n" +
+      "* Use RIGHT-side anchors only; do not include removed/LEFT-side lines\n" +
+      "* For insert-only suggestions, repeat the anchor line unchanged, then append new lines\n" +
+      "* Do not change the anchor fields (path/side/line/startLine) from the candidate — only edit the body"
+    : "";
+
   return `You are validating candidate review comments for PR #${prNumber} in ${repoFullName}.
 
 IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
@@ -104,21 +118,14 @@ Reject if:
 * It's speculative / "might" without a concrete trigger
 * It's stylistic / naming / formatting
 * It's not anchored to a valid changed line
-* It's already reported (dedupe against existing comments)
-* The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead
+* It's already reported (dedupe against existing comments)${anchorRejectionRule}
 
 ### Deduplication (STRICT)
 
 Before approving a candidate, check for duplicates:
 1. **Among candidates**: If two or more candidates describe the same underlying bug (same root cause, even if anchored to different lines or worded differently), approve only the ONE with the best anchor and clearest explanation. Reject the rest with reason "duplicate of candidate N".
 2. **Against existing comments**: If a candidate repeats an issue already covered by an existing PR comment (from \`${commentsPath}\`), reject it with reason "already reported in existing comments".
-3. Same file + overlapping line range + same issue = duplicate, even if the body text differs.
-
-Suggestion block rules (minimal):
-* Preserve exact leading whitespace and keep blocks ≤ 100 lines
-* Use RIGHT-side anchors only; do not include removed/LEFT-side lines
-* For insert-only suggestions, repeat the anchor line unchanged, then append new lines
-* Do not change the anchor fields (path/side/line/startLine) from the candidate — only edit the body
+3. Same file + overlapping line range + same issue = duplicate, even if the body text differs.${suggestionBlockRules}
 
 When rejecting, write a concise reason.
 
@@ -143,7 +150,7 @@ Write \`${reviewValidatedPath}\` with this schema:
       "status": "approved",
       "comment": {
         "path": "src/index.ts",
-        "body": "[P1] Title\n\n1 paragraph.",
+        "body": "[P1] Title\\n\\n1 paragraph.",
         "line": 42,
         "startLine": null,
         "side": "RIGHT",

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -108,7 +108,7 @@ Reject if:
 * The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead
 
 Suggestion block rules (minimal):
-* Preserve exact leading whitespace and keep blocks ≤ 250 lines
+* Preserve exact leading whitespace and keep blocks ≤ 100 lines
 * Use RIGHT-side anchors only; do not include removed/LEFT-side lines
 * For insert-only suggestions, repeat the anchor line unchanged, then append new lines
 * Do not change the anchor fields (path/side/line/startLine) from the candidate — only edit the body

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -32,10 +32,6 @@ export function generateReviewValidatorPrompt(
 
   const includeSuggestions = context.includeSuggestions !== false;
 
-  const anchorRejectionRule = includeSuggestions
-    ? "\n* The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead"
-    : "";
-
   const suggestionBlockRules = includeSuggestions
     ? "\n\nSuggestion block rules (minimal):\n" +
       "* Preserve exact leading whitespace and keep blocks ≤ 100 lines\n" +
@@ -118,7 +114,7 @@ Reject if:
 * It's speculative / "might" without a concrete trigger
 * It's stylistic / naming / formatting
 * It's not anchored to a valid changed line
-* It's already reported (dedupe against existing comments)${anchorRejectionRule}
+* It's already reported (dedupe against existing comments)
 
 ### Deduplication (STRICT)
 

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -111,7 +111,7 @@ Suggestion block rules:
 * Suggestion blocks must preserve exact leading whitespace and not exceed 250 lines
 * If the fix is clearly high confidence but the candidate lacks a suggestion block, add one to the approved comment body
 * If the suggestion is not high confidence, remove the suggestion block or reject the candidate
-* Ensure suggestion blocks only include replacement lines (no unchanged context). For insert-only suggestions, allow the anchor line unchanged plus new lines (only allowed duplication)
+* Ensure suggestion blocks only include replacement lines (no unchanged context). For insert-only suggestions: allow a RIGHT-side anchor line repeated **unchanged** plus the new lines; do not modify the anchor line
 * Do not include removed/LEFT-side lines in suggestions
 * For re-adding deleted content, anchor to a nearby RIGHT-side line and replace that line with itself plus the added lines
 

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -106,6 +106,14 @@ Reject if:
 * It's not anchored to a valid changed line
 * It's already reported (dedupe against existing comments)
 
+Suggestion block rules:
+* If an approved comment includes a GitHub suggestion block, ensure the fix is **high confidence** and minimal
+* Suggestion blocks must preserve exact leading whitespace and not exceed 250 lines
+* If the fix is clearly high confidence but the candidate lacks a suggestion block, add one to the approved comment body
+* If the suggestion is not high confidence, remove the suggestion block or reject the candidate
+* Ensure suggestion blocks only include replacement lines (no unchanged context, no duplicated original code)
+* Do not include removed/LEFT-side lines in suggestions
+
 When rejecting, write a concise reason.
 
 =======================

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -105,6 +105,7 @@ Reject if:
 * It's stylistic / naming / formatting
 * It's not anchored to a valid changed line
 * It's already reported (dedupe against existing comments)
+* The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead
 
 Suggestion block rules:
 * If an approved comment includes a GitHub suggestion block, ensure the fix is **high confidence** and minimal
@@ -114,6 +115,7 @@ Suggestion block rules:
 * Ensure suggestion blocks only include replacement lines (no unchanged context). For insert-only suggestions: allow a RIGHT-side anchor line repeated **unchanged** plus the new lines; do not modify the anchor line
 * Do not include removed/LEFT-side lines in suggestions
 * For re-adding deleted content, anchor to a nearby RIGHT-side line and replace that line with itself plus the added lines
+* Do not change the anchor fields (path/side/line/startLine) from the candidate — only edit the body
 
 When rejecting, write a concise reason.
 

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -107,14 +107,10 @@ Reject if:
 * It's already reported (dedupe against existing comments)
 * The anchor (path/side/line/startLine) would need to change to make the suggestion work — reject instead
 
-Suggestion block rules:
-* If an approved comment includes a GitHub suggestion block, ensure the fix is **high confidence** and minimal
-* Suggestion blocks must preserve exact leading whitespace and not exceed 250 lines
-* If the fix is clearly high confidence but the candidate lacks a suggestion block, add one to the approved comment body
-* If the suggestion is not high confidence, remove the suggestion block or reject the candidate
-* Ensure suggestion blocks only include replacement lines (no unchanged context). For insert-only suggestions: allow a RIGHT-side anchor line repeated **unchanged** plus the new lines; do not modify the anchor line
-* Do not include removed/LEFT-side lines in suggestions
-* For re-adding deleted content, anchor to a nearby RIGHT-side line and replace that line with itself plus the added lines
+Suggestion block rules (minimal):
+* Preserve exact leading whitespace and keep blocks ≤ 250 lines
+* Use RIGHT-side anchors only; do not include removed/LEFT-side lines
+* For insert-only suggestions, repeat the anchor line unchanged, then append new lines
 * Do not change the anchor fields (path/side/line/startLine) from the candidate — only edit the body
 
 When rejecting, write a concise reason.

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -111,8 +111,9 @@ Suggestion block rules:
 * Suggestion blocks must preserve exact leading whitespace and not exceed 250 lines
 * If the fix is clearly high confidence but the candidate lacks a suggestion block, add one to the approved comment body
 * If the suggestion is not high confidence, remove the suggestion block or reject the candidate
-* Ensure suggestion blocks only include replacement lines (no unchanged context, no duplicated original code)
+* Ensure suggestion blocks only include replacement lines (no unchanged context). For insert-only suggestions, allow the anchor line unchanged plus new lines (only allowed duplication)
 * Do not include removed/LEFT-side lines in suggestions
+* For re-adding deleted content, anchor to a nearby RIGHT-side line and replace that line with itself plus the added lines
 
 When rejecting, write a concise reason.
 

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -118,4 +118,5 @@ export type PreparedContext = CommonFields & {
   };
   reviewArtifacts?: ReviewArtifacts;
   outputFilePath?: string;
+  includeSuggestions?: boolean;
 };

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -96,6 +96,7 @@ async function run() {
     // Pass the output file path so the prompt can instruct the Droid
     // to write structured findings for the combine step
     const outputFilePath = process.env.DROID_OUTPUT_FILE || undefined;
+    const includeSuggestions = process.env.INCLUDE_SUGGESTIONS !== "false";
 
     await createPrompt({
       githubContext: context,
@@ -108,6 +109,7 @@ async function run() {
       generatePrompt,
       reviewArtifacts,
       outputFilePath,
+      includeSuggestions,
     });
 
     // Set run type

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -101,13 +101,11 @@ export async function prepareReviewValidatorMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const validatorModel = process.env.VALIDATOR_MODEL?.trim();
   const reviewModel = process.env.REVIEW_MODEL?.trim();
-  const modelToUse = validatorModel || reviewModel;
   const reasoningEffort = process.env.REASONING_EFFORT?.trim();
 
-  if (modelToUse) {
-    droidArgParts.push(`--model "${modelToUse}"`);
+  if (reviewModel) {
+    droidArgParts.push(`--model "${reviewModel}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -98,11 +98,13 @@ export async function prepareReviewValidatorMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
+  const validatorModel = process.env.VALIDATOR_MODEL?.trim();
   const reviewModel = process.env.REVIEW_MODEL?.trim();
+  const modelToUse = validatorModel || reviewModel;
   const reasoningEffort = process.env.REASONING_EFFORT?.trim();
 
-  if (reviewModel) {
-    droidArgParts.push(`--model "${reviewModel}"`);
+  if (modelToUse) {
+    droidArgParts.push(`--model "${modelToUse}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -45,6 +45,8 @@ export async function prepareReviewValidatorMode({
     descriptionPath: `${promptsDir}/pr_description.txt`,
   };
 
+  const includeSuggestions = process.env.INCLUDE_SUGGESTIONS !== "false";
+
   await createPrompt({
     githubContext: context,
     commentId: trackingCommentId,
@@ -56,6 +58,7 @@ export async function prepareReviewValidatorMode({
     },
     generatePrompt: generateReviewValidatorPrompt,
     reviewArtifacts,
+    includeSuggestions,
   });
 
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -84,6 +84,8 @@ export async function prepareReviewMode({
     githubToken,
   });
 
+  const includeSuggestions = process.env.INCLUDE_SUGGESTIONS !== "false";
+
   await createPrompt({
     githubContext: context,
     commentId,
@@ -95,6 +97,7 @@ export async function prepareReviewMode({
     },
     generatePrompt: generateReviewCandidatesPrompt,
     reviewArtifacts,
+    includeSuggestions,
   });
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
 


### PR DESCRIPTION
Add review-bot instructions to include suggestion blocks when the fix is high-confidence, using RIGHT-side anchors and a 250-line cap.

There's a bit of repetition in the prompts but feel free to correct me if anything is not relevant:

candidate: generates comment bodies, so would naturally want to add suggestions there as well
Validator: enforcement, reject if anchor changes
Review prompt: needed in the case a single pass is enabled


[examples](https://github.com/Factory-AI/factory-mono/pull/10607#discussion_r2880980993)

or in [this](https://github.com/Factory-AI/droid-action/pull/52#discussion_r2881164842) pr we are in currently  


I did focus on anchoring on the right, since applying suggestions on deleted lines is not currently supported 
<img width="911" height="804" alt="image" src="https://github.com/user-attachments/assets/2d8cdd97-ef10-49a5-b412-2063c5ccd51e" />


Followup: adding guidance about including suggestions or not based on a boolean in this pr is not super important if we are moving the prompts to skills, but might be a nice in between till I get everything working.



Closes FAC-16670


