### PR TITLE
feat(review): show security badge whenever security review is enabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -352,6 +352,7 @@ runs:
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
+        AUTOMATIC_SECURITY_REVIEW: ${{ inputs.automatic_security_review }}
 
     - name: Collect .factory debug files
       if: always() && steps.prepare.outputs.contains_trigger == 'true'

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -126,7 +126,6 @@ After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "a
 * Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
 * Do **NOT** include a \`body\` parameter in \`submit_review\`.
 * Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary.
-* If any approved comments contain \`[security]\` in their body, prepend a security badge to the tracking comment: \`![Security Review](https://img.shields.io/badge/security%20review-ran-blue)\`. This indicates that security analysis was performed as part of the review.
 * Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
 * Do not approve or request changes.
 `;

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -159,6 +159,7 @@ async function run() {
       branchName: undefined,
       triggerUsername,
       errorDetails,
+      securityReviewRan: process.env.AUTOMATIC_SECURITY_REVIEW === "true",
     };
 
     const updatedBody = updateCommentBody(commentInput);

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -16,7 +16,11 @@ export type CommentUpdateInput = {
   branchName?: string;
   triggerUsername?: string;
   errorDetails?: string;
+  securityReviewRan?: boolean;
 };
+
+export const SECURITY_REVIEW_BADGE =
+  "![Security Review](https://img.shields.io/badge/security%20review-ran-blue)";
 
 export function ensureProperlyEncodedUrl(url: string): string | null {
   try {
@@ -77,6 +81,7 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     branchName,
     triggerUsername,
     errorDetails,
+    securityReviewRan,
   } = input;
 
   // Extract content from the original comment body
@@ -208,6 +213,10 @@ export function updateCommentBody(input: CommentUpdateInput): string {
 
   // Remove any existing duration info at the bottom
   bodyContent = bodyContent.replace(/\n*---\n*Duration: [0-9]+m? [0-9]+s/g, "");
+
+  if (securityReviewRan && !bodyContent.includes("security%20review-ran")) {
+    bodyContent = `${SECURITY_REVIEW_BADGE}\n\n${bodyContent}`.trim();
+  }
 
   // Add the cleaned body content
   newBody += bodyContent;

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -441,4 +441,62 @@ describe("updateCommentBody", () => {
       expect(result).not.toContain("tree/droid/issue-123");
     });
   });
+
+  describe("security review badge", () => {
+    const SHIELD_URL_FRAGMENT = "security%20review-ran";
+
+    it("prepends the security badge when securityReviewRan is true", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is reviewing code and running a security check…",
+        executionDetails: { duration_ms: 60000 },
+        securityReviewRan: true,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain(SHIELD_URL_FRAGMENT);
+      expect(result).toContain(
+        "![Security Review](https://img.shields.io/badge/security%20review-ran-blue)",
+      );
+    });
+
+    it("does not add the badge when securityReviewRan is false", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        executionDetails: { duration_ms: 60000 },
+        securityReviewRan: false,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).not.toContain(SHIELD_URL_FRAGMENT);
+    });
+
+    it("does not add the badge when securityReviewRan is undefined", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        executionDetails: { duration_ms: 60000 },
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).not.toContain(SHIELD_URL_FRAGMENT);
+    });
+
+    it("does not double-prepend when the badge is already present", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody:
+          "Droid is reviewing code and running a security check…\n\n" +
+          "![Security Review](https://img.shields.io/badge/security%20review-ran-blue)\n\n" +
+          "Validator approved 2 findings.",
+        executionDetails: { duration_ms: 60000 },
+        securityReviewRan: true,
+      };
+
+      const result = updateCommentBody(input);
+      const occurrences = result.split(SHIELD_URL_FRAGMENT).length - 1;
+      expect(occurrences).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Makes the security shield badge deterministic: it now appears on the tracking comment whenever `automatic_security_review: true` is set, instead of only when the validator approved at least one `[security]`-tagged finding.

Previously a clean PR gave no signal that the security pass had run. Now it does.

The prepend moves from the validator prompt to the post-execution `update-comment-link` step, with a guard against double-prepending.

### Tests

- [factory-mono#12932](https://github.com/Factory-AI/factory-mono/pull/12932) — clean PR, no findings → badge appears.
- [factory-mono#12920](https://github.com/Factory-AI/factory-mono/pull/12920) — PR with seeded findings → badge appears + findings posted.
- [factory-mono#12933](https://github.com/Factory-AI/factory-mono/pull/12933) — baseline on unmodified `@dev`, used to confirm this PR doesn't change the security pass itself.