### PR TITLE
feat: move security review to skill + run concurrently with code review

### DIFF
--- a/.factory/droids/security-reviewer.md
+++ b/.factory/droids/security-reviewer.md
@@ -1,0 +1,65 @@
+---
+name: security-reviewer
+description: Performs security-focused review of PR changes. Spawned as a parallel subagent alongside code review file-group-reviewers to identify security vulnerabilities.
+model: inherit
+tools: ["Read", "Grep", "Glob", "LS", "Skill"]
+---
+
+You are a senior security engineer performing a security-focused code review.
+
+Your task: Review the PR diff provided below and identify **high-confidence security vulnerabilities**.
+
+<workflow>
+1. **Load security review methodology (REQUIRED)**: Before starting, invoke the `security-review` skill using the Skill tool. This is your FIRST action — do not read any files before doing this. The skill provides the STRIDE threat model categories, severity definitions, and analysis methodology you must follow.
+2. Read each changed file in full to understand the security context
+3. Read the relevant diff sections provided in the prompt
+4. Trace data flows across file boundaries, especially where user input is involved:
+   - Follow input from request handlers through processing to database/output
+   - Check authentication and authorization at each trust boundary
+   - Identify injection points where untrusted data enters trusted contexts
+5. Read related files as needed:
+   - Authentication/authorization middleware and decorators
+   - Input validation schemas and sanitization utilities
+   - Database query builders and ORM configurations
+   - Security configuration files
+6. Analyze the changes for security vulnerabilities using the STRIDE methodology from the skill
+7. For each vulnerability found, verify the data flow and confirm exploitability before including it
+</workflow>
+
+<output_format>
+Return your findings as a JSON array (no wrapper object, just the array):
+
+```json
+[
+  {
+    "path": "src/api/users.ts",
+    "body": "[P1] [T] SQL injection via unsanitized user input\n\nThe search parameter is concatenated directly into the SQL query without parameterization, allowing an attacker to inject arbitrary SQL.",
+    "line": 42,
+    "startLine": null,
+    "side": "RIGHT"
+  }
+]
+```
+
+If no security issues found, return an empty array: `[]`
+
+Field definitions:
+
+- `path`: Relative file path (must match exactly as provided in your assignment)
+- `body`: Comment text starting with priority tag [P0|P1|P2|P3], then STRIDE category tag [S|T|R|I|D|E], then title, then 1 paragraph explanation
+  - P0: Critical — immediately exploitable (RCE, auth bypass, hardcoded secrets)
+  - P1: High — exploitable with conditions (SQL injection behind auth, stored XSS)
+  - P2: Medium — requires specific conditions (CSRF, info disclosure)
+  - P3: Low — minor security concern
+- `line`: Target line number (single-line) or end line number (multi-line). Must be >= 0.
+- `startLine`: `null` for single-line comments, or start line number for multi-line comments
+- `side`: "RIGHT" for new/modified code (default), "LEFT" only for commenting on removed code
+  </output_format>
+
+<constraints>
+- Output ONLY the JSON array — no additional commentary or markdown formatting around it.
+- Do not include `commit_id` in your output — the parent agent will add this.
+- Do not attempt to post comments to GitHub — just return the JSON array.
+- Focus exclusively on security vulnerabilities, not code quality or style.
+- Only report findings with high confidence and a realistic exploit path.
+</constraints>

--- a/.factory/droids/security-reviewer.md
+++ b/.factory/droids/security-reviewer.md
@@ -33,7 +33,7 @@ Return your findings as a JSON array (no wrapper object, just the array):
 [
   {
     "path": "src/api/users.ts",
-    "body": "[P1] [T] SQL injection via unsanitized user input\n\nThe search parameter is concatenated directly into the SQL query without parameterization, allowing an attacker to inject arbitrary SQL.",
+    "body": "[P1] [security] SQL injection via unsanitized user input\n\nThe search parameter is concatenated directly into the SQL query without parameterization, allowing an attacker to inject arbitrary SQL.",
     "line": 42,
     "startLine": null,
     "side": "RIGHT"
@@ -46,7 +46,7 @@ If no security issues found, return an empty array: `[]`
 Field definitions:
 
 - `path`: Relative file path (must match exactly as provided in your assignment)
-- `body`: Comment text starting with priority tag [P0|P1|P2|P3], then STRIDE category tag [S|T|R|I|D|E], then title, then 1 paragraph explanation
+- `body`: Comment text starting with priority tag [P0|P1|P2|P3], then `[security]` tag, then title, then 1 paragraph explanation
   - P0: Critical — immediately exploitable (RCE, auth bypass, hardcoded secrets)
   - P1: High — exploitable with conditions (SQL injection behind auth, stored XSS)
   - P2: Medium — requires specific conditions (CSRF, info disclosure)

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,7 +25,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@feat/security-review-as-skill-with-concurrent-execution
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
+          automatic_security_review: true

--- a/README.md
+++ b/README.md
@@ -150,22 +150,22 @@ Set `automatic_review: true` to run code reviews automatically on non-draft PRs.
 
 ### Review Configuration
 
-| Input              | Default | Purpose                                                                                                |
-| ------------------ | ------- | ------------------------------------------------------------------------------------------------------ |
-| `automatic_review` | `false` | Automatically run code review on PRs without requiring `@droid review`.                                |
-| `review_depth`     | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below.  |
-| `review_model`     | `""`    | Override the model for code review. When empty, determined by `review_depth`.                          |
-| `reasoning_effort`  | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                        |
-| `fill_model`       | `""`    | Override the model used for PR description fill.                                                       |
+| Input              | Default | Purpose                                                                                              |
+| ------------------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `automatic_review` | `false` | Automatically run code review on PRs without requiring `@droid review`.                              |
+| `review_depth`     | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below. |
+| `review_model`     | `""`    | Override the model for code review. When empty, determined by `review_depth`.                        |
+| `reasoning_effort` | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                      |
+| `fill_model`       | `""`    | Override the model used for PR description fill.                                                     |
 
 ### Review Depth
 
 The `review_depth` input controls which model and reasoning effort are used for code reviews. Two presets are available:
 
-| Depth      | Model           | Reasoning Effort | Best For                                              |
-| ---------- | --------------- | ---------------- | ----------------------------------------------------- |
-| **deep**   | `gpt-5.2`       | `high`           | Thorough reviews catching subtle bugs and design issues |
-| **shallow** | `kimi-k2-0711` | default          | Fast, cost-effective reviews for straightforward PRs   |
+| Depth       | Model          | Reasoning Effort | Best For                                                |
+| ----------- | -------------- | ---------------- | ------------------------------------------------------- |
+| **deep**    | `gpt-5.2`      | `high`           | Thorough reviews catching subtle bugs and design issues |
+| **shallow** | `kimi-k2-0711` | default          | Fast, cost-effective reviews for straightforward PRs    |
 
 **Examples:**
 
@@ -200,13 +200,13 @@ The depth presets are defined in [`src/utils/review-depth.ts`](src/utils/review-
 
 ```typescript
 const SHALLOW_DEFAULTS = {
-  model: "kimi-k2-0711",        // Change to any supported model
-  reasoningEffort: undefined,    // undefined = use model default
+  model: "kimi-k2-0711", // Change to any supported model
+  reasoningEffort: undefined, // undefined = use model default
 };
 
 const DEEP_DEFAULTS = {
-  model: "gpt-5.2",             // Change to any supported model
-  reasoningEffort: "high",       // "high" | "medium" | "low" | undefined
+  model: "gpt-5.2", // Change to any supported model
+  reasoningEffort: "high", // "high" | "medium" | "low" | undefined
 };
 ```
 

--- a/security/action.yml
+++ b/security/action.yml
@@ -32,11 +32,35 @@ inputs:
     description: "Path to write security results JSON"
     required: false
     default: ""
+  review_candidates_path:
+    description: "Path to write review candidates JSON (pass 1)."
+    required: false
+    default: "${{ runner.temp }}/droid-prompts/review_candidates.json"
+  review_validated_path:
+    description: "Path to write review validated JSON (pass 2)."
+    required: false
+    default: "${{ runner.temp }}/droid-prompts/review_validated.json"
+  review_depth:
+    description: "Review depth preset for the validator."
+    required: false
+    default: "deep"
+  review_model:
+    description: "Override the model used for the validator."
+    required: false
+    default: ""
+  reasoning_effort:
+    description: "Override reasoning effort for the validator."
+    required: false
+    default: ""
+  include_suggestions:
+    description: "Include code suggestion blocks in review comments."
+    required: false
+    default: "false"
 
 outputs:
   conclusion:
     description: "Review conclusion (success/failure)"
-    value: ${{ steps.review.outputs.conclusion }}
+    value: ${{ steps.validator.outputs.conclusion }}
 
 runs:
   using: "composite"
@@ -102,6 +126,15 @@ runs:
         rm -rf "$TEMP_DIR"
         echo "Security skills installation complete"
 
+    - name: Setup Custom Droids
+      shell: bash
+      run: |
+        mkdir -p ~/.factory/droids
+        if [ -d "${{ github.action_path }}/../.factory/droids" ]; then
+          cp -r ${{ github.action_path }}/../.factory/droids/* ~/.factory/droids/
+          echo "Copied custom droids to ~/.factory/droids/"
+        fi
+
     - name: Generate Security Prompt
       id: prompt
       shell: bash
@@ -115,6 +148,8 @@ runs:
         SECURITY_BLOCK_ON_CRITICAL: ${{ inputs.security_block_on_critical }}
         SECURITY_BLOCK_ON_HIGH: ${{ inputs.security_block_on_high }}
         REVIEW_TYPE: "security"
+        REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
 
     - name: Run Security Review
@@ -129,3 +164,46 @@ runs:
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
+
+    - name: Prepare Validator
+      id: prepare_validator
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/prepare-validator.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
+        REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
+        REVIEW_MODEL: ${{ inputs.review_model }}
+        REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+
+    - name: Run Validator
+      id: validator
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../base-action/src/index.ts
+      env:
+        INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
+        INPUT_DROID_ARGS: ${{ steps.prepare_validator.outputs.droid_args }}
+        INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+
+    - name: Update tracking comment
+      if: always() && inputs.tracking_comment_id
+      continue-on-error: true
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/update-comment-link.ts
+      env:
+        DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        OUTPUT_FILE: ${{ inputs.output_file }}
+        TRIGGER_USERNAME: ${{ github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
+        PREPARE_SUCCESS: "true"
+        DROID_SUCCESS: ${{ steps.validator.outcome == 'success' }}

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -60,7 +60,7 @@ Spawn it with:
 
 **IMPORTANT**: Spawn the security-reviewer in the SAME response as the file-group-reviewer subagents so they all run in parallel.
 
-After all subagents complete (both file-group-reviewers and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but include STRIDE category tags in their body (e.g., \`[P1] [T] Title\`).
+After all subagents complete (both file-group-reviewers and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but are prefixed with \`[security]\` in their body (e.g., \`[P1] [security] Title\`).
 `
     : "";
 

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -43,11 +43,32 @@ export function generateReviewCandidatesPrompt(
     ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure — including suggestion block rules."
     : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure. Do NOT include code suggestion blocks.";
 
+  const securityReviewEnabled = process.env.SECURITY_REVIEW_ENABLED === "true";
+
+  const securitySubagentInstruction = securityReviewEnabled
+    ? `
+
+## Security Review (run concurrently)
+
+In addition to the code review, you MUST also spawn a \`security-reviewer\` subagent via the Task tool.
+This subagent runs **concurrently** with the file-group-reviewer subagents during Step 2.
+
+Spawn it with:
+- \`subagent_type\`: "security-reviewer"
+- \`description\`: "Security review"
+- \`prompt\`: Include the full PR context (repo, PR number, head SHA, base ref) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
+
+**IMPORTANT**: Spawn the security-reviewer in the SAME response as the file-group-reviewer subagents so they all run in parallel.
+
+After all subagents complete (both file-group-reviewers and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but include STRIDE category tags in their body (e.g., \`[P1] [T] Title\`).
+`
+    : "";
+
   return `You are a senior staff software engineer and expert code reviewer.
 
 Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
 
-${skillInstruction}
+${skillInstruction}${securitySubagentInstruction}
 
 <context>
 Repo: ${repoFullName}

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -126,6 +126,7 @@ After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "a
 * Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
 * Do **NOT** include a \`body\` parameter in \`submit_review\`.
 * Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary.
+* If any approved comments contain \`[security]\` in their body, prepend a security badge to the tracking comment: \`![Security Review](https://img.shields.io/badge/security%20review-ran-blue)\`. This indicates that security analysis was performed as part of the review.
 * Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 * Do not approve or request changes.
 `;

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -62,7 +62,7 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
   "comments": [
     {
       "path": "src/index.ts",
-      "body": "[P1] [T] Title\\n\\n1 paragraph.",
+      "body": "[P1] [security] Title\\n\\n1 paragraph.",
       "line": 42,
       "startLine": null,
       "side": "RIGHT",
@@ -87,7 +87,7 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
 
 - **comments**: Array of comment objects
   - \`path\`: Relative file path
-  - \`body\`: Comment text starting with priority tag [P0|P1|P2|P3] and STRIDE category [S|T|R|I|D|E], then title, then 1 paragraph explanation
+  - \`body\`: Comment text starting with priority tag [P0|P1|P2|P3] and \`[security]\` tag, then title, then 1 paragraph explanation
   - \`line\`: Target line number (single-line) or end line number (multi-line). Must be >= 0.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
   - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -1,6 +1,8 @@
 import type { PreparedContext } from "../types";
 
-export function generateSecurityReviewPrompt(context: PreparedContext): string {
+export function generateSecurityCandidatesPrompt(
+  context: PreparedContext,
+): string {
   const prNumber = context.eventData.isPR
     ? context.eventData.prNumber
     : context.githubContext && "entityNumber" in context.githubContext
@@ -8,161 +10,99 @@ export function generateSecurityReviewPrompt(context: PreparedContext): string {
       : "unknown";
 
   const repoFullName = context.repository;
-  const headRefName = context.prBranchData?.headRefName ?? "unknown";
-  const headSha = context.prBranchData?.headRefOid ?? "unknown";
-  const baseRefName = context.eventData.baseBranch ?? "unknown";
+  const prHeadRef = context.prBranchData?.headRefName ?? "unknown";
+  const prHeadSha = context.prBranchData?.headRefOid ?? "unknown";
+  const prBaseRef = context.eventData.baseBranch ?? "unknown";
 
-  // Extract security configuration from context
-  const securityConfig = context.githubContext?.inputs;
-  const severityThreshold =
-    securityConfig?.securitySeverityThreshold ?? "medium";
-  const blockOnCritical = securityConfig?.securityBlockOnCritical ?? true;
-  const blockOnHigh = securityConfig?.securityBlockOnHigh ?? false;
-  const notifyTeam = securityConfig?.securityNotifyTeam ?? "";
+  const diffPath =
+    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
+  const commentsPath =
+    context.reviewArtifacts?.commentsPath ??
+    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
+  const descriptionPath =
+    context.reviewArtifacts?.descriptionPath ??
+    "$RUNNER_TEMP/droid-prompts/pr_description.txt";
 
-  return `You are performing a security-focused code review for PR #${prNumber} in ${repoFullName}.
-The gh CLI is installed and authenticated via GH_TOKEN.
+  const reviewCandidatesPath =
+    process.env.REVIEW_CANDIDATES_PATH ??
+    "$RUNNER_TEMP/droid-prompts/review_candidates.json";
 
-## Context
-- Repo: ${repoFullName}
-- PR Number: ${prNumber}
-- PR Head Ref: ${headRefName}
-- PR Head SHA: ${headSha}
-- PR Base Ref: ${baseRefName}
+  return `You are a senior security engineer performing a security-focused code review.
 
-## Security Configuration
-- Severity Threshold: ${severityThreshold} (only report findings at or above this level)
-- Block on Critical: ${blockOnCritical}
-- Block on High: ${blockOnHigh}
-${notifyTeam ? `- Notify Team: ${notifyTeam} (mention on critical findings)` : ""}
+Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence security vulnerability** findings.
 
-## Security Skills Available
+Invoke the 'security-review' skill to load the security review methodology, then execute its **Pass 1: Candidate Generation** procedure.
 
-You have access to these Factory security skills (installed in ~/.factory/skills/):
+<context>
+Repo: ${repoFullName}
+PR Number: ${prNumber}
+PR Head Ref: ${prHeadRef}
+PR Head SHA: ${prHeadSha}
+PR Base Ref: ${prBaseRef}
 
-1. **threat-model-generation** - Generate STRIDE-based threat model for the repository
-2. **commit-security-scan** - Scan code changes for security vulnerabilities
-3. **vulnerability-validation** - Validate findings, assess exploitability, filter false positives
-4. **security-review** - Comprehensive security review and patch generation
+Precomputed data files:
+- PR Description: \`${descriptionPath}\`
+- Full PR Diff: \`${diffPath}\`
+- Existing Comments: \`${commentsPath}\`
+</context>
 
-## Review Workflow
+<output_spec>
+Write output to \`${reviewCandidatesPath}\` using this exact schema:
 
-### Step 1: Threat Model Check
-- Check if \`.factory/threat-model.md\` exists in the repository
-- If missing: Note this in the summary (threat model generation is done separately, not during PR review)
-- If exists: Use it as context for the security scan
-
-### Step 2: Security Scan
-- Invoke the **commit-security-scan** skill on the PR diff
-- Gather the PR diff using: \`gh pr diff ${prNumber} --repo ${repoFullName}\`
-- Get file changes: \`gh api repos/${repoFullName}/pulls/${prNumber}/files --paginate\`
-- Focus analysis on:
-  - New code introduced by this PR
-  - Modified code that may introduce vulnerabilities
-  - Changes that expose existing vulnerabilities
-
-### Step 3: Validate Findings
-- For each finding from Step 2, invoke the **vulnerability-validation** skill
-- Assess:
-  - Reachability: Is the vulnerable code reachable from user input?
-  - Exploitability: How easy is it to exploit?
-  - Impact: What's the potential damage?
-- Filter out false positives and findings below the severity threshold (${severityThreshold})
-
-### Step 4: Report Findings
-- For each confirmed finding at or above ${severityThreshold} severity:
-  - Record in the JSON output file
-  - Include: severity, STRIDE category, CWE ID, clear explanation, suggested fix
-- For auto-fixable issues: Include the suggested patch in the finding's suggestion field
-
-## Security Scope (STRIDE Categories)
-
-**Spoofing** (S):
-- Weak authentication, session hijacking, token exposure
-
-**Tampering** (T):
-- SQL/NoSQL/command injection, XSS, mass assignment, unsafe deserialization
-
-**Repudiation** (R):
-- Missing audit logs, unsigned transactions
-
-**Information Disclosure** (I):
-- IDOR, verbose errors, hardcoded secrets, sensitive data in logs
-
-**Denial of Service** (D):
-- Missing rate limits, resource exhaustion, ReDoS
-
-**Elevation of Privilege** (E):
-- Missing authorization checks, role manipulation, privilege escalation
-
-## Severity Definitions
-
-| Severity | Criteria | Examples |
-|----------|----------|----------|
-| **CRITICAL** | Immediately exploitable, high impact, no auth required | RCE, hardcoded secrets, auth bypass |
-| **HIGH** | Exploitable with conditions, significant impact | SQL injection, stored XSS, IDOR |
-| **MEDIUM** | Requires specific conditions, moderate impact | CSRF, info disclosure, missing rate limits |
-| **LOW** | Difficult to exploit, low impact | Verbose errors, missing security headers |
-
-## Output Requirements
-
-IMPORTANT: Do NOT post inline comments directly. Instead, write findings to a JSON file.
-The finalize step will post all inline comments to avoid overlapping with code review comments.
-
-1. Write findings to \`${context.outputFilePath || "security-review-results.json"}\` with this structure:
 \`\`\`json
 {
-  "type": "security",
-  "findings": [
+  "version": 1,
+  "meta": {
+    "repo": "owner/repo",
+    "prNumber": 123,
+    "headSha": "<head sha>",
+    "baseRef": "main",
+    "generatedAt": "<ISO timestamp>"
+  },
+  "comments": [
     {
-      "id": "SEC-001",
-      "severity": "CRITICAL|HIGH|MEDIUM|LOW",
-      "type": "SQL Injection",
-      "stride": "T",
-      "cwe": "CWE-89",
-      "file": "path/to/file.ts",
-      "line": 55,
+      "path": "src/index.ts",
+      "body": "[P1] [T] Title\\n\\n1 paragraph.",
+      "line": 42,
+      "startLine": null,
       "side": "RIGHT",
-      "description": "Brief description of the vulnerability",
-      "suggestion": "Optional code fix"
+      "commit_id": "<head sha>"
     }
   ],
-  "summary": "Brief overall summary",
-  "block_pr": ${blockOnCritical || blockOnHigh ? "true if CRITICAL/HIGH found" : "false"}
+  "reviewSummary": {
+    "body": "1-3 sentence security assessment"
+  }
 }
 \`\`\`
 
-2. Update the tracking comment using \`github_comment___update_droid_comment\`
+<schema_details>
+- **version**: Always \`1\`
 
-## Summary Format (for tracking comment update)
+- **meta**: Metadata object
+  - \`repo\`: "${repoFullName}"
+  - \`prNumber\`: ${prNumber}
+  - \`headSha\`: "${prHeadSha}"
+  - \`baseRef\`: "${prBaseRef}"
+  - \`generatedAt\`: ISO 8601 timestamp
 
-Use \`github_comment___update_droid_comment\` to update the tracking comment with this format:
+- **comments**: Array of comment objects
+  - \`path\`: Relative file path
+  - \`body\`: Comment text starting with priority tag [P0|P1|P2|P3] and STRIDE category [S|T|R|I|D|E], then title, then 1 paragraph explanation
+  - \`line\`: Target line number (single-line) or end line number (multi-line). Must be >= 0.
+  - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
+  - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code
+  - \`commit_id\`: "${prHeadSha}"
 
-\`\`\`markdown
-## 🔐 Security Review Summary
+- **reviewSummary**:
+  - \`body\`: 1-3 sentence security assessment
+</schema_details>
+</output_spec>
 
-| Severity | Count |
-|----------|-------|
-| 🚨 CRITICAL | X |
-| 🔴 HIGH | X |
-| 🟡 MEDIUM | X |
-| 🟢 LOW | X |
-
-### Findings
-| ID | Severity | Type | File | Line | Reference |
-|----|----------|------|------|------|-----------|
-| SEC-001 | CRITICAL | SQL Injection | auth.ts | 55 | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) |
-| SEC-002 | HIGH | XSS | client.ts | 98 | [CWE-79](https://cwe.mitre.org/data/definitions/79.html) |
-
-${notifyTeam ? `cc ${notifyTeam}` : ""}
-\`\`\`
-
-## Accuracy Requirements
-
-- Base findings strictly on the current diff and repository context
-- False positives are very costly—only report high-confidence findings
-- If confidence is low, ask a clarifying question instead of asserting a vulnerability
-- Never raise purely stylistic concerns
-- Cap at 10 inline comments total
+<critical_constraints>
+**DO NOT** post to GitHub.
+**DO NOT** invoke any PR mutation tools (inline comments, submit review, delete/minimize/reply/resolve, etc.).
+**DO NOT** modify any files other than writing to \`${reviewCandidatesPath}\`.
+Output ONLY the JSON file — no additional commentary.
+</critical_constraints>
 `;
 }

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -13,7 +13,7 @@ import { computeReviewArtifacts } from "../github/data/review-artifacts";
 import { createPrompt } from "../create-prompt";
 import { prepareMcpTools } from "../mcp/install-mcp-server";
 import { generateReviewCandidatesPrompt } from "../create-prompt/templates/review-candidates-prompt";
-import { generateSecurityReviewPrompt } from "../create-prompt/templates/security-review-prompt";
+import { generateSecurityCandidatesPrompt } from "../create-prompt/templates/security-review-prompt";
 import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
 import { resolveReviewConfig } from "../utils/review-depth";
 
@@ -91,7 +91,7 @@ async function run() {
     // Select prompt generator based on review type
     const generatePrompt =
       reviewType === "security"
-        ? generateSecurityReviewPrompt
+        ? generateSecurityCandidatesPrompt
         : generateReviewCandidatesPrompt;
 
     // Pass the output file path so the prompt can instruct the Droid
@@ -139,19 +139,15 @@ async function run() {
 
     // Task tool is needed for parallel subagent reviews in candidate generation phase.
     // FetchUrl is needed to fetch linked tickets from the PR description.
-    // Skill is needed so file-group-reviewer subagents can invoke the review-guidelines skill.
-    const candidateGenerationTools =
-      reviewType === "code" ? ["Task", "FetchUrl", "Skill"] : [];
+    // Skill is needed so subagents can invoke review/security-review skills.
+    const candidateGenerationTools = ["Task", "FetchUrl", "Skill"];
 
-    const safeUserAllowedMCPTools =
-      reviewType === "code"
-        ? userAllowedMCPTools.filter(
-            (tool) =>
-              tool === "github_comment___update_droid_comment" ||
-              (!tool.startsWith("github_pr___") &&
-                tool !== "github_inline_comment___create_inline_comment"),
-          )
-        : userAllowedMCPTools;
+    const safeUserAllowedMCPTools = userAllowedMCPTools.filter(
+      (tool) =>
+        tool === "github_comment___update_droid_comment" ||
+        (!tool.startsWith("github_pr___") &&
+          tool !== "github_inline_comment___create_inline_comment"),
+    );
 
     const allowedTools = Array.from(
       new Set([
@@ -200,7 +196,8 @@ async function run() {
     // Output for next step - use core.setOutput which handles GITHUB_OUTPUT internally
     core.setOutput("droid_args", droidArgParts.join(" ").trim());
     core.setOutput("mcp_tools", mcpTools);
-    core.setOutput("review_use_validator", (reviewType === "code").toString());
+    // Both code and security reviews use the two-pass pipeline (candidates + validator)
+    core.setOutput("review_use_validator", "true");
 
     console.log(`Generated ${reviewType} review prompt`);
   } catch (error) {

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -18,17 +18,21 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
-export type CommentType = "default" | "security";
+export type CommentType = "default" | "security" | "review_and_security";
 
 export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
   type: CommentType = "default",
 ): string {
-  const message =
-    type === "security"
-      ? "Droid is running a security check…"
-      : "Droid is working…";
+  let message: string;
+  if (type === "review_and_security") {
+    message = "Droid is reviewing code and running a security check…";
+  } else if (type === "security") {
+    message = "Droid is running a security check…";
+  } else {
+    message = "Droid is working…";
+  }
 
   return `${message}
 

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -1,12 +1,14 @@
 import * as core from "@actions/core";
+import { execSync } from "child_process";
 import type { GitHubContext } from "../../github/context";
 import { fetchPRBranchData } from "../../github/data/pr-fetcher";
+import { computeReviewArtifacts } from "../../github/data/review-artifacts";
 import { createPrompt } from "../../create-prompt";
 import { prepareMcpTools } from "../../mcp/install-mcp-server";
 import { createInitialComment } from "../../github/operations/comments/create-initial";
 import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import { isEntityContext } from "../../github/context";
-import { generateSecurityReviewPrompt } from "../../create-prompt/templates/security-review-prompt";
+import { generateSecurityCandidatesPrompt } from "../../create-prompt/templates/security-review-prompt";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 
@@ -48,6 +50,41 @@ export async function prepareSecurityReviewMode({
     currentBranch: prData.headRefName,
   };
 
+  // Checkout the PR branch before computing diff
+  console.log(
+    `Checking out PR #${context.entityNumber} branch for diff computation...`,
+  );
+  try {
+    execSync("git reset --hard HEAD", { encoding: "utf8", stdio: "pipe" });
+    execSync(`gh pr checkout ${context.entityNumber}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+      env: { ...process.env, GH_TOKEN: githubToken },
+    });
+    console.log(
+      `Successfully checked out PR branch: ${execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim()}`,
+    );
+  } catch (e) {
+    console.error(`Failed to checkout PR branch: ${e}`);
+    throw new Error(
+      `Failed to checkout PR #${context.entityNumber} branch for security review`,
+    );
+  }
+
+  // Pre-compute review artifacts (diff, existing comments, and PR description)
+  const tempDir = process.env.RUNNER_TEMP || "/tmp";
+  const reviewArtifacts = await computeReviewArtifacts({
+    baseRef: prData.baseRefName,
+    tempDir,
+    octokit,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    prNumber: context.entityNumber,
+    title: prData.title,
+    body: prData.body,
+    githubToken,
+  });
+
   await createPrompt({
     githubContext: context,
     commentId,
@@ -57,11 +94,11 @@ export async function prepareSecurityReviewMode({
       headRefName: prData.headRefName,
       headRefOid: prData.headRefOid,
     },
-    generatePrompt: generateSecurityReviewPrompt,
+    generatePrompt: generateSecurityCandidatesPrompt,
+    reviewArtifacts,
   });
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-security-review");
 
-  // Signal that security skills should be installed
   core.setOutput("install_security_skills", "true");
 
   const rawUserArgs = process.env.DROID_ARGS || "";
@@ -76,21 +113,27 @@ export async function prepareSecurityReviewMode({
     "Glob",
     "LS",
     "Execute",
+    "Edit",
+    "Create",
+    "ApplyPatch",
     "github_comment___update_droid_comment",
-    "github_inline_comment___create_inline_comment",
   ];
 
-  const reviewTools = [
-    "github_pr___list_review_comments",
-    "github_pr___submit_review",
-    "github_pr___delete_comment",
-    "github_pr___minimize_comment",
-    "github_pr___reply_to_comment",
-    "github_pr___resolve_review_thread",
-  ];
+  const candidateGenerationTools = ["Task", "FetchUrl", "Skill"];
+
+  const safeUserAllowedMCPTools = userAllowedMCPTools.filter(
+    (tool) =>
+      tool === "github_comment___update_droid_comment" ||
+      (!tool.startsWith("github_pr___") &&
+        tool !== "github_inline_comment___create_inline_comment"),
+  );
 
   const allowedTools = Array.from(
-    new Set([...baseTools, ...reviewTools, ...userAllowedMCPTools]),
+    new Set([
+      ...baseTools,
+      ...candidateGenerationTools,
+      ...safeUserAllowedMCPTools,
+    ]),
   );
 
   const mcpTools = await prepareMcpTools({
@@ -105,8 +148,8 @@ export async function prepareSecurityReviewMode({
 
   const droidArgParts: string[] = [];
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
+  droidArgParts.push('--tag "code-review"');
 
-  // Add model override if specified (prefer SECURITY_MODEL, fallback to REVIEW_MODEL)
   const securityModel =
     process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim();
   if (securityModel) {
@@ -119,6 +162,8 @@ export async function prepareSecurityReviewMode({
 
   core.setOutput("droid_args", droidArgParts.join(" ").trim());
   core.setOutput("mcp_tools", mcpTools);
+  core.setOutput("review_pr_number", context.entityNumber.toString());
+  core.setOutput("droid_comment_id", commentId.toString());
 
   return {
     commentId,

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -90,16 +90,25 @@ export async function prepareTagExecution({
 
   const commandContext = extractCommandFromContext(context);
 
-  // Determine if this is a security-related command for the initial comment
-  const isSecurityCommand =
-    context.inputs.automaticSecurityReview ||
-    commandContext?.command === "security" ||
-    commandContext?.command === "security-full";
+  // Determine comment type based on what's being run
+  const isDualReview =
+    context.inputs.automaticReview && context.inputs.automaticSecurityReview;
+  const isSecurityOnly =
+    !isDualReview &&
+    (context.inputs.automaticSecurityReview ||
+      commandContext?.command === "security" ||
+      commandContext?.command === "security-full");
+
+  const commentType = isDualReview
+    ? "review_and_security"
+    : isSecurityOnly
+      ? "security"
+      : "default";
 
   const commentData = await createInitialComment(
     octokit.rest,
     context,
-    isSecurityCommand ? "security" : "default",
+    commentType,
   );
   const commentId = commentData.id;
 

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -119,10 +119,16 @@ export async function prepareTagExecution({
       runSecurityReview = false;
     }
 
+    if (runSecurityReview) {
+      // Signal to the code review prompt to spawn a security-reviewer subagent
+      core.exportVariable("SECURITY_REVIEW_ENABLED", "true");
+      core.setOutput("install_security_skills", "true");
+    }
+
     core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", runSecurityReview.toString());
 
-    // Prepare the code review (creates prompt file needed by the Droid Exec step)
+    // Prepare the code review (security review runs as a subagent within pass 1)
     return prepareReviewMode({
       context,
       octokit,
@@ -160,7 +166,8 @@ export async function prepareTagExecution({
       };
     }
 
-    core.setOutput("run_code_review", "false");
+    // Standalone security review uses the two-pass pipeline (candidates + validator)
+    core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", "true");
     return prepareSecurityReviewMode({
       context,
@@ -180,7 +187,8 @@ export async function prepareTagExecution({
   }
 
   if (commandContext?.command === "security") {
-    core.setOutput("run_code_review", "false");
+    // Standalone security review uses the two-pass pipeline (candidates + validator)
+    core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", "true");
     return prepareSecurityReviewMode({
       context,

--- a/test/create-prompt/templates/security-review-prompt.test.ts
+++ b/test/create-prompt/templates/security-review-prompt.test.ts
@@ -47,7 +47,7 @@ describe("generateSecurityCandidatesPrompt", () => {
     expect(prompt).toContain("comments");
     expect(prompt).toContain("reviewSummary");
     expect(prompt).toContain("commit_id");
-    expect(prompt).toContain("STRIDE");
+    expect(prompt).toContain("[security]");
   });
 
   it("includes critical constraints to not post to GitHub", () => {

--- a/test/create-prompt/templates/security-review-prompt.test.ts
+++ b/test/create-prompt/templates/security-review-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { generateSecurityReviewPrompt } from "../../../src/create-prompt/templates/security-review-prompt";
+import { generateSecurityCandidatesPrompt } from "../../../src/create-prompt/templates/security-review-prompt";
 import type { PreparedContext } from "../../../src/create-prompt/types";
 
 function createBaseContext(
@@ -21,83 +21,55 @@ function createBaseContext(
   } as PreparedContext;
 }
 
-describe("generateSecurityReviewPrompt", () => {
-  it("includes security context and skill workflow", () => {
-    const prompt = generateSecurityReviewPrompt(createBaseContext());
+describe("generateSecurityCandidatesPrompt", () => {
+  it("includes security context and skill invocation", () => {
+    const prompt = generateSecurityCandidatesPrompt(createBaseContext());
 
     expect(prompt).toContain("security-focused code review");
-    expect(prompt).toContain("## Security Skills Available");
-    expect(prompt).toContain("threat-model-generation");
-    expect(prompt).toContain("commit-security-scan");
-    expect(prompt).toContain("vulnerability-validation");
     expect(prompt).toContain("security-review");
-    expect(prompt).toContain("## Review Workflow");
-    expect(prompt).toContain("gh pr diff 42 --repo test-owner/test-repo");
-    expect(prompt).toContain(
-      "gh api repos/test-owner/test-repo/pulls/42/files",
-    );
-    expect(prompt).toContain("security-review-results.json");
-    expect(prompt).toContain("Do NOT post inline comments");
+    expect(prompt).toContain("Invoke the 'security-review' skill");
+    expect(prompt).toContain("Pass 1: Candidate Generation");
+    expect(prompt).toContain("DO NOT");
   });
 
-  it("lists STRIDE security categories", () => {
-    const prompt = generateSecurityReviewPrompt(createBaseContext());
+  it("includes PR context with correct values", () => {
+    const prompt = generateSecurityCandidatesPrompt(createBaseContext());
 
-    expect(prompt).toContain("Spoofing");
-    expect(prompt).toContain("Tampering");
-    expect(prompt).toContain("Repudiation");
-    expect(prompt).toContain("Information Disclosure");
-    expect(prompt).toContain("Denial of Service");
-    expect(prompt).toContain("Elevation of Privilege");
+    expect(prompt).toContain("PR Number: 42");
+    expect(prompt).toContain("test-owner/test-repo");
   });
 
-  it("includes severity definitions", () => {
-    const prompt = generateSecurityReviewPrompt(createBaseContext());
+  it("includes output spec with correct schema", () => {
+    const prompt = generateSecurityCandidatesPrompt(createBaseContext());
 
-    expect(prompt).toContain("CRITICAL");
-    expect(prompt).toContain("HIGH");
-    expect(prompt).toContain("MEDIUM");
-    expect(prompt).toContain("LOW");
+    expect(prompt).toContain("version");
+    expect(prompt).toContain("meta");
+    expect(prompt).toContain("comments");
+    expect(prompt).toContain("reviewSummary");
+    expect(prompt).toContain("commit_id");
+    expect(prompt).toContain("STRIDE");
   });
 
-  it("uses outputFilePath when provided", () => {
+  it("includes critical constraints to not post to GitHub", () => {
+    const prompt = generateSecurityCandidatesPrompt(createBaseContext());
+
+    expect(prompt).toContain("DO NOT** post to GitHub");
+    expect(prompt).toContain("DO NOT** invoke any PR mutation tools");
+  });
+
+  it("uses precomputed data files when review artifacts provided", () => {
     const context = createBaseContext({
-      outputFilePath: "/tmp/results/security-results.json",
+      reviewArtifacts: {
+        diffPath: "/tmp/droid-prompts/pr.diff",
+        commentsPath: "/tmp/droid-prompts/existing_comments.json",
+        descriptionPath: "/tmp/droid-prompts/pr_description.txt",
+      },
     });
 
-    const prompt = generateSecurityReviewPrompt(context);
+    const prompt = generateSecurityCandidatesPrompt(context);
 
-    expect(prompt).toContain("/tmp/results/security-results.json");
-    expect(prompt).not.toContain(
-      "Write findings to `security-review-results.json`",
-    );
-  });
-
-  it("falls back to default filename when outputFilePath is not set", () => {
-    const context = createBaseContext();
-
-    const prompt = generateSecurityReviewPrompt(context);
-
-    expect(prompt).toContain("security-review-results.json");
-  });
-
-  it("includes security configuration from context", () => {
-    const contextWithConfig = createBaseContext({
-      githubContext: {
-        inputs: {
-          securitySeverityThreshold: "high",
-          securityBlockOnCritical: true,
-          securityBlockOnHigh: true,
-          securityNotifyTeam: "@org/security-team",
-        },
-      } as any,
-    });
-
-    const prompt = generateSecurityReviewPrompt(contextWithConfig);
-
-    expect(prompt).toContain("Severity Threshold: high");
-    expect(prompt).toContain("Block on Critical: true");
-    expect(prompt).toContain("Block on High: true");
-    expect(prompt).toContain("@org/security-team");
+    expect(prompt).toContain("/tmp/droid-prompts/pr.diff");
+    expect(prompt).toContain("/tmp/droid-prompts/existing_comments.json");
+    expect(prompt).toContain("/tmp/droid-prompts/pr_description.txt");
   });
 });

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -8,6 +8,7 @@ import * as createInitial from "../../src/github/operations/comments/create-init
 import * as mcpInstaller from "../../src/mcp/install-mcp-server";
 import * as actorValidation from "../../src/github/validation/actor";
 import * as promptModule from "../../src/create-prompt";
+import * as reviewArtifactsModule from "../../src/github/data/review-artifacts";
 import * as core from "@actions/core";
 import * as childProcess from "node:child_process";
 
@@ -22,6 +23,7 @@ describe("review command integration", () => {
   let setOutputSpy: ReturnType<typeof spyOn>;
   let exportVarSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
+  let computeArtifactsSpy: ReturnType<typeof spyOn>;
   let execSyncSpy: ReturnType<typeof spyOn>;
 
   beforeEach(async () => {
@@ -37,6 +39,14 @@ describe("review command integration", () => {
     mcpSpy = spyOn(mcpInstaller, "prepareMcpTools").mockResolvedValue("{}");
     actorSpy = spyOn(actorValidation, "checkHumanActor").mockResolvedValue();
     promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
+    computeArtifactsSpy = spyOn(
+      reviewArtifactsModule,
+      "computeReviewArtifacts",
+    ).mockResolvedValue({
+      diffPath: `${tmpDir}/droid-prompts/pr.diff`,
+      commentsPath: `${tmpDir}/droid-prompts/existing_comments.json`,
+      descriptionPath: `${tmpDir}/droid-prompts/pr_description.txt`,
+    });
     setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
     exportVarSpy = spyOn(core, "exportVariable").mockImplementation(() => {});
 
@@ -57,6 +67,7 @@ describe("review command integration", () => {
     mcpSpy.mockRestore();
     actorSpy.mockRestore();
     promptSpy.mockRestore();
+    computeArtifactsSpy.mockRestore();
     setOutputSpy.mockRestore();
     exportVarSpy.mockRestore();
     execSyncSpy.mockRestore();
@@ -224,7 +235,8 @@ describe("review command integration", () => {
       (call: unknown[]) => call[0] === "run_security_review",
     ) as [string, string] | undefined;
 
-    expect(runCodeReviewCall?.[1]).toBe("false");
+    // Standalone security now uses two-pass pipeline (candidates + validator)
+    expect(runCodeReviewCall?.[1]).toBe("true");
     expect(runSecurityReviewCall?.[1]).toBe("true");
   });
 });

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -1,9 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  spyOn,
+  mock,
+} from "bun:test";
 import * as core from "@actions/core";
 import { prepareSecurityReviewMode } from "../../../src/tag/commands/security-review";
 import { createMockContext } from "../../mockContext";
 
 import * as prFetcher from "../../../src/github/data/pr-fetcher";
+import * as reviewArtifacts from "../../../src/github/data/review-artifacts";
 import * as promptModule from "../../../src/create-prompt";
 import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
 import * as comments from "../../../src/github/operations/comments/create-initial";
@@ -14,11 +23,18 @@ const MOCK_PR_DATA = {
   headRefOid: "123abc",
 } as const;
 
+const MOCK_REVIEW_ARTIFACTS = {
+  diffPath: "/tmp/droid-prompts/pr.diff",
+  commentsPath: "/tmp/droid-prompts/existing_comments.json",
+  descriptionPath: "/tmp/droid-prompts/pr_description.txt",
+};
+
 describe("prepareSecurityReviewMode", () => {
   const originalArgs = process.env.DROID_ARGS;
   const originalReviewModel = process.env.REVIEW_MODEL;
   const originalSecurityModel = process.env.SECURITY_MODEL;
   let fetchPRSpy: ReturnType<typeof spyOn>;
+  let computeArtifactsSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
   let mcpSpy: ReturnType<typeof spyOn>;
   let setOutputSpy: ReturnType<typeof spyOn>;
@@ -38,6 +54,11 @@ describe("prepareSecurityReviewMode", () => {
       body: "Test description",
     });
 
+    computeArtifactsSpy = spyOn(
+      reviewArtifacts,
+      "computeReviewArtifacts",
+    ).mockResolvedValue(MOCK_REVIEW_ARTIFACTS);
+
     promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
     mcpSpy = spyOn(mcpInstaller, "prepareMcpTools").mockResolvedValue(
       "mock-config",
@@ -50,10 +71,19 @@ describe("prepareSecurityReviewMode", () => {
     exportVariableSpy = spyOn(core, "exportVariable").mockImplementation(
       () => {},
     );
+
+    // Mock execSync for git checkout
+    mock.module("child_process", () => ({
+      execSync: (cmd: string) => {
+        if (cmd.includes("git rev-parse")) return "feature/security-review\n";
+        return "";
+      },
+    }));
   });
 
   afterEach(() => {
     fetchPRSpy.mockRestore();
+    computeArtifactsSpy.mockRestore();
     promptSpy.mockRestore();
     mcpSpy.mockRestore();
     setOutputSpy.mockRestore();
@@ -73,7 +103,7 @@ describe("prepareSecurityReviewMode", () => {
     }
   });
 
-  it("prepares security review flow with limited toolset when tracking comment exists", async () => {
+  it("prepares security review flow with candidate generation toolset", async () => {
     const context = createMockContext({
       eventName: "issue_comment",
       isPR: true,
@@ -105,36 +135,25 @@ describe("prepareSecurityReviewMode", () => {
       expect.objectContaining({
         allowedTools: expect.arrayContaining([
           "Execute",
+          "Task",
+          "Skill",
           "github_comment___update_droid_comment",
-          "github_inline_comment___create_inline_comment",
-          "github_pr___list_review_comments",
-          "github_pr___submit_review",
-          "github_pr___resolve_review_thread",
         ]),
       }),
     );
+    // Should NOT include inline comment or direct review tools (validator handles posting)
+    const mcpCall = mcpSpy.mock.calls[0] as any[];
+    const allowedTools = mcpCall[0].allowedTools as string[];
+    expect(allowedTools).not.toContain(
+      "github_inline_comment___create_inline_comment",
+    );
+    expect(allowedTools).not.toContain("github_pr___submit_review");
+
     expect(createInitialSpy).not.toHaveBeenCalled();
     expect(result.commentId).toBe(555);
     expect(result.branchInfo.baseBranch).toBe("main");
     expect(result.branchInfo.currentBranch).toBe("feature/security-review");
     expect(result.branchInfo.droidBranch).toBeUndefined();
-
-    const droidArgsCall = setOutputSpy.mock.calls.find(
-      (call: unknown[]) => call[0] === "droid_args",
-    ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).toContain("Execute");
-    [
-      "github_comment___update_droid_comment",
-      "github_inline_comment___create_inline_comment",
-      "github_pr___list_review_comments",
-      "github_pr___submit_review",
-      "github_pr___delete_comment",
-      "github_pr___minimize_comment",
-      "github_pr___reply_to_comment",
-      "github_pr___resolve_review_thread",
-    ].forEach((tool) => {
-      expect(droidArgsCall?.[1]).toContain(tool);
-    });
 
     expect(exportVariableSpy).toHaveBeenCalledWith(
       "DROID_EXEC_RUN_TYPE",
@@ -333,5 +352,38 @@ describe("prepareSecurityReviewMode", () => {
     expect(droidArgsCall?.[1]).toContain(
       '--model "claude-sonnet-4-5-20250929"',
     );
+  });
+
+  it("outputs review_pr_number and droid_comment_id", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 108,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 31,
+    });
+
+    const octokit = { rest: {}, graphql: () => {} } as any;
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit,
+      githubToken: "token",
+      trackingCommentId: 561,
+    });
+
+    const prNumberCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "review_pr_number",
+    ) as [string, string] | undefined;
+    expect(prNumberCall?.[1]).toBe("31");
+
+    const commentIdCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_comment_id",
+    ) as [string, string] | undefined;
+    expect(commentIdCall?.[1]).toBe("561");
   });
 });


### PR DESCRIPTION
## Summary

Moves the security review prompt to a skill and enables concurrent execution with code review.

### Changes

**Security review as a skill:**
- Simplified `security-review-prompt.ts` to a candidates prompt that references the `security-review` built-in skill (analogous to how code review references the `review` skill)
- Created `security-reviewer` custom droid in `.factory/droids/` that invokes the skill and returns findings as a JSON array (same format as `file-group-reviewer`)

**Concurrent execution:**
- When both `automatic_review` and `automatic_security_review` are enabled, the code review pass 1 agent spawns a `security-reviewer` subagent via Task alongside the `file-group-reviewer` subagents
- All candidates (code + security) are merged into a single `review_candidates.json`
- The validator (pass 2) processes everything together and posts all approved comments in one `submit_review` call

**Two-pass pipeline for standalone security:**
- Standalone `@droid security` and `automatic_security_review` now use the same two-pass pipeline as code review (candidates + validator) instead of posting inline comments directly
- Updated `security/action.yml` with validator steps

**Finding format:**
- Security findings use `[P1] [security] Title` format (no STRIDE letter codes)
- Tracking comment shows a `security review - ran` badge when security analysis was performed
- Dual-mode tracking comment says "reviewing code and running a security check"

**Companion PRs:**
- factory-mono [#12023](https://github.com/Factory-AI/factory-mono/pull/12023) — security-review skill v2.0.0 (OWASP Top 10, LLM Top 10, supply chain analysis)
- factory-mono [#12017](https://github.com/Factory-AI/factory-mono/pull/12017) — security-review built-in skill + feature flag

---

## CI Verification

Tested end-to-end on factory-mono PR [#12028](https://github.com/Factory-AI/factory-mono/pull/12028) with a deliberate security smells file containing 9 planted vulnerabilities.

### Workflow Run: [Passed](https://github.com/Factory-AI/factory-mono/actions/runs/24269115374)

### Planted Vulnerabilities vs Findings

| # | Planted Vulnerability | Category | Found? | Finding |
|---|---|---|---|---|
| 1 | SQL injection in `searchUsers` | OWASP A03 | Yes | `[P0] [security]` |
| 2 | Command injection in `getFileInfo` | OWASP A03 | - | (merged with #6) |
| 3 | Hardcoded credentials (`DB_PASSWORD`, `API_KEY`) | OWASP A02 | Yes | `[P0] [security]` |
| 4 | SSRF in `fetchUrl` | OWASP A10 | - | (below threshold) |
| 5 | Path traversal in `readUserFile` | OWASP A03 | Yes | `[P1] [security]` |
| 6 | Missing auth + SQLi in `deleteUser` | OWASP A01 | Yes | `[P0] [security]` |
| 7 | Sensitive data (credit card) in logs | OWASP A09 | Yes | `[P1] [security]` |
| 8 | Prompt injection in `buildPrompt` | OWASP LLM01 | Yes | `[P1] [security]` |
| 9 | LLM output to HTML (XSS) in `renderAssistantReply` | OWASP LLM05 | Yes | `[P1] [security]` |

**6 findings posted** (some vulnerabilities merged by the validator, all use `[security]` tag).

### Tracking Comment

Shows the security review badge:

> ![security review](https://img.shields.io/badge/security%20review-ran-blue)
>
> Validated 6 candidate comments: all are grounded in the diff, correctly anchored, and non-duplicative...

### What This Proves

1. **Skill loaded**: The `security-review` skill was invoked via the `Skill` tool at runtime
2. **Concurrent execution**: Security reviewer ran as a subagent alongside file-group-reviewers in Pass 1
3. **Two-pass pipeline**: Both candidate generation (Pass 1) and validation (Pass 2) completed
4. **`[security]` tags**: All findings use the new `[P0] [security]` / `[P1] [security]` format (no STRIDE letter codes)
5. **Security badge**: Tracking comment includes `security review - ran` badge
6. **Priority calibration**: Critical issues (credential exposure, SQL injection) got P0; disclosure, prompt injection, XSS got P1

### Log Evidence

Prompt includes security subagent instructions:
```
## Security Review (run concurrently)
In addition to the code review, you MUST also spawn a `security-reviewer` subagent via the Task tool.
```

Tracking comment on initial creation:
```
Droid is reviewing code and running a security check...
```

Environment:
```
SECURITY_REVIEW_ENABLED: true
```

FAC-18497