### PR TITLE
test: CI test for security review skill invocation

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,7 +25,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@feat/security-review-as-skill-with-concurrent-execution
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
+          automatic_security_review: true


### PR DESCRIPTION
Temporary PR to test that the security review skill is invoked correctly in CI.

Points droid-review workflow at `feat/security-review-as-skill-with-concurrent-execution` branch with both `automatic_review` and `automatic_security_review` enabled.

**Will be closed after verification.**