### PR TITLE
security: stop uploading raw Droid runtime artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -353,23 +353,3 @@ runs:
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}
         AUTOMATIC_SECURITY_REVIEW: ${{ inputs.automatic_security_review }}
-
-    - name: Collect .factory debug files
-      if: always() && steps.prepare.outputs.contains_trigger == 'true'
-      shell: bash
-      run: |
-        if [ -d "$HOME/.factory" ]; then
-          cp -r "$HOME/.factory" "${{ runner.temp }}/.factory"
-        fi
-
-    - name: Upload debug artifacts
-      if: always() && steps.prepare.outputs.contains_trigger == 'true'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: droid-review-debug-${{ github.run_id }}
-        path: |
-          ${{ runner.temp }}/.factory/**
-          ${{ runner.temp }}/droid-prompts/**
-        include-hidden-files: true
-        if-no-files-found: ignore
-        retention-days: 7

--- a/test/action-yml.test.ts
+++ b/test/action-yml.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const actionYml = readFileSync(
+  join(import.meta.dir, "..", "action.yml"),
+  "utf8",
+);
+
+describe("action.yml debug artifact invariants", () => {
+  it("loads the Droid composite action metadata", () => {
+    expect(actionYml.length).toBeGreaterThan(0);
+    expect(actionYml).toContain("runs:");
+    expect(actionYml).toContain('using: "composite"');
+  });
+
+  it("does not copy raw Factory runtime state", () => {
+    expect(actionYml).not.toContain("Collect .factory debug files");
+    expect(actionYml).not.toMatch(/cp\s+-[rR]\s+["']?\$HOME\/?\.factory/);
+  });
+
+  it("does not upload raw prompt or Factory runtime trees directly", () => {
+    expect(actionYml).not.toContain("Upload debug artifacts");
+    expect(actionYml).not.toMatch(
+      /\$\{\{\s*runner\.temp\s*\}\}\/\.factory(?:\/\*\*)?/,
+    );
+    expect(actionYml).not.toMatch(
+      /\$\{\{\s*runner\.temp\s*\}\}\/droid-prompts\/\*\*/,
+    );
+    expect(actionYml).not.toMatch(
+      /name:\s*droid-review-debug-\$\{\{\s*github\.run_id\s*\}/,
+    );
+  });
+
+  it("does not enable hidden-file uploads for raw Droid runtime artifacts", () => {
+    expect(actionYml).not.toMatch(
+      /include-hidden-files:\s*true[\s\S]{0,500}(?:\.factory|droid-prompts)/,
+    );
+    expect(actionYml).not.toMatch(
+      /(?:\.factory|droid-prompts)[\s\S]{0,500}include-hidden-files:\s*true/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The action uploaded raw Droid runtime state for every triggered run:

```text
$HOME/.factory/**
droid-prompts/**
```

That runtime state can contain settings, MCP configuration, logs, sessions, and prompt material. In secrets-backed workflows, resolved provider credentials may be materialized in runtime settings.

`show_full_output: false` controls console output. It does not control uploaded artifacts.

## Change

- Remove the raw `.factory` collection step.
- Remove the raw debug artifact upload step.
- Add metadata tests that reject raw runtime artifact paths.

## Review map

| Area | Files | What to check |
|---|---|---|
| Artifact behavior | `action.yml` | Raw runtime and prompt paths are no longer uploaded. |
| Regression guard | `test/action-yml.test.ts` | Metadata tests catch raw copy/upload patterns. |

## Behavior

Before:

```text
Triggered Droid run
→ copy $HOME/.factory
→ upload .factory/** and droid-prompts/**
```

After:

```text
Triggered Droid run
→ no raw runtime debug artifact upload
```

## Follow-up

A companion PR adds an explicit redacted debug artifact mode: #87.

## Validation

```bash
bun test test/action-yml.test.ts
bun run typecheck
bun run format:check

cd base-action
bun test
bun run typecheck
bun run format:check
```

## Non-goals

- No redacted artifact mode in this PR.
- No settings input changes.
- No model or review behavior changes.
- No raw artifact opt-in.

## Contribution license

This repository does not currently include a FOSS license or contributor license agreement.

For this pull request, I expressly grant Factory AI and its affiliates a perpetual, worldwide, royalty-free, irrevocable license to use, copy, modify, publish, distribute, sublicense, and relicense these contributions, including as part of this repository or any related Factory AI product or service.
