### PR TITLE
fix(cli): Security review plugins prompt update

### DIFF
--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -49,8 +49,9 @@ You have access to security skills from the security-engineer plugin (security-e
 
 ### Step 1: Threat Model Check
 - Check if \`.factory/threat-model.md\` exists in the repository
-- If missing: Note this in the summary (threat model generation is done separately, not during PR review)
-- If exists: Use it as context for the security scan
+- If missing: Invoke the **threat-model-generation** skill to generate one, then use it as context
+- If exists but older than 90 days: Note it may be stale, but proceed with existing
+- If exists and current: Use it as context for the security scan
 
 ### Step 2: Security Scan
 - Invoke the **commit-security-scan** skill on the PR diff


### PR DESCRIPTION
## Summary
Updates the security review plugin prompt to automatically generate a threat model when one is missing, instead of simply noting its absence, and adds handling for stale threat models.
## Changes
- **Auto-generate missing threat models**: When `.factory/threat-model.md` does not exist, the prompt now instructs Droid to invoke the **threat-model-generation** skill to create one and use it as context, rather than deferring generation to a separate process.
- **Stale threat model handling**: Added a new condition for threat models older than 90 days — the prompt notes them as potentially stale but proceeds with the existing file.
- **Clarified existing model path**: The "exists and current" case is now explicitly labeled for clarity.
## Implementation Details
Single file change in `src/create-prompt/templates/security-review-prompt.ts`, modifying the "Step 1: Threat Model Check" section of the security review prompt template (+3 / −2 lines).
## Testing
[To be filled by author]
## Related Issues
[To be filled by author]