### PR TITLE
chore: Security review plugins

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -252,66 +252,16 @@ runs:
       env:
         EXPERIMENTAL_ALLOWED_DOMAINS: ${{ inputs.experimental_allowed_domains }}
 
-    - name: Install Security Skills
+    - name: Install Security Plugin
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.install_security_skills == 'true'
       shell: bash
       run: |
-        echo "Installing security skills from Factory-AI/skills..."
-        SKILLS_DIR="$HOME/.factory/skills"
-        mkdir -p "$SKILLS_DIR"
-
-        # Clone public skills repo (sparse checkout for efficiency)
-        TEMP_DIR=$(mktemp -d)
-        git clone --filter=blob:none --sparse \
-          "https://github.com/Factory-AI/skills.git" \
-          "$TEMP_DIR" 2>/dev/null || {
-          echo "Warning: Could not clone skills repo. Security skills will not be available."
-          exit 0
+        echo "Installing security-engineer plugin from factory-plugins marketplace..."
+        droid plugin marketplace add https://github.com/Factory-AI/factory-plugins 2>/dev/null || true
+        droid plugin install security-engineer@factory-plugins --scope user 2>/dev/null || {
+          echo "Warning: Could not install security-engineer plugin. Security review may have limited functionality."
         }
-
-        cd "$TEMP_DIR"
-        git sparse-checkout set \
-          skills/threat-model-generation \
-          skills/commit-security-scan \
-          skills/vulnerability-validation \
-          skills/security-review 2>/dev/null || true
-
-        # Copy skills to ~/.factory/skills/ and track installed count
-        INSTALLED_COUNT=0
-        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
-          if [ -d "skills/$skill" ]; then
-            cp -r "skills/$skill" "$SKILLS_DIR/"
-            echo "  Installed skill: $skill"
-            INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
-          else
-            echo "  Warning: Skill not found in repo: $skill"
-          fi
-        done
-
-        # Cleanup
-        rm -rf "$TEMP_DIR"
-
-        # Verify at least one skill was installed
-        if [ "$INSTALLED_COUNT" -eq 0 ]; then
-          echo "Warning: No security skills were installed. The skills may not exist in the Factory-AI/skills repository."
-          echo "Security review will proceed but may have limited functionality."
-        else
-          echo "Security skills installation complete ($INSTALLED_COUNT skills installed)"
-        fi
-
-        # Verify skills exist in the target directory
-        echo "Verifying installed skills in $SKILLS_DIR..."
-        VERIFIED_COUNT=0
-        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
-          if [ -d "$SKILLS_DIR/$skill" ]; then
-            echo "  Verified: $skill"
-            VERIFIED_COUNT=$((VERIFIED_COUNT + 1))
-          fi
-        done
-
-        if [ "$VERIFIED_COUNT" -ne "$INSTALLED_COUNT" ]; then
-          echo "Warning: Skill verification mismatch. Expected $INSTALLED_COUNT, found $VERIFIED_COUNT in $SKILLS_DIR"
-        fi
+        echo "Security plugin installation complete"
 
     - name: Run Droid Exec
       id: droid

--- a/security/action.yml
+++ b/security/action.yml
@@ -70,37 +70,15 @@ runs:
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}
 
-    - name: Install Security Skills
+    - name: Install Security Plugin
       shell: bash
       run: |
-        echo "Installing security skills from Factory-AI/skills..."
-        SKILLS_DIR="$HOME/.factory/skills"
-        mkdir -p "$SKILLS_DIR"
-
-        TEMP_DIR=$(mktemp -d)
-        git clone --filter=blob:none --sparse \
-          "https://github.com/Factory-AI/skills.git" \
-          "$TEMP_DIR" 2>/dev/null || {
-          echo "Warning: Could not clone skills repo."
-          exit 0
+        echo "Installing security-engineer plugin from factory-plugins marketplace..."
+        droid plugin marketplace add https://github.com/Factory-AI/factory-plugins 2>/dev/null || true
+        droid plugin install security-engineer@factory-plugins --scope user 2>/dev/null || {
+          echo "Warning: Could not install security-engineer plugin. Security review may have limited functionality."
         }
-
-        cd "$TEMP_DIR"
-        git sparse-checkout set \
-          skills/threat-model-generation \
-          skills/commit-security-scan \
-          skills/vulnerability-validation \
-          skills/security-review 2>/dev/null || true
-
-        for skill in threat-model-generation commit-security-scan vulnerability-validation security-review; do
-          if [ -d "skills/$skill" ]; then
-            cp -r "skills/$skill" "$SKILLS_DIR/"
-            echo "  Installed skill: $skill"
-          fi
-        done
-
-        rm -rf "$TEMP_DIR"
-        echo "Security skills installation complete"
+        echo "Security plugin installation complete"
 
     - name: Generate Security Prompt
       id: prompt

--- a/src/create-prompt/templates/security-report-prompt.ts
+++ b/src/create-prompt/templates/security-report-prompt.ts
@@ -43,7 +43,7 @@ The gh CLI is installed and authenticated via GH_TOKEN.
 
 ## Security Skills Available
 
-You have access to these Factory security skills (installed in ~/.factory/skills/):
+You have access to security skills from the security-engineer plugin (security-engineer@factory-plugins):
 
 1. **threat-model-generation** - Generate STRIDE-based threat model for the repository
 2. **commit-security-scan** - Scan code for security vulnerabilities

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -38,7 +38,7 @@ ${notifyTeam ? `- Notify Team: ${notifyTeam} (mention on critical findings)` : "
 
 ## Security Skills Available
 
-You have access to these Factory security skills (installed in ~/.factory/skills/):
+You have access to security skills from the security-engineer plugin (security-engineer@factory-plugins):
 
 1. **threat-model-generation** - Generate STRIDE-based threat model for the repository
 2. **commit-security-scan** - Scan code changes for security vulnerabilities


### PR DESCRIPTION
## Summary
Replaces the manual security skills installation process with the new `droid plugin` CLI, switching from a git-clone-and-copy approach to the `security-engineer@factory-plugins` marketplace plugin.
## Changes
- **`action.yml`**: Replaced the ~50-line "Install Security Skills" step (sparse git clone, per-skill copy, verification loop) with a 3-line "Install Security Plugin" step using `droid plugin marketplace add` and `droid plugin install security-engineer@factory-plugins --scope user`.
- **`security/action.yml`**: Applied the same simplification to the standalone security action, reducing ~25 lines of shell to the same plugin install commands.
- **`src/create-prompt/templates/security-report-prompt.ts`**: Updated the "Security Skills Available" section to reference the plugin source (`security-engineer@factory-plugins`) instead of the local `~/.factory/skills/` directory.
- **`src/create-prompt/templates/security-review-prompt.ts`**: Same prompt reference update as above.
## Implementation Details
The previous approach cloned `Factory-AI/skills` with a sparse checkout, copied four individual skill directories (`threat-model-generation`, `commit-security-scan`, `vulnerability-validation`, `security-review`) into `~/.factory/skills/`, and ran a multi-step verification. The new approach delegates all of this to the `droid plugin` CLI, which handles marketplace registration, download, and installation in two commands. Both action files include graceful fallback warnings if the plugin install fails.
## Testing
[To be filled by author]
## Related Issues
[To be filled by author]