### PR TITLE
fix: prevent @fill from inferring wrong Linear ticket references

### DIFF
--- a/src/create-prompt/templates/fill-prompt.ts
+++ b/src/create-prompt/templates/fill-prompt.ts
@@ -28,6 +28,7 @@ Procedure:
 Use the gathered information to write the description:
 - Base every statement on verified changes from the diff and context you collected.
 - Preserve important details already present in the existing description (ticket numbers, custom sections, links, manual notes). If uncertain about a detail, keep it as-is.
+- Do NOT infer, guess, or add ticket references (Linear, Jira, GitHub issues, etc.) that are not already explicitly present in the existing PR description, PR comments, or branch name. Never extract ticket IDs from commit messages or other indirect sources. If no ticket is linked, leave the section empty or omit it entirely.
 - Remove any placeholder text such as "@droid fill" before submitting.
 - Keep the tone concise and factual. Use clear Markdown headings/bullets.
 - If a template is available, fill it out; otherwise structure the output as:
@@ -36,7 +37,6 @@ Use the gathered information to write the description:
   ## Implementation Details (optional when not applicable)
   ## Testing
   ## Breaking Changes (only when relevant)
-  ## Related Issues
 - For sections you cannot verify, write "[To be filled by author]".
 
 Submission:


### PR DESCRIPTION
## Summary
`` was associating PRs with incorrect Linear tickets. The LLM was inferring ticket IDs from commit messages and other indirect sources, sometimes guessing wrong. This fix adds an explicit instruction to the fill prompt to prevent speculative ticket association.
## Changes
- Added an explicit instruction in the fill prompt telling the LLM to **never** infer, guess, or add ticket references (Linear, Jira, GitHub issues, etc.) that are not already present in the PR description, PR comments, or branch name — and specifically to never extract ticket IDs from commit messages or other indirect sources.
- Removed `## Related Issues` from the default output structure to avoid prompting the LLM into speculative ticket association.
## Implementation Details
The change is scoped to `src/create-prompt/templates/fill-prompt.ts`, which defines the prompt template used by `` to generate PR descriptions. Two targeted edits were made:
1. A new guardrail instruction was inserted into the "Use the gathered information to write the description" section, explicitly forbidding ticket inference from indirect sources.
2. The `## Related Issues` heading was removed from the default output structure template, so the LLM is no longer prompted to fill in a section that encourages guessing.
## Testing
[To be filled by author]
## Related
FAC-18468