### PR TITLE
feat: add shallow/deep review depth presets (default: shallow with kimi-k2-0711)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,67 @@ Set `automatic_review: true` to run code reviews automatically on non-draft PRs.
 
 ### Review Configuration
 
-| Input              | Default   | Purpose                                                                 |
-| ------------------ | --------- | ----------------------------------------------------------------------- |
-| `automatic_review` | `false`   | Automatically run code review on PRs without requiring `@droid review`. |
-| `review_model`     | `gpt-5.2` | Override the model used for code review.                                |
-| `fill_model`       | `""`      | Override the model used for PR description fill.                        |
+| Input              | Default | Purpose                                                                                                |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------ |
+| `automatic_review` | `false` | Automatically run code review on PRs without requiring `@droid review`.                                |
+| `review_depth`     | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below.  |
+| `review_model`     | `""`    | Override the model for code review. When empty, determined by `review_depth`.                          |
+| `reasoning_effort`  | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                        |
+| `fill_model`       | `""`    | Override the model used for PR description fill.                                                       |
+
+### Review Depth
+
+The `review_depth` input controls which model and reasoning effort are used for code reviews. Two presets are available:
+
+| Depth      | Model           | Reasoning Effort | Best For                                              |
+| ---------- | --------------- | ---------------- | ----------------------------------------------------- |
+| **deep**   | `gpt-5.2`       | `high`           | Thorough reviews catching subtle bugs and design issues |
+| **shallow** | `kimi-k2-0711` | default          | Fast, cost-effective reviews for straightforward PRs   |
+
+**Examples:**
+
+```yaml
+# Deep review (default - no extra config needed)
+- uses: Factory-AI/droid-action@v3
+  with:
+    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+    automatic_review: true
+
+# Shallow review for faster feedback
+- uses: Factory-AI/droid-action@v3
+  with:
+    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+    automatic_review: true
+    review_depth: shallow
+
+# Fully custom model (overrides depth preset entirely)
+- uses: Factory-AI/droid-action@v3
+  with:
+    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+    automatic_review: true
+    review_model: claude-sonnet-4-5-20250929
+    reasoning_effort: high
+```
+
+> **Tip:** Setting `review_model` or `reasoning_effort` explicitly always takes priority over the depth preset. You can mix and match -- for example, use `review_depth: shallow` but override just `reasoning_effort: high` to get the shallow model with higher reasoning.
+
+### Updating Review Models
+
+The depth presets are defined in [`src/utils/review-depth.ts`](src/utils/review-depth.ts). To change which models are used for shallow or deep reviews, edit the `REVIEW_DEPTH_PRESETS` object:
+
+```typescript
+const SHALLOW_DEFAULTS = {
+  model: "kimi-k2-0711",        // Change to any supported model
+  reasoningEffort: undefined,    // undefined = use model default
+};
+
+const DEEP_DEFAULTS = {
+  model: "gpt-5.2",             // Change to any supported model
+  reasoningEffort: "high",       // "high" | "medium" | "low" | undefined
+};
+```
+
+Individual users can also override these defaults per-workflow without modifying the source by setting `review_model` and/or `reasoning_effort` inputs directly in their workflow YAML.
 
 ### Security Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -91,14 +91,18 @@ inputs:
     description: "Number of days of commits to scan for scheduled security scans. Only applies when security_scan_schedule is enabled."
     required: false
     default: "7"
+  review_depth:
+    description: "Review depth preset: 'shallow' (fast, uses kimi-k2-0711) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    required: false
+    default: "deep"
   review_model:
-    description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to review flows."
+    description: "Override the model used for code review (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). If empty, the model is determined by review_depth."
     required: false
-    default: "gpt-5.2"
+    default: ""
   reasoning_effort:
-    description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty and review_model is also empty, the action defaults internally to gpt-5.2 at high reasoning."
+    description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty, determined by review_depth (shallow=default, deep=high)."
     required: false
-    default: "high"
+    default: ""
   include_suggestions:
     description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
     required: false
@@ -187,6 +191,7 @@ runs:
         SECURITY_NOTIFY_TEAM: ${{ inputs.security_notify_team }}
         SECURITY_SCAN_SCHEDULE: ${{ inputs.security_scan_schedule }}
         SECURITY_SCAN_DAYS: ${{ inputs.security_scan_days }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
@@ -345,6 +350,7 @@ runs:
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}

--- a/review/action.yml
+++ b/review/action.yml
@@ -12,14 +12,18 @@ inputs:
   tracking_comment_id:
     description: "ID of the tracking comment to update"
     required: true
+  review_depth:
+    description: "Review depth preset: 'shallow' (fast, uses kimi-k2-0711) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    required: false
+    default: "deep"
   review_model:
-    description: "Model to use for review"
+    description: "Override the model used for review. If empty, determined by review_depth."
     required: false
-    default: "gpt-5.2"
+    default: ""
   reasoning_effort:
-    description: "Reasoning effort for review (passed to Droid Exec as --reasoning-effort)"
+    description: "Override reasoning effort for review. If empty, determined by review_depth (shallow=default, deep=high)."
     required: false
-    default: "high"
+    default: ""
   output_file:
     description: "Path to write review results JSON"
     required: false
@@ -82,6 +86,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REVIEW_TYPE: "code"
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
@@ -120,6 +125,7 @@ runs:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -15,6 +15,7 @@ import { prepareMcpTools } from "../mcp/install-mcp-server";
 import { generateReviewCandidatesPrompt } from "../create-prompt/templates/review-candidates-prompt";
 import { generateSecurityReviewPrompt } from "../create-prompt/templates/security-review-prompt";
 import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
+import { resolveReviewConfig } from "../utils/review-depth";
 
 async function run() {
   try {
@@ -174,14 +175,19 @@ async function run() {
     droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
     droidArgParts.push('--tag "code-review"');
 
-    const reviewModel =
+    const rawModel =
       reviewType === "security"
         ? process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim()
         : process.env.REVIEW_MODEL?.trim();
-    const reasoningEffort = process.env.REASONING_EFFORT?.trim();
 
-    if (reviewModel) {
-      droidArgParts.push(`--model "${reviewModel}"`);
+    const { model, reasoningEffort } = resolveReviewConfig({
+      reviewModel: rawModel,
+      reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+      reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+    });
+
+    if (model) {
+      droidArgParts.push(`--model "${model}"`);
     }
     if (reasoningEffort) {
       droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);

--- a/src/mcp/github-pr-server.ts
+++ b/src/mcp/github-pr-server.ts
@@ -624,7 +624,12 @@ export function createGitHubPRServer({
             path: z
               .string()
               .describe("The file path to comment on (e.g., 'src/index.js')"),
-            body: z.string().min(1).describe("The comment text (supports markdown and GitHub code suggestion blocks)"),
+            body: z
+              .string()
+              .min(1)
+              .describe(
+                "The comment text (supports markdown and GitHub code suggestion blocks)",
+              ),
             line: z
               .number()
               .int()

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -9,6 +9,7 @@ import { prepareMcpTools } from "../../mcp/install-mcp-server";
 import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import type { PrepareResult } from "../../prepare/types";
 import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
+import { resolveReviewConfig } from "../../utils/review-depth";
 
 export async function prepareReviewValidatorMode({
   context,
@@ -101,11 +102,14 @@ export async function prepareReviewValidatorMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const reviewModel = process.env.REVIEW_MODEL?.trim();
-  const reasoningEffort = process.env.REASONING_EFFORT?.trim();
+  const { model, reasoningEffort } = resolveReviewConfig({
+    reviewModel: process.env.REVIEW_MODEL?.trim(),
+    reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+    reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+  });
 
-  if (reviewModel) {
-    droidArgParts.push(`--model "${reviewModel}"`);
+  if (model) {
+    droidArgParts.push(`--model "${model}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -11,6 +11,7 @@ import { isEntityContext } from "../../github/context";
 import { generateReviewCandidatesPrompt } from "../../create-prompt/templates/review-candidates-prompt";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
+import { resolveReviewConfig } from "../../utils/review-depth";
 
 type ReviewCommandOptions = {
   context: GitHubContext;
@@ -153,11 +154,14 @@ export async function prepareReviewMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const reviewModel = process.env.REVIEW_MODEL?.trim();
-  const reasoningEffort = process.env.REASONING_EFFORT?.trim();
+  const { model, reasoningEffort } = resolveReviewConfig({
+    reviewModel: process.env.REVIEW_MODEL?.trim(),
+    reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+    reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+  });
 
-  if (reviewModel) {
-    droidArgParts.push(`--model "${reviewModel}"`);
+  if (model) {
+    droidArgParts.push(`--model "${model}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);

--- a/src/utils/review-depth.ts
+++ b/src/utils/review-depth.ts
@@ -1,0 +1,38 @@
+export type ReviewDepth = "shallow" | "deep";
+
+const SHALLOW_DEFAULTS = {
+  model: "kimi-k2-0711",
+  reasoningEffort: undefined as string | undefined,
+};
+
+const DEEP_DEFAULTS = {
+  model: "gpt-5.2",
+  reasoningEffort: "high" as string | undefined,
+};
+
+export const REVIEW_DEPTH_PRESETS: Record<
+  ReviewDepth,
+  { model: string; reasoningEffort: string | undefined }
+> = {
+  shallow: SHALLOW_DEFAULTS,
+  deep: DEEP_DEFAULTS,
+};
+
+/**
+ * Resolve the effective review model and reasoning effort based on depth.
+ * Explicit overrides (review_model, reasoning_effort) take priority over depth presets.
+ */
+export function resolveReviewConfig(options?: {
+  reviewModel?: string;
+  reasoningEffort?: string;
+  reviewDepth?: string;
+}): { model: string; reasoningEffort: string | undefined } {
+  const depth = (options?.reviewDepth || "deep") as ReviewDepth;
+  const defaults =
+    REVIEW_DEPTH_PRESETS[depth] ?? REVIEW_DEPTH_PRESETS["shallow"];
+
+  return {
+    model: options?.reviewModel || defaults.model,
+    reasoningEffort: options?.reasoningEffort || defaults.reasoningEffort,
+  };
+}

--- a/src/utils/review-depth.ts
+++ b/src/utils/review-depth.ts
@@ -1,4 +1,7 @@
-export type ReviewDepth = "shallow" | "deep";
+export enum ReviewDepth {
+  Shallow = "shallow",
+  Deep = "deep",
+}
 
 const SHALLOW_DEFAULTS = {
   model: "kimi-k2-0711",
@@ -14,8 +17,8 @@ export const REVIEW_DEPTH_PRESETS: Record<
   ReviewDepth,
   { model: string; reasoningEffort: string | undefined }
 > = {
-  shallow: SHALLOW_DEFAULTS,
-  deep: DEEP_DEFAULTS,
+  [ReviewDepth.Shallow]: SHALLOW_DEFAULTS,
+  [ReviewDepth.Deep]: DEEP_DEFAULTS,
 };
 
 /**
@@ -27,9 +30,9 @@ export function resolveReviewConfig(options?: {
   reasoningEffort?: string;
   reviewDepth?: string;
 }): { model: string; reasoningEffort: string | undefined } {
-  const depth = (options?.reviewDepth || "deep") as ReviewDepth;
+  const depth = (options?.reviewDepth || ReviewDepth.Deep) as ReviewDepth;
   const defaults =
-    REVIEW_DEPTH_PRESETS[depth] ?? REVIEW_DEPTH_PRESETS["shallow"];
+    REVIEW_DEPTH_PRESETS[depth] ?? REVIEW_DEPTH_PRESETS[ReviewDepth.Shallow];
 
   return {
     model: options?.reviewModel || defaults.model,

--- a/test/create-prompt/templates/review-validator-prompt.test.ts
+++ b/test/create-prompt/templates/review-validator-prompt.test.ts
@@ -65,7 +65,9 @@ describe("generateReviewValidatorPrompt", () => {
     expect(prompt).toContain(
       "You are validating candidate review comments for PR",
     );
-    expect(prompt).toContain("Phase 2 (validator) of a two-pass review pipeline");
+    expect(prompt).toContain(
+      "Phase 2 (validator) of a two-pass review pipeline",
+    );
   });
 
   it("instructs to post summary in tracking comment, not in submit_review body", () => {

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -385,10 +385,9 @@ describe("prepareReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    // When neither REVIEW_MODEL nor REASONING_EFFORT is provided, no --model or --reasoning-effort
-    // flags are added. Defaults are handled by the action.yml inputs (gpt-5.2 / high).
-    expect(droidArgsCall?.[1]).not.toContain("--model");
-    expect(droidArgsCall?.[1]).not.toContain("--reasoning-effort");
+    // When REVIEW_MODEL is empty the deep depth preset kicks in (gpt-5.2, high reasoning).
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.2"');
+    expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 
   it("stores PR description as an artifact file", async () => {


### PR DESCRIPTION
## Summary

Adds a `review_depth` input to control review thoroughness. This makes it easy for users to switch between fast and thorough reviews.

### Review Depth Presets

| Depth | Model | Reasoning Effort | Best For |
|-------|-------|-----------------|----------|
| **deep** (default) | `gpt-5.2` | `high` | Thorough reviews catching subtle bugs and design issues |
| **shallow** | `kimi-k2-0711` | default | Fast, cost-effective reviews for straightforward PRs |

### How to use

```yaml
# Deep review (default - no extra config needed)
- uses: Factory-AI/droid-action@v3
  with:
    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
    automatic_review: true

# Shallow review for faster feedback
- uses: Factory-AI/droid-action@v3
  with:
    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
    automatic_review: true
    review_depth: shallow

# Fully custom model (overrides depth preset entirely)
- uses: Factory-AI/droid-action@v3
  with:
    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
    automatic_review: true
    review_model: claude-sonnet-4-5-20250929
    reasoning_effort: high
```

### Changes

- New `review_depth` input (`shallow`/`deep`, default: `deep`) on both `action.yml` and `review/action.yml`
- New `src/utils/review-depth.ts` utility with centralized depth presets (easy to modify)
- `review_model` and `reasoning_effort` defaults changed from hardcoded values to empty (derived from depth)
- Explicit `review_model`/`reasoning_effort` overrides still take priority over depth presets
- README updated with review depth documentation, usage examples, and instructions for updating model selections

Resolves: FAC-17934