### PR TITLE
STRIDE enforcement for first step of security workflow

### DIFF
--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -49,9 +49,20 @@ You have access to security skills from the security-engineer plugin (security-e
 
 ### Step 1: Threat Model Check
 - Check if \`.factory/threat-model.md\` exists in the repository
-- If missing: Invoke the **threat-model-generation** skill to generate one, then use it as context
-- If exists but older than 90 days: Note it may be stale, but proceed with existing
-- If exists and current: Use it as context for the security scan
+- If exists: Read it and use it as context for the security scan
+- If missing: Invoke the **threat-model-generation** skill to build a STRIDE threat model in-session before proceeding. Specifically:
+  1. Scan the repository structure to identify key components (APIs, services, databases, auth systems, external integrations)
+  2. Identify trust boundaries (e.g., client/server, internal/external, authenticated/unauthenticated)
+  3. Map data flows across those boundaries (user input paths, API endpoints, file I/O, network calls)
+  4. For each STRIDE category, identify the top attack surfaces relevant to this codebase:
+     - **Spoofing**: Auth mechanisms, session management, token handling
+     - **Tampering**: Input validation points, database queries, file operations
+     - **Repudiation**: Logging and audit trail coverage
+     - **Information Disclosure**: Error handling, secrets management, data exposure paths
+     - **Denial of Service**: Rate limiting, resource-intensive operations, unbounded inputs
+     - **Elevation of Privilege**: Authorization checks, role-based access, privilege boundaries
+  5. Use this threat model analysis as context when scanning the PR diff in subsequent steps
+  - Do NOT mention the missing threat model file in the summary comment — just generate the analysis silently and proceed
 
 ### Step 2: Security Scan
 - Invoke the **commit-security-scan** skill on the PR diff


### PR DESCRIPTION
## Summary
Enhances the security workflow's first step (Threat Model Check) by replacing the brief fallback instruction with detailed STRIDE-based threat-modeling guidance when `.factory/threat-model.md` is missing from the repository.
## Changes
- **Expanded missing-threat-model path**: When no threat model file exists, the prompt now instructs Droid to build a full STRIDE threat model in-session before proceeding with the security scan. The instructions cover:
  1. Scanning the repository structure for key components
  2. Identifying trust boundaries
  3. Mapping data flows across those boundaries
  4. Enumerating attack surfaces for each STRIDE category (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
  5. Using the generated analysis as context for subsequent scan steps
- **Simplified existing-file path**: When the threat model file already exists, the prompt now simply reads and uses it — the previous staleness check (older than 90 days) has been removed.
- **Silent generation**: Added instruction to not mention the missing threat model file in the summary comment, keeping the output clean.
## Implementation Details
All changes are in the security review prompt template (`src/create-prompt/templates/security-review-prompt.ts`), specifically the "Step 1: Threat Model Check" section. No runtime logic or API changes — this is purely a prompt content update.
## Testing
[To be filled by author]
## Related Issues
[To be filled by author]