### PR TITLE
fix(review): write PR comments in author's language, not file's

### DIFF
--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -135,6 +135,10 @@ ${sideFieldDescription}
 </schema_details>
 </output_spec>
 
+<language>
+Write every review comment (priority tag aside) — titles, paragraphs, suggestion-block prose, and the \`reviewSummary.body\` — in the language the PR author is using. Detect the language from the PR description and title at \`${descriptionPath}\`; fall back to English if uncertain. Do **not** mirror the language of the source files being reviewed: when the diff includes localized files (translations, \`docs/jp/...\`, \`docs/ko/...\`, \`.es.mdx\`, etc.), still write comments in the PR author's language, not the file's. Priority tags (\`[P0]\`/\`[P1]\`/\`[P2]\`/\`[P3]\`) and the \`[security]\` marker remain in English regardless.
+</language>
+
 <critical_constraints>
 **DO NOT** post to GitHub.
 **DO NOT** invoke any PR mutation tools (inline comments, submit review, delete/minimize/reply/resolve, etc.).

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -66,6 +66,10 @@ If the diff is large, read in chunks (offset/limit). **Do not proceed until you 
 2. Preserve ordering: keep results in the same order as candidates.
 3. **Posting rule (STRICT):** Only post comments where \`status === "approved"\`. Never post rejected items.
 
+### Language
+
+Approved comments and the review summary must be in the language the PR author is using. Detect the language from the PR description and title at \`${descriptionPath}\`; fall back to English if uncertain. Do **not** mirror the language of the source files being reviewed (localized files, translations, \`docs/jp/...\`, etc.) — match the PR author's language. If a candidate was written in the wrong language (e.g., Japanese on an English PR because the diff touched JP docs), rewrite the body into the correct language while preserving meaning, the priority tag (\`[P0]\`/\`[P1]\`/\`[P2]\`/\`[P3]\`), and any \`[security]\` marker. Approve it if the underlying finding is otherwise valid; do not reject solely on language. Priority tags and the \`[security]\` marker remain in English regardless.
+
 ### Output: Write \`${reviewValidatedPath}\`
 
 \`\`\`json

--- a/src/create-prompt/templates/security-report-prompt.ts
+++ b/src/create-prompt/templates/security-report-prompt.ts
@@ -206,5 +206,6 @@ The report file should follow this structure:
 2. **Patches**: Test all generated patches before committing. Ensure they don't break functionality.
 3. **PR Description**: Update the PR body with actual finding counts before creating.
 4. **Commit Messages**: Use semantic commit format: \`fix(security): [VULN-XXX] Description\`
+5. **Language**: Write the human-readable parts of the report (titles, descriptions, exploitation, impact, recommended fix, PR body) in the repository's primary language — detect this from the existing README, top-level docs, and any prior PR/issue text. Fall back to English when uncertain. Do **not** mirror the language of source files inside the scan when those files are localized translations (e.g., \`docs/jp/...\`). Severity labels (CRITICAL/HIGH/MEDIUM/LOW), CWE identifiers, severity tags, file paths, and code snippets stay in their canonical form regardless.
 `;
 }

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -98,6 +98,10 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
 </schema_details>
 </output_spec>
 
+<language>
+Write every finding — titles, explanations, suggestion prose, and the \`reviewSummary.body\` — in the language the PR author is using. Detect the language from the PR description and title at \`${descriptionPath}\`; fall back to English if uncertain. Do **not** mirror the language of the source files being reviewed: when the diff includes localized files (translations, \`docs/jp/...\`, \`docs/ko/...\`, \`.es.mdx\`, etc.), still write findings in the PR author's language, not the file's. Priority tags (\`[P0]\`/\`[P1]\`/\`[P2]\`/\`[P3]\`) and the \`[security]\` marker remain in English regardless.
+</language>
+
 <critical_constraints>
 **DO NOT** post to GitHub.
 **DO NOT** invoke any PR mutation tools (inline comments, submit review, delete/minimize/reply/resolve, etc.).


### PR DESCRIPTION
## Summary

When the GitHub Action reviewed a PR whose diff included localized files (e.g. `docs/jp/...`), the review prompt had no language guidance, so the model mirrored the file content language and posted Japanese review comments on an English PR. Reproduced on https://github.com/Factory-AI/factory/pull/1039.

## Changes

Add an explicit language section to all four prompt templates:

- `src/create-prompt/templates/review-candidates-prompt.ts` (Pass 1)
- `src/create-prompt/templates/review-validator-prompt.ts` (Pass 2)
- `src/create-prompt/templates/security-review-prompt.ts` (security subagent)
- `src/create-prompt/templates/security-report-prompt.ts` (full-repo scan)

Rule:

- Detect the PR author's language from the PR description and title (the `descriptionPath` artifact) and write all human-readable parts of the output in that language: titles, paragraphs, suggestion prose, `reviewSummary.body`.
- Fall back to English when uncertain.
- **Do not** mirror the language of source files being reviewed when those files are translations/localization (`docs/jp/...`, `docs/ko/...`, `.es.mdx`, etc.).
- Priority tags (`[P0]`/`[P1]`/`[P2]`/`[P3]`), the `[security]` marker, severity labels (CRITICAL/HIGH/MEDIUM/LOW), CWE/OWASP refs, file paths, and code snippets stay in English regardless.

The validator prompt also instructs Pass 2 to **rewrite** a candidate's body into the correct language if Pass 1 produced it in the wrong one (preserving meaning, the priority tag, and any `[security]` marker), rather than rejecting it solely on language.

Companion guidance is being added to `apps/cli/builtin-skills/{review,security-review}/SKILL.md` in `factory-mono` so interactive `/review` and `/security-review` follow the same rule (separate PR).

## Validation

- `bun run typecheck` ✅
- `bun run format:check` ✅
- `bun test` ✅ (377 pass, 0 fail, 892 expect calls)