### PR TITLE
fix(review-depth): use kimi-k2.6 for shallow preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ jobs:
 
 The `review_depth` input controls which model and reasoning effort are used for code reviews. Two presets are available:
 
-| Depth       | Model          | Reasoning Effort | Best For                                                |
-| ----------- | -------------- | ---------------- | ------------------------------------------------------- |
-| **deep**    | `gpt-5.2`      | `high`           | Thorough reviews catching subtle bugs and design issues |
-| **shallow** | `kimi-k2-0711` | default          | Fast, cost-effective reviews for straightforward PRs    |
+| Depth       | Model       | Reasoning Effort | Best For                                                |
+| ----------- | ----------- | ---------------- | ------------------------------------------------------- |
+| **deep**    | `gpt-5.2`   | `high`           | Thorough reviews catching subtle bugs and design issues |
+| **shallow** | `kimi-k2.6` | default          | Fast, cost-effective reviews for straightforward PRs    |
 
 **Examples:**
 
@@ -262,7 +262,7 @@ The `review_depth` input controls which model and reasoning effort are used for 
 
 > **Tip:** Setting `review_model` or `reasoning_effort` explicitly always takes priority over the depth preset. You can mix and match -- for example, use `review_depth: shallow` but override just `reasoning_effort: high` to get the shallow model with higher reasoning.
 
-The default models (`gpt-5.2` for `deep`, `kimi-k2-0711` for `shallow`) are managed by Factory and may change over time. To pin a specific model regardless of the depth preset, set `review_model` to any model ID supported by `droid exec --model`. A few common choices:
+The default models (`gpt-5.2` for `deep`, `kimi-k2.6` for `shallow`) are managed by Factory and may change over time. To pin a specific model regardless of the depth preset, set `review_model` to any model ID supported by `droid exec --model`. A few common choices:
 
 - `claude-opus-4-7`
 - `claude-sonnet-4-6`

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ inputs:
     required: false
     default: "7"
   review_depth:
-    description: "Review depth preset: 'shallow' (fast, uses kimi-k2-0711) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    description: "Review depth preset: 'shallow' (fast, uses kimi-k2.6) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
     required: false
     default: "deep"
   review_model:

--- a/review/action.yml
+++ b/review/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "ID of the tracking comment to update"
     required: true
   review_depth:
-    description: "Review depth preset: 'shallow' (fast, uses kimi-k2-0711) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    description: "Review depth preset: 'shallow' (fast, uses kimi-k2.6) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
     required: false
     default: "deep"
   review_model:

--- a/src/utils/review-depth.ts
+++ b/src/utils/review-depth.ts
@@ -4,7 +4,7 @@ export enum ReviewDepth {
 }
 
 const SHALLOW_DEFAULTS = {
-  model: "kimi-k2-0711",
+  model: "kimi-k2.6",
   reasoningEffort: undefined as string | undefined,
 };
 


### PR DESCRIPTION
## Summary

The shallow depth preset pointed at `kimi-k2-0711`, which is a stale identifier the public Droid CLI no longer recognizes. Verified on a real GitLab pipeline:

```
Running: droid exec ... --model kimi-k2-0711
Invalid model: kimi-k2-0711
```

The deep preset (`gpt-5.2`) works fine; only shallow was broken. Anyone passing `review_depth: shallow` today silently hits this error.

## Fix

Per `droid exec` invalid-model help text, the current valid Kimi K2 model IDs are `kimi-k2.6` (newest) and `kimi-k2.5`. Switch the preset to `kimi-k2.6` — preserves the original design intent (fast, cheap Kimi K2 for shallow reviews) without changing the type of model.

Explicit `review_model` override still wins via `resolveReviewConfig` (priority unchanged).

## Files changed

- `src/utils/review-depth.ts` — `SHALLOW_DEFAULTS.model`
- `action.yml` + `review/action.yml` — input descriptions
- `README.md` — presets table + ref in `review_model` section

## Test plan

- All 377 unit tests pass locally
- Will validate end-to-end on a GitLab MR after merge (already confirmed working with `claude-sonnet-4-5-20250929` as an interim model in the GitLab feature branch's test pipelines, so the wiring is good)
- Equivalent path on GitHub: any PR with `review_depth: shallow` will now use `kimi-k2.6` instead of erroring out