### PR TITLE
security: avoid logging Droid settings contents

### DIFF
--- a/base-action/src/setup-droid-settings.ts
+++ b/base-action/src/setup-droid-settings.ts
@@ -20,10 +20,7 @@ export async function setupDroidSettings(
     const existingSettings = await $`cat ${settingsPath}`.quiet().text();
     if (existingSettings.trim()) {
       settings = JSON.parse(existingSettings);
-      console.log(
-        `Found existing settings:`,
-        JSON.stringify(settings, null, 2),
-      );
+      console.log(`Found existing settings file`);
     } else {
       console.log(`Settings file exists but is empty`);
     }

--- a/base-action/test/setup-droid-settings.test.ts
+++ b/base-action/test/setup-droid-settings.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { setupDroidSettings } from "../src/setup-droid-settings";
 import { tmpdir } from "os";
 import { mkdir, writeFile, readFile, rm } from "fs/promises";
@@ -14,6 +14,16 @@ const testHomeDir = join(
 const settingsPath = join(testHomeDir, ".factory", "droid", "settings.json");
 const testSettingsDir = join(testHomeDir, ".factory-test");
 const testSettingsPath = join(testSettingsDir, "test-settings.json");
+
+function stringifyLogArg(value: unknown): string {
+  if (typeof value === "string") return value;
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
 describe("setupDroidSettings", () => {
   beforeEach(async () => {
@@ -144,5 +154,76 @@ describe("setupDroidSettings", () => {
     expect(settings.existingKey).toBe("existingValue");
     expect(settings.newKey).toBe("newValue");
     expect(settings.model).toBe("gpt-5-codex");
+  });
+
+  test("should not log existing settings contents", async () => {
+    await mkdir(join(testHomeDir, ".factory", "droid"), { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify(
+        {
+          customModels: [
+            {
+              apiKey: "custom-model-secret-test-value",
+            },
+          ],
+          mcp: {
+            env: {
+              GITHUB_TOKEN: "test-github-token-value",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const messages: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args) => {
+      messages.push(args.map(stringifyLogArg).join(" "));
+    });
+
+    try {
+      console.log("object serialization check", {
+        apiKey: "custom-model-secret-test-value",
+        mcp: {
+          env: {
+            GITHUB_TOKEN: "test-github-token-value",
+          },
+        },
+      });
+      const serializedObjectOutput = messages.join("\n");
+      expect(serializedObjectOutput).toContain("apiKey");
+      expect(serializedObjectOutput).toContain("GITHUB_TOKEN");
+      expect(serializedObjectOutput).toContain(
+        "custom-model-secret-test-value",
+      );
+      expect(serializedObjectOutput).toContain("test-github-token-value");
+      messages.length = 0;
+
+      await setupDroidSettings(
+        JSON.stringify({ model: "test-model" }),
+        testHomeDir,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+    const output = messages.join("\n");
+
+    expect(settings.enableAllProjectMcpServers).toBe(true);
+    expect(settings.model).toBe("test-model");
+    expect(settings.customModels[0].apiKey).toBe(
+      "custom-model-secret-test-value",
+    );
+    expect(settings.mcp.env.GITHUB_TOKEN).toBe("test-github-token-value");
+
+    expect(output).toContain("Found existing settings file");
+    expect(output).not.toContain("custom-model-secret-test-value");
+    expect(output).not.toContain("test-github-token-value");
+    expect(output).not.toContain("apiKey");
+    expect(output).not.toContain("GITHUB_TOKEN");
   });
 });


### PR DESCRIPTION
## Problem

`setupDroidSettings` printed the contents of an existing settings file.

Droid settings may contain provider credentials, custom model configuration, MCP env values, or token-shaped runtime fields. Logging the full settings object creates avoidable exposure in CI logs.

## Change

- Replace full settings JSON logging with a generic status message.
- Keep settings merge behavior unchanged.
- Add regression coverage that verifies sensitive values and key names are not logged.
- Serialize non-string console args in the test capture path so object-shaped logs are not hidden as `[object Object]`.

## Review map

| Area | Files | What to check |
|---|---|---|
| Logging behavior | `base-action/src/setup-droid-settings.ts` | Existing settings contents are not printed. |
| Regression test | `base-action/test/setup-droid-settings.test.ts` | String and object-shaped console output are caught. |
| Scope | Both files | Settings paths and merge semantics are unchanged. |

## Behavior

Before:

```text
Found existing settings: { ...full settings JSON... }
```

After:

```text
Found existing settings file
```

Settings merge behavior is unchanged.

## Validation

```bash
cd base-action
bun test setup-droid-settings
bun test
bun run typecheck
bun run format:check

cd ..
bun run typecheck
bun run format:check
```

## Non-goals

- No settings path changes.
- No artifact behavior changes.
- No Droid model behavior changes.
- No settings value or key-name logging.

## Contribution license

This repository does not currently include a FOSS license or contributor license agreement.

For this pull request, I expressly grant Factory AI and its affiliates a perpetual, worldwide, royalty-free, irrevocable license to use, copy, modify, publish, distribute, sublicense, and relicense these contributions, including as part of this repository or any related Factory AI product or service.
