### PR TITLE
fix: create prompt file when both automatic review flags are set

### DIFF
--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -103,13 +103,11 @@ export async function prepareTagExecution({
   );
   const commentId = commentData.id;
 
-  // Handle parallel review mode when both flags are set
+  // Handle when both automatic review flags are set
   if (
     context.inputs.automaticReview &&
     context.inputs.automaticSecurityReview
   ) {
-    // Output flags for parallel workflow jobs
-    const runCodeReview = true;
     let runSecurityReview = true;
 
     // Check if security review already exists on this PR (run once behavior)
@@ -121,19 +119,16 @@ export async function prepareTagExecution({
       runSecurityReview = false;
     }
 
-    // Set outputs for downstream jobs
-    core.setOutput("run_code_review", runCodeReview.toString());
+    core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", runSecurityReview.toString());
 
-    // For parallel mode, return early - individual jobs will run their own reviews
-    return {
-      skipped: false,
-      branchInfo: {
-        baseBranch: "",
-        currentBranch: "",
-      },
-      mcpTools: "",
-    };
+    // Prepare the code review (creates prompt file needed by the Droid Exec step)
+    return prepareReviewMode({
+      context,
+      octokit,
+      githubToken,
+      trackingCommentId: commentId,
+    });
   }
 
   if (context.inputs.automaticReview) {


### PR DESCRIPTION
## Problem

When both `automatic_review: true` and `automatic_security_review: true` are set, `prepareTagExecution()` returned early without creating a prompt file, causing the "Run Droid Exec" step to fail with:

```
Prompt file '/home/runner/_work/_temp/droid-prompts/droid-prompt.txt' does not exist.
```

Repro: https://github.com/Factory-AI/factory-mono/actions/runs/23825974314/job/69449081451

The early return was left by a "parallel mode" design (separate jobs for code review and security review) that was never implemented. The `action.yml` is a single composite action with no step that reads `run_security_review`, so the early return just skipped prompt creation and nothing picked up the slack.

## Fix

When both flags are set, call `prepareReviewMode()` instead of returning early. This creates the prompt file and runs code review normally. The `run_security_review` output is still set but has no effect since no step in `action.yml` consumes it -- security review was never running in this configuration anyway.

---

Resolves [FAC-18342](https://linear.app/factoryai/issue/FAC-18342/add-enable-security-review-parameter-to-droid-action-github-workflow)