### PR TITLE
fix: bump internal CI workflow from @v3 to @dev

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v3
+        uses: Factory-AI/droid-action@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true


### PR DESCRIPTION
## Problem

The internal `droid-review.yml` CI workflow was failing on every PR with:

```
Prompt file '/home/runner/work/_temp/droid-prompts/droid-prompt.txt' does not exist.
```

**Root cause:** The workflow passes both `automatic_review: true` and `automatic_security_review: true`, and references `Factory-AI/droid-action@v3`. The `@v3` code recognizes both inputs, but its combined review path was designed for a parallel multi-job workflow — it returns early without generating a prompt file or setting `droid_args`/`mcp_tools` outputs. Since `droid-review.yml` runs everything in a single job, the base-action fails trying to read the missing prompt file.

The `dev` branch fixes this by calling `prepareReviewMode` in the combined path and spawning the security review as a subagent within the same job.

## Fix

Bump from `@v3` to `@dev` so the action code matches the single-job setup in `droid-review.yml`.

## Impact

**None on customers.** This file is the CI workflow for this repo only. Customers write their own workflow files and reference `@v3`.