### PR TITLE
Consolidate review summary into tracking comment

### DIFF
--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -352,11 +352,10 @@ One short paragraph explaining *why* this is a bug and *how* it manifests.
 
 Use \`github_comment___update_droid_comment\` to update the tracking comment (comment ID ${context.droidCommentId}) with the review summary. Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 
-The summary should:
+In the summary:
 
 * State whether the changes are correct or incorrect
 * Provide a 1-3 sentence overall assessment
-* If there are findings, include a brief list of the issues found with their severity levels
 ${
   context.outputFilePath
     ? `

--- a/src/create-prompt/templates/review-prompt.ts
+++ b/src/create-prompt/templates/review-prompt.ts
@@ -333,7 +333,7 @@ One short paragraph explaining *why* this is a bug and *how* it manifests.
   * Anchor using **path + side + line**
   * RIGHT = new/modified code, LEFT = removed code
   * Line numbers must correspond to the chosen side
-* Use \`github_pr___submit_review\` for the summary
+* Use \`github_pr___submit_review\` to submit inline comments — do **NOT** include a \`body\` parameter (no summary in the review)
 * Use \`github_pr___delete_comment\` or \`github_pr___minimize_comment\` for outdated "no issues" comments
 * Use \`github_pr___reply_to_comment\` to acknowledge resolved issues
 * **Do NOT call** \`github_pr___resolve_review_thread\`
@@ -342,7 +342,7 @@ One short paragraph explaining *why* this is a bug and *how* it manifests.
 ### "No issues" handling
 
 * If no issues and a prior "no issues" comment exists → skip
-* If no issues and no prior comment exists → post a brief summary
+* If no issues and no prior comment exists → update the tracking comment with a brief summary
 * If issues exist and a prior "no issues" comment exists → delete/minimize it
 * **Do NOT delete** comment ID ${context.droidCommentId}
 
@@ -350,10 +350,13 @@ One short paragraph explaining *why* this is a bug and *how* it manifests.
 
 ## Review summary
 
-In the submitted review body:
+Use \`github_comment___update_droid_comment\` to update the tracking comment (comment ID ${context.droidCommentId}) with the review summary. Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
+
+The summary should:
 
 * State whether the changes are correct or incorrect
 * Provide a 1-3 sentence overall assessment
+* If there are findings, include a brief list of the issues found with their severity levels
 ${
   context.outputFilePath
     ? `

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -174,7 +174,9 @@ Tooling note:
 After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "approved"\`:
 
 * For each approved entry, call \`github_inline_comment___create_inline_comment\` with the \`comment\` object.
-* Submit a review via \`github_pr___submit_review\` using the summary body (if there are any approved items OR a meaningful overall assessment).
+* If there are approved inline comments, call \`github_pr___submit_review\` to submit them — do **NOT** include a \`body\` parameter.
+* Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary. The summary should state whether the changes are correct or incorrect, provide a 1-3 sentence overall assessment, and if there are findings, include a brief list of the issues found with their severity levels.
+* Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 * Do not approve or request changes.
 `;
 }

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -175,7 +175,7 @@ After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "a
 
 * For each approved entry, call \`github_inline_comment___create_inline_comment\` with the \`comment\` object.
 * If there are approved inline comments, call \`github_pr___submit_review\` to submit them — do **NOT** include a \`body\` parameter.
-* Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary. The summary should state whether the changes are correct or incorrect, provide a 1-3 sentence overall assessment, and if there are findings, include a brief list of the issues found with their severity levels.
+* Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary.
 * Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 * Do not approve or request changes.
 `;

--- a/test/create-prompt/templates/review-prompt.test.ts
+++ b/test/create-prompt/templates/review-prompt.test.ts
@@ -107,6 +107,19 @@ describe("generateReviewPrompt", () => {
     expect(prompt).toContain("All findings are low-severity (P2/P3)");
   });
 
+  it("instructs to post summary in tracking comment, not in submit_review body", () => {
+    const context = createBaseContext();
+    const prompt = generateReviewPrompt(context);
+
+    expect(prompt).toContain("github_comment___update_droid_comment");
+    expect(prompt).toContain(
+      "do **NOT** include a `body` parameter",
+    );
+    expect(prompt).toContain(
+      "Do **NOT** post the summary as a separate comment or as the body of `submit_review`",
+    );
+  });
+
   it("references PR description artifact in pre-computed files", () => {
     const context = createBaseContext({
       reviewArtifacts: {

--- a/test/create-prompt/templates/review-validator-prompt.test.ts
+++ b/test/create-prompt/templates/review-validator-prompt.test.ts
@@ -78,6 +78,19 @@ describe("generateReviewValidatorPrompt", () => {
     expect(prompt).toContain("Phase 4: Post approved items");
   });
 
+  it("instructs to post summary in tracking comment, not in submit_review body", () => {
+    const context = createBaseContext();
+    const prompt = generateReviewValidatorPrompt(context);
+
+    expect(prompt).toContain("github_comment___update_droid_comment");
+    expect(prompt).toContain(
+      "do **NOT** include a `body` parameter",
+    );
+    expect(prompt).toContain(
+      "Do **NOT** post the summary as a separate comment or as the body of `submit_review`",
+    );
+  });
+
   it("includes correct PR context", () => {
     const context = createBaseContext({
       prBranchData: {


### PR DESCRIPTION
## Summary

When a review runs, the initial tracking comment shows "Droid is working..." and gets updated with completion status. Previously, a **separate** PR review comment was also posted at the bottom with the review summary, resulting in two comments with overlapping content.

This PR consolidates them: the review summary is now written directly to the tracking comment via `update_droid_comment`, and `submit_review` is called without a `body` parameter (it still groups inline comments).

Applies to both the single-pass review prompt and the two-pass validator flow.

## Before / After

- **Old behavior** (two separate comments): https://github.com/Factory-AI/droid-action/pull/54
- **New behavior** (single consolidated comment): https://github.com/Factory-AI/droid-action/pull/53

<img width="1031" height="828" alt="image" src="https://github.com/user-attachments/assets/638571aa-2ba9-4588-877c-032f70bc97f0" />


## Context

Request from Marcel at Cars Commerce: https://factory-ai.slack.com/archives/C0A88SWJH6J/p1771745510428959

## Changes

- `review-prompt.ts`: Instruct model to put summary in tracking comment via `update_droid_comment` instead of `submit_review` body
- `review-validator-prompt.ts`: Same change for the two-pass validator flow
- Added tests for both prompts verifying the new behavior


closes: FAC-16835