### PR TITLE
Batch all review comments into a single submit_review call

### DIFF
--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -173,8 +173,9 @@ Tooling note:
 
 After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "approved"\`:
 
-* For each approved entry, call \`github_inline_comment___create_inline_comment\` with the \`comment\` object.
-* If there are approved inline comments, call \`github_pr___submit_review\` to submit them — do **NOT** include a \`body\` parameter.
+* Collect all approved comments and submit them as a **single batched review** via \`github_pr___submit_review\`, passing them in the \`comments\` array parameter.
+* Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
+* do **NOT** include a \`body\` parameter in \`submit_review\`.
 * Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary.
 * Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 * Do not approve or request changes.

--- a/src/mcp/github-pr-server.ts
+++ b/src/mcp/github-pr-server.ts
@@ -181,6 +181,16 @@ export async function listReviewAndIssueComments({
   };
 }
 
+export type ReviewComment = {
+  path: string;
+  body: string;
+  line?: number;
+  side?: string;
+  start_line?: number;
+  start_side?: string;
+  position?: number;
+};
+
 export async function submitReviewWithComments({
   owner,
   repo,
@@ -193,7 +203,7 @@ export async function submitReviewWithComments({
   repo: string;
   prNumber: number;
   body?: string;
-  comments?: Array<{ path: string; position: number; body: string }>;
+  comments?: ReviewComment[];
   octokit: OctokitLike;
 }): Promise<number | undefined> {
   const response = await octokit.rest.pulls.createReview({
@@ -603,20 +613,45 @@ export function createGitHubPRServer({
 
   server.tool(
     "submit_review",
-    "Submit a PR review containing inline comments",
+    "Submit a PR review with all inline comments batched into a single review. " +
+      "Use line/side to anchor comments to specific lines in the diff.",
     {
       pr_number: z.number().int().describe("PR number to review"),
       body: z.string().describe("Optional summary body").optional(),
       comments: z
         .array(
           z.object({
-            path: z.string(),
-            position: z.number().int(),
-            body: z.string().min(1),
+            path: z
+              .string()
+              .describe("The file path to comment on (e.g., 'src/index.js')"),
+            body: z.string().min(1).describe("The comment text (supports markdown and GitHub code suggestion blocks)"),
+            line: z
+              .number()
+              .int()
+              .optional()
+              .describe(
+                "Line number for single-line comments, or end line for multi-line comments",
+              ),
+            side: z
+              .enum(["LEFT", "RIGHT"])
+              .optional()
+              .default("RIGHT")
+              .describe(
+                "Side of the diff: RIGHT for new/modified code, LEFT for removed code",
+              ),
+            start_line: z
+              .number()
+              .int()
+              .optional()
+              .describe("Start line for multi-line comments"),
+            start_side: z
+              .enum(["LEFT", "RIGHT"])
+              .optional()
+              .describe("Side for the start line of multi-line comments"),
           }),
         )
         .max(30)
-        .describe("List of inline comments to include")
+        .describe("List of inline comments to include in the review")
         .optional(),
     },
     async ({ pr_number, body, comments }) => {

--- a/src/mcp/github-pr-server.ts
+++ b/src/mcp/github-pr-server.ts
@@ -181,7 +181,7 @@ export async function listReviewAndIssueComments({
   };
 }
 
-export type ReviewComment = {
+type ReviewComment = {
   path: string;
   body: string;
   line?: number;

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -80,7 +80,6 @@ export async function prepareReviewValidatorMode({
     "Create",
     "Edit",
     "github_comment___update_droid_comment",
-    "github_inline_comment___create_inline_comment",
   ];
 
   const validatorTools = ["github_pr___submit_review"];


### PR DESCRIPTION
## Summary

Instead of posting inline comments individually via `create_inline_comment` (which creates separate review events for each comment), this batches all comments into the `submit_review` `comments` array. This produces a single cohesive review on the PR.

## Changes

- **`github-pr-server.ts`**: Updated `submit_review` tool schema to support modern `line`/`side`/`start_line`/`start_side` parameters (matching GitHub's createReview API), instead of only the legacy `position` field
- **`review-prompt.ts`**: Instruct model to batch all findings into one `submit_review` call
- **`review-validator-prompt.ts`**: Same for the two-pass validator flow
- **`review.ts` / `review-validator.ts`**: Removed `create_inline_comment` from allowed tools in review flows

## Before / After

- **Old behavior** (individual review comments): https://github.com/Factory-AI/droid-action/pull/54
- **New behavior** (single batched review): https://github.com/Factory-AI/droid-action/pull/56

closes FAC-16847