### PR TITLE
refactor(review): hoist GH+GL shared review code into src/core/review/

### DIFF
--- a/src/core/review/artifacts/types.ts
+++ b/src/core/review/artifacts/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared shape for the three on-disk review artifacts. Both GitHub and
+ * GitLab pipelines pre-compute the same trio (diff, existing comments,
+ * description) and write them under `${tempDir}/droid-prompts/`, then
+ * pass the resulting paths into the Pass 1 / Pass 2 prompts.
+ *
+ * The fetch mechanics differ substantially per platform (git+gh CLI vs
+ * REST API), so we don't try to share the fetchers — only the path
+ * shape and the disk-write helper.
+ */
+export type ReviewArtifactPaths = {
+  diffPath: string;
+  commentsPath: string;
+  descriptionPath: string;
+};
+
+/**
+ * Raw content for each of the three artifacts, before they're written
+ * to disk by `writeReviewArtifacts`.
+ */
+export type ReviewArtifactContents = {
+  diff: string;
+  comments: unknown; // JSON-serializable
+  description: string;
+};

--- a/src/core/review/artifacts/write.ts
+++ b/src/core/review/artifacts/write.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import type { ReviewArtifactContents, ReviewArtifactPaths } from "./types";
+
+/**
+ * Naming convention for review-artifact files on disk. Each platform
+ * gets its own basename for the diff and description (pr.diff /
+ * mr.diff, pr_description.txt / mr_description.txt) but the existing
+ * comments file is platform-neutral.
+ */
+export type ReviewArtifactNames = {
+  diff: string;
+  comments: string;
+  description: string;
+};
+
+/**
+ * Write the three review-artifact files into `outDir` in parallel,
+ * creating `outDir` if it doesn't yet exist. Returns the resolved
+ * on-disk paths so the caller can hand them straight to the prompt
+ * builder.
+ */
+export async function writeReviewArtifacts(
+  outDir: string,
+  contents: ReviewArtifactContents,
+  names: ReviewArtifactNames,
+): Promise<ReviewArtifactPaths> {
+  await fs.mkdir(outDir, { recursive: true });
+
+  const diffPath = path.join(outDir, names.diff);
+  const commentsPath = path.join(outDir, names.comments);
+  const descriptionPath = path.join(outDir, names.description);
+
+  await Promise.all([
+    fs.writeFile(diffPath, contents.diff),
+    fs.writeFile(commentsPath, JSON.stringify(contents.comments, null, 2)),
+    fs.writeFile(descriptionPath, contents.description),
+  ]);
+
+  return { diffPath, commentsPath, descriptionPath };
+}

--- a/src/core/review/prompts/candidates.ts
+++ b/src/core/review/prompts/candidates.ts
@@ -57,7 +57,7 @@ This subagent runs **concurrently** with the code review subagents during Step 2
 Spawn it with:
 - \`subagent_type\`: "security-reviewer"
 - \`description\`: "Security review"
-- \`prompt\`: Include the full ${t.entityNoun} context (${t.repoLabel.toLowerCase()}, ${t.entityNoun} ${t.metaEntityNumberKey === "prNumber" ? "number" : "IID"}, head SHA, ${t.baseRefLabel.toLowerCase()}) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
+- \`prompt\`: Include the full ${t.entityNoun} context (${t.repoLabel.toLowerCase()}, ${t.entityNoun} ${t.metaEntityNumberKey === "prNumber" ? "number" : "IID"}, head SHA, ${t.baseRefShortLabel}) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
 
 **IMPORTANT**: Spawn the security-reviewer in the SAME response as the code review subagents so they all run in parallel.
 

--- a/src/core/review/prompts/candidates.ts
+++ b/src/core/review/prompts/candidates.ts
@@ -1,0 +1,146 @@
+/**
+ * Platform-agnostic Pass 1 (candidate generation) prompt.
+ *
+ * Both `src/create-prompt/templates/review-candidates-prompt.ts` (GitHub)
+ * and `src/gitlab/prompts/candidates.ts` (GitLab) delegate to this builder
+ * via thin adapters that supply a `ReviewTerminology` object plus the
+ * runtime context (entity number, SHAs, artifact paths). The /review skill
+ * itself is platform-agnostic; this builder produces the runtime harness
+ * (where to read inputs, where to write the candidates JSON, what NOT to
+ * call) around it.
+ *
+ * STRICT contract: this prompt MUST NOT instruct the model to call any
+ * posting tool. Posting is Pass 2's responsibility, and tool gating is
+ * additionally enforced at the `droid exec` level via `--enabled-tools`.
+ */
+
+import type { ReviewPromptContext } from "./types";
+
+export function generateCandidatesPrompt(ctx: ReviewPromptContext): string {
+  const {
+    terminology: t,
+    entityNumber,
+    repoOrProject,
+    headRef,
+    headSha,
+    baseRef,
+    diffPath,
+    commentsPath,
+    descriptionPath,
+    candidatesPath,
+    includeSuggestions,
+    securityReviewEnabled,
+  } = ctx;
+
+  const bodyFieldDescription = includeSuggestions
+    ? "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation.\n" +
+      "    Follow the suggestion block rules from the review skill when including suggestions."
+    : "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation";
+
+  const sideFieldDescription = includeSuggestions
+    ? '  - `side`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.\n' +
+      "    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it."
+    : '  - `side`: "RIGHT" for new/modified code (default), "LEFT" only for removed code';
+
+  const skillInstruction = includeSuggestions
+    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure — including suggestion block rules."
+    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure. Do NOT include code suggestion blocks.";
+
+  const securitySubagentInstruction = securityReviewEnabled
+    ? `
+
+## Security Review (run concurrently)
+
+In addition to the code review, you MUST also spawn a \`security-reviewer\` subagent via the Task tool.
+This subagent runs **concurrently** with the code review subagents during Step 2.
+
+Spawn it with:
+- \`subagent_type\`: "security-reviewer"
+- \`description\`: "Security review"
+- \`prompt\`: Include the full ${t.entityNoun} context (${t.repoLabel.toLowerCase()}, ${t.entityNoun} ${t.metaEntityNumberKey === "prNumber" ? "number" : "IID"}, head SHA, ${t.baseRefLabel.toLowerCase()}) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
+
+**IMPORTANT**: Spawn the security-reviewer in the SAME response as the code review subagents so they all run in parallel.
+
+After all subagents complete (both code review and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but are prefixed with \`[security]\` in their body (e.g., \`[P1] [security] Title\`).
+`
+    : "";
+
+  return `You are a senior staff software engineer and expert code reviewer.
+
+Your task: Review ${t.entityNoun} ${t.entityNumberSigil}${entityNumber} in ${repoOrProject} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
+
+${skillInstruction}${securitySubagentInstruction}
+
+<context>
+${t.repoLabel}: ${repoOrProject}
+${t.entityNumberLabel}: ${entityNumber}
+${t.headRefLabel}: ${headRef}
+${t.headShaLabel}: ${headSha}
+${t.baseRefLabel}: ${baseRef}
+
+Precomputed data files:
+- ${t.descriptionLabel}: \`${descriptionPath}\`
+- ${t.diffLabel}: \`${diffPath}\`
+- Existing Comments: \`${commentsPath}\`
+</context>
+
+<output_spec>
+Write output to \`${candidatesPath}\` using this exact schema:
+
+\`\`\`json
+{
+  "version": 1,
+  "meta": {
+    "${t.metaRepoKey}": "${t.repoExample}",
+    "${t.metaEntityNumberKey}": 123,
+    "headSha": "<head sha>",
+    "${t.metaBaseRefKey}": "main",
+    "generatedAt": "<ISO timestamp>"
+  },
+  "comments": [
+    {
+      "path": "src/index.ts",
+      "body": "[P1] Title\\n\\n1 paragraph.",
+      "line": 42,
+      "startLine": null,
+      "side": "RIGHT",
+      "commit_id": "<head sha>"
+    }
+  ],
+  "reviewSummary": {
+    "body": "1-3 sentence overall assessment"
+  }
+}
+\`\`\`
+
+<schema_details>
+- **version**: Always \`1\`
+
+- **meta**: Metadata object
+  - \`${t.metaRepoKey}\`: "${repoOrProject}"
+  - \`${t.metaEntityNumberKey}\`: ${entityNumber}
+  - \`headSha\`: "${headSha}"
+  - \`${t.metaBaseRefKey}\`: "${baseRef}"
+  - \`generatedAt\`: ISO 8601 timestamp (e.g., "2024-01-15T10:30:00Z")
+
+- **comments**: Array of comment objects
+  - \`path\`: ${t.pathFieldDescription}
+${bodyFieldDescription}
+  - \`line\`: ${t.lineFieldDescription}
+  - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
+${sideFieldDescription}
+  - \`commit_id\`: "${headSha}"
+
+- **reviewSummary**:
+  - \`body\`: 1-3 sentence overall assessment
+</schema_details>
+</output_spec>
+
+<critical_constraints>
+**DO NOT** post to ${t.platformName}.
+**DO NOT** invoke any ${t.entityNoun} mutation tools ${t.mutationToolForbiddance}.
+**DO NOT** modify any files other than writing to \`${candidatesPath}\`.
+Output ONLY the JSON file—no additional commentary.
+</critical_constraints>
+`;
+}

--- a/src/core/review/prompts/types.ts
+++ b/src/core/review/prompts/types.ts
@@ -25,6 +25,8 @@ export interface ReviewTerminology {
   headShaLabel: string;
   /** Label for the target branch row (e.g. "PR Base Ref" or "MR Target Branch") */
   baseRefLabel: string;
+  /** Short form of the target-branch concept, used in narrative prose (e.g. "base ref" or "target branch") */
+  baseRefShortLabel: string;
   /** Label for the description artifact (e.g. "PR Description" or "MR Description") */
   descriptionLabel: string;
   /** Label for the diff artifact (e.g. "Full PR Diff" or "Full MR Diff") */

--- a/src/core/review/prompts/types.ts
+++ b/src/core/review/prompts/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared types for the platform-agnostic review prompts.
+ *
+ * The candidate-generation (Pass 1) and validator (Pass 2) prompts are
+ * structurally identical between GitHub and GitLab. The only things that
+ * vary are labels, identifier names, MCP tool names, and a small number
+ * of platform-specific instruction lines. Those variations are captured
+ * here so the shared templates can stay platform-agnostic.
+ */
+
+export interface ReviewTerminology {
+  /** "PR" or "MR" */
+  entityNoun: string;
+  /** "#" for GitHub PRs, "!" for GitLab MRs */
+  entityNumberSigil: string;
+  /** "GitHub" or "GitLab" */
+  platformName: string;
+  /** Label for the repo/project value (e.g. "Repo" or "Project") */
+  repoLabel: string;
+  /** Label for the entity number row in <context> (e.g. "PR Number" or "MR IID") */
+  entityNumberLabel: string;
+  /** Label for the source branch row (e.g. "PR Head Ref" or "MR Source Branch") */
+  headRefLabel: string;
+  /** Label for the head SHA row (e.g. "PR Head SHA" or "MR Head SHA") */
+  headShaLabel: string;
+  /** Label for the target branch row (e.g. "PR Base Ref" or "MR Target Branch") */
+  baseRefLabel: string;
+  /** Label for the description artifact (e.g. "PR Description" or "MR Description") */
+  descriptionLabel: string;
+  /** Label for the diff artifact (e.g. "Full PR Diff" or "Full MR Diff") */
+  diffLabel: string;
+  /** JSON meta key for the repo identifier (e.g. "repo" or "project") */
+  metaRepoKey: string;
+  /** JSON meta key for the entity number (e.g. "prNumber" or "mrIid") */
+  metaEntityNumberKey: string;
+  /** JSON meta key for the base ref (e.g. "baseRef" or "targetBranch") */
+  metaBaseRefKey: string;
+  /** Example identifier in schema doc (e.g. "owner/repo" or "group/project") */
+  repoExample: string;
+  /** Free-form description for the `path` field (small wording variation) */
+  pathFieldDescription: string;
+  /** Free-form description for the `line` field (small wording variation) */
+  lineFieldDescription: string;
+  /** Free-form blurb listing mutation tools the candidates pass MUST NOT use */
+  mutationToolForbiddance: string;
+  /** MCP tool name for posting a batched review (Pass 2) */
+  submitReviewToolName: string;
+  /** Extra args appended to the submit_review instruction (e.g. " along with `mr_iid: 5`") */
+  submitReviewExtraArg: string;
+  /** Trailing clause on the "Do NOT include a body parameter" line */
+  submitReviewBodyExclusionTrailer: string;
+  /** MCP tool name for updating the sticky tracking comment/note */
+  updateTrackingToolName: string;
+  /** Human-readable name for the sticky comment (e.g. "tracking comment" or "sticky tracking note") */
+  trackingCommentName: string;
+  /** "comment" (GH) or "top-level note" (GL), used in "post the summary as a separate X" */
+  summaryEntityName: string;
+  /** Trailing clause on the summary-forbiddance line (e.g. " or as the body of `submit_review`" on GH; "" on GL) */
+  summaryPostingExtraExclusion: string;
+  /** Approval/changes line at the end of validator instructions */
+  approvalChangesNote: string;
+  /** Optional security-badge instruction line — GL only */
+  securityBadgeInstruction?: string;
+}
+
+export interface ReviewPromptContext {
+  terminology: ReviewTerminology;
+  /** PR number / MR IID */
+  entityNumber: number | string;
+  /** Full repo/project identifier */
+  repoOrProject: string;
+  /** Source branch name */
+  headRef: string;
+  /** Head SHA */
+  headSha: string;
+  /** Target branch name */
+  baseRef: string;
+  /** On-disk path to the diff artifact */
+  diffPath: string;
+  /** On-disk path to existing-comments JSON */
+  commentsPath: string;
+  /** On-disk path to description text */
+  descriptionPath: string;
+  /** On-disk path where Pass 1 writes the candidates JSON */
+  candidatesPath: string;
+  /** On-disk path where Pass 2 writes the validated JSON (validator only) */
+  validatedPath?: string;
+  includeSuggestions: boolean;
+  /** Spawn security-reviewer subagent during Pass 1 (candidates only) */
+  securityReviewEnabled: boolean;
+}

--- a/src/core/review/prompts/validator.ts
+++ b/src/core/review/prompts/validator.ts
@@ -1,0 +1,138 @@
+/**
+ * Platform-agnostic Pass 2 (validator) prompt.
+ *
+ * The validator reads the candidates JSON produced by Pass 1, validates
+ * each one, writes a refined JSON to disk, and posts the approved
+ * findings as a single batched call to the platform's submit-review tool.
+ * Both `src/create-prompt/templates/review-validator-prompt.ts` (GitHub)
+ * and `src/gitlab/prompts/validator.ts` (GitLab) delegate to this builder
+ * via thin adapters that supply a `ReviewTerminology` shape.
+ *
+ * Pass 2 is the only place where the posting tool is exposed (via
+ * `--enabled-tools` on the second `droid exec` invocation).
+ */
+
+import type { ReviewPromptContext } from "./types";
+
+export function generateValidatorPrompt(ctx: ReviewPromptContext): string {
+  const {
+    terminology: t,
+    entityNumber,
+    repoOrProject,
+    headRef,
+    headSha,
+    baseRef,
+    diffPath,
+    commentsPath,
+    descriptionPath,
+    candidatesPath,
+    validatedPath,
+    includeSuggestions,
+  } = ctx;
+
+  if (!validatedPath) {
+    throw new Error("validator prompt requires validatedPath in context");
+  }
+
+  const skillInstruction = includeSuggestions
+    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure — including suggestion block rules."
+    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure. Do NOT include code suggestion blocks.";
+
+  const securityBadgeLine = t.securityBadgeInstruction
+    ? `\n* ${t.securityBadgeInstruction}`
+    : "";
+
+  return `You are validating candidate review comments for ${t.entityNoun} ${t.entityNumberSigil}${entityNumber} in ${repoOrProject}.
+
+IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
+
+${skillInstruction}
+
+### Context
+
+* ${t.repoLabel}: ${repoOrProject}
+* ${t.entityNumberLabel}: ${entityNumber}
+* ${t.headRefLabel}: ${headRef}
+* ${t.headShaLabel}: ${headSha}
+* ${t.baseRefLabel}: ${baseRef}
+
+### Inputs
+
+Read these files before validating:
+* ${t.descriptionLabel}: \`${descriptionPath}\`
+* Candidates: \`${candidatesPath}\`
+* ${t.diffLabel}: \`${diffPath}\`
+* Existing Comments: \`${commentsPath}\`
+
+If the diff is large, read in chunks (offset/limit). **Do not proceed until you have read the ENTIRE diff.**
+
+### Critical Requirements
+
+1. You MUST read and validate **every** candidate before posting anything.
+2. Preserve ordering: keep results in the same order as candidates.
+3. **Posting rule (STRICT):** Only post comments where \`status === "approved"\`. Never post rejected items.
+
+### Output: Write \`${validatedPath}\`
+
+\`\`\`json
+{
+  "version": 1,
+  "meta": {
+    "${t.metaRepoKey}": "${repoOrProject}",
+    "${t.metaEntityNumberKey}": ${entityNumber},
+    "headSha": "${headSha}",
+    "${t.metaBaseRefKey}": "${baseRef}",
+    "validatedAt": "<ISO timestamp>"
+  },
+  "results": [
+    {
+      "status": "approved",
+      "comment": {
+        "path": "src/index.ts",
+        "body": "[P1] Title\\n\\n1 paragraph.",
+        "line": 42,
+        "startLine": null,
+        "side": "RIGHT",
+        "commit_id": "${headSha}"
+      }
+    },
+    {
+      "status": "rejected",
+      "candidate": {
+        "path": "src/other.ts",
+        "body": "[P2] ...",
+        "line": 10,
+        "startLine": null,
+        "side": "RIGHT",
+        "commit_id": "${headSha}"
+      },
+      "reason": "Not a real bug because ..."
+    }
+  ],
+  "reviewSummary": {
+    "status": "approved",
+    "body": "1-3 sentence overall assessment"
+  }
+}
+\`\`\`
+
+Notes:
+* Use \`commit_id\` = \`${headSha}\`.
+* \`results\` MUST have exactly one entry per candidate, in the same order.
+
+Tooling note:
+* If the tools list includes \`ApplyPatch\` (common for OpenAI models like GPT-5.2), use \`ApplyPatch\` to create/update the file at the exact path.
+* Otherwise, use \`Create\` (or \`Edit\` if overwriting) to write the file.
+
+### Post approved items
+
+After writing \`${validatedPath}\`, post comments ONLY for \`status === "approved"\`:
+
+* Collect all approved comments and submit them as a **single batched review** via \`${t.submitReviewToolName}\`, passing them in the \`comments\` array parameter${t.submitReviewExtraArg}.
+* Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
+* Do **NOT** include a \`body\` parameter in \`submit_review\`${t.submitReviewBodyExclusionTrailer}.
+* Use \`${t.updateTrackingToolName}\` to update the ${t.trackingCommentName} with the review summary.${securityBadgeLine}
+* Do **NOT** post the summary as a separate ${t.summaryEntityName}${t.summaryPostingExtraExclusion}.
+* ${t.approvalChangesNote}
+`;
+}

--- a/src/core/review/tracking/format.ts
+++ b/src/core/review/tracking/format.ts
@@ -9,8 +9,12 @@ export function formatDurationMs(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const seconds = ms / 1000;
   if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remSec = Math.round(seconds - minutes * 60);
+  // Round to whole seconds first, then split into minutes+seconds, so
+  // that a remainder rounding up to 60 carries cleanly into the next
+  // minute (e.g. 119600ms → "2m 0s", not "1m 60s").
+  const totalSeconds = Math.round(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remSec = totalSeconds - minutes * 60;
   return `${minutes}m ${remSec}s`;
 }
 

--- a/src/core/review/tracking/format.ts
+++ b/src/core/review/tracking/format.ts
@@ -1,0 +1,20 @@
+/**
+ * Small formatting helpers shared between the GitHub MCP comment server
+ * and the GitLab tracking-note builder. Kept platform-agnostic so the
+ * two renderers can stay independent while still producing identical
+ * telemetry text (e.g. "1m 23s • $0.0042").
+ */
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSec = Math.round(seconds - minutes * 60);
+  return `${minutes}m ${remSec}s`;
+}
+
+export function formatCostUsd(usd: number): string {
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(4)}`;
+}

--- a/src/core/review/tracking/format.ts
+++ b/src/core/review/tracking/format.ts
@@ -1,8 +1,9 @@
 /**
- * Small formatting helpers shared between the GitHub MCP comment server
- * and the GitLab tracking-note builder. Kept platform-agnostic so the
- * two renderers can stay independent while still producing identical
- * telemetry text (e.g. "1m 23s • $0.0042").
+ * Small formatting helpers for sticky review-tracking
+ * comments/notes. Currently consumed by the GitLab tracking-note
+ * builder (`src/gitlab/operations/tracking-note.ts`); kept platform-
+ * agnostic in core so the GitHub MCP comment server can adopt the same
+ * "1m 23s • $0.0042" rendering when its telemetry path is unified.
  */
 
 export function formatDurationMs(ms: number): string {

--- a/src/core/review/tracking/types.ts
+++ b/src/core/review/tracking/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared shapes for sticky review-tracking comments/notes.
+ *
+ * Both GitHub and GitLab keep a single "sticky" comment per PR/MR that
+ * carries the live status of the Droid review pipeline (running →
+ * success/failure) plus telemetry. The body-building mechanics differ
+ * between platforms today — GitHub updates it from inside the agent via
+ * the github-comment-server MCP tool, while GitLab builds the whole body
+ * in TypeScript and writes it from CI — so we only share the contract
+ * (state machine + telemetry shape) here, not the renderer itself.
+ */
+
+export type ReviewTrackingState = "running" | "success" | "failure";
+
+export type ReviewTrackingTelemetry = {
+  totalNumTurns?: number | null;
+  totalDurationMs?: number | null;
+  totalCostUsd?: number | null;
+  pass1SessionId?: string | null;
+  pass2SessionId?: string | null;
+};
+
+export interface ReviewTrackingFields {
+  state: ReviewTrackingState;
+  pipelineUrl?: string | null;
+  jobUrl?: string | null;
+  triggerUsername?: string | null;
+  errorDetails?: string | null;
+  securityReviewRan?: boolean;
+  telemetry?: ReviewTrackingTelemetry | null;
+}

--- a/src/core/review/triggers/parse-command.ts
+++ b/src/core/review/triggers/parse-command.ts
@@ -1,0 +1,74 @@
+/**
+ * Platform-agnostic Droid command parser.
+ *
+ * Both GitHub and GitLab look for the same `@droid <command>` mentions
+ * in PR/MR bodies and comments. This parser only operates on a raw
+ * string; the per-platform context extraction (which fields of which
+ * webhook payload to scan) stays in the platform-specific module
+ * because the payload shapes diverge.
+ */
+
+export type DroidCommand =
+  | "fill"
+  | "review"
+  | "security"
+  | "security-full"
+  | "default";
+
+export interface ParsedCommand {
+  command: DroidCommand;
+  raw: string;
+  location: "body" | "comment";
+  timestamp?: string | null;
+}
+
+/**
+ * Parses text to detect specific @droid commands.
+ *
+ * Returns `null` when no `@droid` mention is present, the generic
+ * `default` command for a bare `@droid`, or the specific subcommand
+ * when matched. `location` defaults to "body" and is overridden by
+ * the caller when the text came from a comment.
+ */
+export function parseDroidCommand(text: string): ParsedCommand | null {
+  if (!text) {
+    return null;
+  }
+
+  const fillMatch = text.match(/@droid\s+fill/i);
+  if (fillMatch) {
+    return { command: "fill", raw: fillMatch[0], location: "body" };
+  }
+
+  // Note: `@droid review security` will match as just `@droid review`.
+  const reviewMatch = text.match(/@droid\s+review/i);
+  if (reviewMatch) {
+    return { command: "review", raw: reviewMatch[0], location: "body" };
+  }
+
+  const securityFullMatch = text.match(/@droid\s+security\s+--full/i);
+  if (securityFullMatch) {
+    return {
+      command: "security-full",
+      raw: securityFullMatch[0],
+      location: "body",
+    };
+  }
+
+  // Check after security-full to avoid false matches.
+  const securityMatch = text.match(/@droid\s+security(?:\s|$|[^-\w])/i);
+  if (securityMatch) {
+    return {
+      command: "security",
+      raw: securityMatch[0].trim(),
+      location: "body",
+    };
+  }
+
+  const droidMatch = text.match(/@droid/i);
+  if (droidMatch) {
+    return { command: "default", raw: droidMatch[0], location: "body" };
+  }
+
+  return null;
+}

--- a/src/create-prompt/templates/review-candidates-prompt.ts
+++ b/src/create-prompt/templates/review-candidates-prompt.ts
@@ -1,3 +1,14 @@
+/**
+ * GitHub Pass-1 (candidate generation) prompt — thin adapter.
+ *
+ * Delegates to the platform-agnostic builder in
+ * `src/core/review/prompts/candidates.ts`, mapping the GitHub
+ * `PreparedContext` shape onto the shared `ReviewPromptContext` and
+ * supplying `GITHUB_TERMINOLOGY` (PR labels, github_* MCP tool names).
+ */
+
+import { generateCandidatesPrompt } from "../../core/review/prompts/candidates";
+import { GITHUB_TERMINOLOGY } from "../terminology";
 import type { PreparedContext } from "../types";
 
 export function generateReviewCandidatesPrompt(
@@ -9,137 +20,25 @@ export function generateReviewCandidatesPrompt(
       ? String(context.githubContext.entityNumber)
       : "unknown";
 
-  const repoFullName = context.repository;
-  const prHeadRef = context.prBranchData?.headRefName ?? "unknown";
-  const prHeadSha = context.prBranchData?.headRefOid ?? "unknown";
-  const prBaseRef = context.eventData.baseBranch ?? "unknown";
-
-  const diffPath =
-    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
-  const commentsPath =
-    context.reviewArtifacts?.commentsPath ??
-    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
-  const descriptionPath =
-    context.reviewArtifacts?.descriptionPath ??
-    "$RUNNER_TEMP/droid-prompts/pr_description.txt";
-
-  const reviewCandidatesPath =
-    process.env.REVIEW_CANDIDATES_PATH ??
-    "$RUNNER_TEMP/droid-prompts/review_candidates.json";
-
-  const includeSuggestions = context.includeSuggestions !== false;
-
-  const bodyFieldDescription = includeSuggestions
-    ? "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation.\n" +
-      "    Follow the suggestion block rules from the review skill when including suggestions."
-    : "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation";
-
-  const sideFieldDescription = includeSuggestions
-    ? '  - `side`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.\n' +
-      "    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it."
-    : '  - `side`: "RIGHT" for new/modified code (default), "LEFT" only for removed code';
-
-  const skillInstruction = includeSuggestions
-    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure — including suggestion block rules."
-    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure. Do NOT include code suggestion blocks.";
-
-  const securityReviewEnabled = process.env.SECURITY_REVIEW_ENABLED === "true";
-
-  const securitySubagentInstruction = securityReviewEnabled
-    ? `
-
-## Security Review (run concurrently)
-
-In addition to the code review, you MUST also spawn a \`security-reviewer\` subagent via the Task tool.
-This subagent runs **concurrently** with the code review subagents during Step 2.
-
-Spawn it with:
-- \`subagent_type\`: "security-reviewer"
-- \`description\`: "Security review"
-- \`prompt\`: Include the full PR context (repo, PR number, head SHA, base ref) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
-
-**IMPORTANT**: Spawn the security-reviewer in the SAME response as the code review subagents so they all run in parallel.
-
-After all subagents complete (both code review and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but are prefixed with \`[security]\` in their body (e.g., \`[P1] [security] Title\`).
-`
-    : "";
-
-  return `You are a senior staff software engineer and expert code reviewer.
-
-Your task: Review PR #${prNumber} in ${repoFullName} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
-
-${skillInstruction}${securitySubagentInstruction}
-
-<context>
-Repo: ${repoFullName}
-PR Number: ${prNumber}
-PR Head Ref: ${prHeadRef}
-PR Head SHA: ${prHeadSha}
-PR Base Ref: ${prBaseRef}
-
-Precomputed data files:
-- PR Description: \`${descriptionPath}\`
-- Full PR Diff: \`${diffPath}\`
-- Existing Comments: \`${commentsPath}\`
-</context>
-
-<output_spec>
-Write output to \`${reviewCandidatesPath}\` using this exact schema:
-
-\`\`\`json
-{
-  "version": 1,
-  "meta": {
-    "repo": "owner/repo",
-    "prNumber": 123,
-    "headSha": "<head sha>",
-    "baseRef": "main",
-    "generatedAt": "<ISO timestamp>"
-  },
-  "comments": [
-    {
-      "path": "src/index.ts",
-      "body": "[P1] Title\\n\\n1 paragraph.",
-      "line": 42,
-      "startLine": null,
-      "side": "RIGHT",
-      "commit_id": "<head sha>"
-    }
-  ],
-  "reviewSummary": {
-    "body": "1-3 sentence overall assessment"
-  }
-}
-\`\`\`
-
-<schema_details>
-- **version**: Always \`1\`
-
-- **meta**: Metadata object
-  - \`repo\`: "${repoFullName}"
-  - \`prNumber\`: ${prNumber}
-  - \`headSha\`: "${prHeadSha}"
-  - \`baseRef\`: "${prBaseRef}"
-  - \`generatedAt\`: ISO 8601 timestamp (e.g., "2024-01-15T10:30:00Z")
-
-- **comments**: Array of comment objects
-  - \`path\`: Relative file path (e.g., "src/index.ts")
-${bodyFieldDescription}
-  - \`line\`: Target line number (single-line) or end line number (multi-line). Must be ≥ 0.
-  - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
-${sideFieldDescription}
-  - \`commit_id\`: "${prHeadSha}"
-
-- **reviewSummary**:
-  - \`body\`: 1-3 sentence overall assessment
-</schema_details>
-</output_spec>
-
-<critical_constraints>
-**DO NOT** post to GitHub.
-**DO NOT** invoke any PR mutation tools (inline comments, submit review, delete/minimize/reply/resolve, etc.).
-**DO NOT** modify any files other than writing to \`${reviewCandidatesPath}\`.
-Output ONLY the JSON file—no additional commentary.
-</critical_constraints>
-`;
+  return generateCandidatesPrompt({
+    terminology: GITHUB_TERMINOLOGY,
+    entityNumber: prNumber,
+    repoOrProject: context.repository,
+    headRef: context.prBranchData?.headRefName ?? "unknown",
+    headSha: context.prBranchData?.headRefOid ?? "unknown",
+    baseRef: context.eventData.baseBranch ?? "unknown",
+    diffPath:
+      context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff",
+    commentsPath:
+      context.reviewArtifacts?.commentsPath ??
+      "$RUNNER_TEMP/droid-prompts/existing_comments.json",
+    descriptionPath:
+      context.reviewArtifacts?.descriptionPath ??
+      "$RUNNER_TEMP/droid-prompts/pr_description.txt",
+    candidatesPath:
+      process.env.REVIEW_CANDIDATES_PATH ??
+      "$RUNNER_TEMP/droid-prompts/review_candidates.json",
+    includeSuggestions: context.includeSuggestions !== false,
+    securityReviewEnabled: process.env.SECURITY_REVIEW_ENABLED === "true",
+  });
 }

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -1,3 +1,14 @@
+/**
+ * GitHub Pass-2 (validator) prompt — thin adapter.
+ *
+ * Delegates to the platform-agnostic builder in
+ * `src/core/review/prompts/validator.ts`, mapping the GitHub
+ * `PreparedContext` shape onto the shared `ReviewPromptContext` and
+ * supplying `GITHUB_TERMINOLOGY`.
+ */
+
+import { generateValidatorPrompt } from "../../core/review/prompts/validator";
+import { GITHUB_TERMINOLOGY } from "../terminology";
 import type { PreparedContext } from "../types";
 
 export function generateReviewValidatorPrompt(
@@ -9,124 +20,28 @@ export function generateReviewValidatorPrompt(
       ? String(context.githubContext.entityNumber)
       : "unknown";
 
-  const repoFullName = context.repository;
-  const prHeadRef = context.prBranchData?.headRefName ?? "unknown";
-  const prHeadSha = context.prBranchData?.headRefOid ?? "unknown";
-  const prBaseRef = context.eventData.baseBranch ?? "unknown";
-
-  const diffPath =
-    context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff";
-  const commentsPath =
-    context.reviewArtifacts?.commentsPath ??
-    "$RUNNER_TEMP/droid-prompts/existing_comments.json";
-  const descriptionPath =
-    context.reviewArtifacts?.descriptionPath ??
-    "$RUNNER_TEMP/droid-prompts/pr_description.txt";
-
-  const reviewCandidatesPath =
-    process.env.REVIEW_CANDIDATES_PATH ??
-    "$RUNNER_TEMP/droid-prompts/review_candidates.json";
-  const reviewValidatedPath =
-    process.env.REVIEW_VALIDATED_PATH ??
-    "$RUNNER_TEMP/droid-prompts/review_validated.json";
-
-  const includeSuggestions = context.includeSuggestions !== false;
-
-  const skillInstruction = includeSuggestions
-    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure — including suggestion block rules."
-    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure. Do NOT include code suggestion blocks.";
-
-  return `You are validating candidate review comments for PR #${prNumber} in ${repoFullName}.
-
-IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
-
-${skillInstruction}
-
-### Context
-
-* Repo: ${repoFullName}
-* PR Number: ${prNumber}
-* PR Head Ref: ${prHeadRef}
-* PR Head SHA: ${prHeadSha}
-* PR Base Ref: ${prBaseRef}
-
-### Inputs
-
-Read these files before validating:
-* PR Description: \`${descriptionPath}\`
-* Candidates: \`${reviewCandidatesPath}\`
-* Full PR Diff: \`${diffPath}\`
-* Existing Comments: \`${commentsPath}\`
-
-If the diff is large, read in chunks (offset/limit). **Do not proceed until you have read the ENTIRE diff.**
-
-### Critical Requirements
-
-1. You MUST read and validate **every** candidate before posting anything.
-2. Preserve ordering: keep results in the same order as candidates.
-3. **Posting rule (STRICT):** Only post comments where \`status === "approved"\`. Never post rejected items.
-
-### Output: Write \`${reviewValidatedPath}\`
-
-\`\`\`json
-{
-  "version": 1,
-  "meta": {
-    "repo": "${repoFullName}",
-    "prNumber": ${prNumber},
-    "headSha": "${prHeadSha}",
-    "baseRef": "${prBaseRef}",
-    "validatedAt": "<ISO timestamp>"
-  },
-  "results": [
-    {
-      "status": "approved",
-      "comment": {
-        "path": "src/index.ts",
-        "body": "[P1] Title\\n\\n1 paragraph.",
-        "line": 42,
-        "startLine": null,
-        "side": "RIGHT",
-        "commit_id": "${prHeadSha}"
-      }
-    },
-    {
-      "status": "rejected",
-      "candidate": {
-        "path": "src/other.ts",
-        "body": "[P2] ...",
-        "line": 10,
-        "startLine": null,
-        "side": "RIGHT",
-        "commit_id": "${prHeadSha}"
-      },
-      "reason": "Not a real bug because ..."
-    }
-  ],
-  "reviewSummary": {
-    "status": "approved",
-    "body": "1-3 sentence overall assessment"
-  }
-}
-\`\`\`
-
-Notes:
-* Use \`commit_id\` = \`${prHeadSha}\`.
-* \`results\` MUST have exactly one entry per candidate, in the same order.
-
-Tooling note:
-* If the tools list includes \`ApplyPatch\` (common for OpenAI models like GPT-5.2), use \`ApplyPatch\` to create/update the file at the exact path.
-* Otherwise, use \`Create\` (or \`Edit\` if overwriting) to write the file.
-
-### Post approved items
-
-After writing \`${reviewValidatedPath}\`, post comments ONLY for \`status === "approved"\`:
-
-* Collect all approved comments and submit them as a **single batched review** via \`github_pr___submit_review\`, passing them in the \`comments\` array parameter.
-* Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
-* Do **NOT** include a \`body\` parameter in \`submit_review\`.
-* Use \`github_comment___update_droid_comment\` to update the tracking comment with the review summary.
-* Do **NOT** post the summary as a separate comment or as the body of \`submit_review\`.
-* Do not approve or request changes.
-`;
+  return generateValidatorPrompt({
+    terminology: GITHUB_TERMINOLOGY,
+    entityNumber: prNumber,
+    repoOrProject: context.repository,
+    headRef: context.prBranchData?.headRefName ?? "unknown",
+    headSha: context.prBranchData?.headRefOid ?? "unknown",
+    baseRef: context.eventData.baseBranch ?? "unknown",
+    diffPath:
+      context.reviewArtifacts?.diffPath ?? "$RUNNER_TEMP/droid-prompts/pr.diff",
+    commentsPath:
+      context.reviewArtifacts?.commentsPath ??
+      "$RUNNER_TEMP/droid-prompts/existing_comments.json",
+    descriptionPath:
+      context.reviewArtifacts?.descriptionPath ??
+      "$RUNNER_TEMP/droid-prompts/pr_description.txt",
+    candidatesPath:
+      process.env.REVIEW_CANDIDATES_PATH ??
+      "$RUNNER_TEMP/droid-prompts/review_candidates.json",
+    validatedPath:
+      process.env.REVIEW_VALIDATED_PATH ??
+      "$RUNNER_TEMP/droid-prompts/review_validated.json",
+    includeSuggestions: context.includeSuggestions !== false,
+    securityReviewEnabled: process.env.SECURITY_REVIEW_ENABLED === "true",
+  });
 }

--- a/src/create-prompt/terminology.ts
+++ b/src/create-prompt/terminology.ts
@@ -1,0 +1,32 @@
+import type { ReviewTerminology } from "../core/review/prompts/types";
+
+export const GITHUB_TERMINOLOGY: ReviewTerminology = {
+  entityNoun: "PR",
+  entityNumberSigil: "#",
+  platformName: "GitHub",
+  repoLabel: "Repo",
+  entityNumberLabel: "PR Number",
+  headRefLabel: "PR Head Ref",
+  headShaLabel: "PR Head SHA",
+  baseRefLabel: "PR Base Ref",
+  descriptionLabel: "PR Description",
+  diffLabel: "Full PR Diff",
+  metaRepoKey: "repo",
+  metaEntityNumberKey: "prNumber",
+  metaBaseRefKey: "baseRef",
+  repoExample: "owner/repo",
+  pathFieldDescription: 'Relative file path (e.g., "src/index.ts")',
+  lineFieldDescription:
+    "Target line number (single-line) or end line number (multi-line). Must be ≥ 0.",
+  mutationToolForbiddance:
+    "(inline comments, submit review, delete/minimize/reply/resolve, etc.)",
+  submitReviewToolName: "github_pr___submit_review",
+  submitReviewExtraArg: "",
+  submitReviewBodyExclusionTrailer: "",
+  updateTrackingToolName: "github_comment___update_droid_comment",
+  trackingCommentName: "tracking comment",
+  summaryEntityName: "comment",
+  summaryPostingExtraExclusion: " or as the body of `submit_review`",
+  approvalChangesNote: "Do not approve or request changes.",
+  // No security-badge instruction on GitHub today; left undefined intentionally.
+};

--- a/src/create-prompt/terminology.ts
+++ b/src/create-prompt/terminology.ts
@@ -9,6 +9,7 @@ export const GITHUB_TERMINOLOGY: ReviewTerminology = {
   headRefLabel: "PR Head Ref",
   headShaLabel: "PR Head SHA",
   baseRefLabel: "PR Base Ref",
+  baseRefShortLabel: "base ref",
   descriptionLabel: "PR Description",
   diffLabel: "Full PR Diff",
   metaRepoKey: "repo",

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -1,4 +1,5 @@
 import type { GitHubContext } from "../github/context";
+import type { ReviewArtifactPaths } from "../core/review/artifacts/types";
 
 export type CommonFields = {
   repository: string;
@@ -103,11 +104,7 @@ export type EventData =
   | PullRequestEvent
   | PullRequestTargetEvent;
 
-export type ReviewArtifacts = {
-  diffPath: string;
-  commentsPath: string;
-  descriptionPath: string;
-};
+export type ReviewArtifacts = ReviewArtifactPaths;
 
 export type PreparedContext = CommonFields & {
   eventData: EventData;

--- a/src/github/utils/command-parser.ts
+++ b/src/github/utils/command-parser.ts
@@ -1,87 +1,19 @@
 /**
- * Command parser for detecting specific @droid commands in GitHub comments and PR bodies
+ * Command parser for detecting specific @droid commands in GitHub
+ * comments and PR bodies. The pure string-parsing portion is platform-
+ * agnostic and lives in `src/core/review/triggers/parse-command.ts`;
+ * this file owns the GitHub-payload-aware context extraction.
  */
 
 import type { GitHubContext } from "../context";
+import {
+  parseDroidCommand,
+  type DroidCommand,
+  type ParsedCommand,
+} from "../../core/review/triggers/parse-command";
 
-export type DroidCommand =
-  | "fill"
-  | "review"
-  | "security"
-  | "security-full"
-  | "default";
-
-export interface ParsedCommand {
-  command: DroidCommand;
-  raw: string;
-  location: "body" | "comment";
-  timestamp?: string | null;
-}
-
-/**
- * Parses text to detect specific @droid commands
- * @param text The text to parse (comment body or PR description)
- * @returns ParsedCommand if a command is found, null otherwise
- */
-export function parseDroidCommand(text: string): ParsedCommand | null {
-  if (!text) {
-    return null;
-  }
-
-  // Check for @droid fill command (case insensitive)
-  const fillMatch = text.match(/@droid\s+fill/i);
-  if (fillMatch) {
-    return {
-      command: "fill",
-      raw: fillMatch[0],
-      location: "body", // Will be set by caller
-    };
-  }
-
-  // Check for @droid review command (case insensitive)
-  // Note: @droid review security will match as just @droid review
-  const reviewMatch = text.match(/@droid\s+review/i);
-  if (reviewMatch) {
-    return {
-      command: "review",
-      raw: reviewMatch[0],
-      location: "body", // Will be set by caller
-    };
-  }
-
-  // Check for @droid security --full command (case insensitive)
-  const securityFullMatch = text.match(/@droid\s+security\s+--full/i);
-  if (securityFullMatch) {
-    return {
-      command: "security-full",
-      raw: securityFullMatch[0],
-      location: "body", // Will be set by caller
-    };
-  }
-
-  // Check for @droid security command (case insensitive)
-  // Must check after security-full to avoid false matches
-  const securityMatch = text.match(/@droid\s+security(?:\s|$|[^-\w])/i);
-  if (securityMatch) {
-    return {
-      command: "security",
-      raw: securityMatch[0].trim(),
-      location: "body", // Will be set by caller
-    };
-  }
-
-  // Check for generic @droid mention (default behavior)
-  const droidMatch = text.match(/@droid/i);
-  if (droidMatch) {
-    return {
-      command: "default",
-      raw: droidMatch[0],
-      location: "body", // Will be set by caller
-    };
-  }
-
-  return null;
-}
+export type { DroidCommand, ParsedCommand };
+export { parseDroidCommand };
 
 /**
  * Extracts a droid command from the GitHub context
@@ -91,12 +23,10 @@ export function parseDroidCommand(text: string): ParsedCommand | null {
 export function extractCommandFromContext(
   context: GitHubContext,
 ): ParsedCommand | null {
-  // Handle missing payload
   if (!context.payload) {
     return null;
   }
 
-  // Check PR body for commands (pull_request events)
   if (
     context.eventName === "pull_request" &&
     "pull_request" in context.payload
@@ -110,7 +40,6 @@ export function extractCommandFromContext(
     }
   }
 
-  // Check issue body for commands (issues events)
   if (context.eventName === "issues" && "issue" in context.payload) {
     const body = context.payload.issue.body;
     if (body) {
@@ -121,7 +50,6 @@ export function extractCommandFromContext(
     }
   }
 
-  // Check comment body for commands (issue_comment events)
   if (context.eventName === "issue_comment" && "comment" in context.payload) {
     const comment = context.payload.comment;
     if (comment.body) {
@@ -136,7 +64,6 @@ export function extractCommandFromContext(
     }
   }
 
-  // Check review comment body (pull_request_review_comment events)
   if (
     context.eventName === "pull_request_review_comment" &&
     "comment" in context.payload
@@ -154,7 +81,6 @@ export function extractCommandFromContext(
     }
   }
 
-  // Check review body (pull_request_review events)
   if (
     context.eventName === "pull_request_review" &&
     "review" in context.payload

--- a/src/gitlab/data/review-artifacts.ts
+++ b/src/gitlab/data/review-artifacts.ts
@@ -9,19 +9,17 @@
  * These mirror the artifacts the GitHub Action precomputes
  * (`pr.diff`, `existing_comments.json`, `pr_description.txt`) so the GitLab
  * Pass-1 / Pass-2 prompts can refer to them by stable paths and the model
- * doesn't have to round-trip through MCP tools to fetch them.
+ * doesn't have to round-trip through MCP tools to fetch them. The disk
+ * write itself uses the shared `writeReviewArtifacts` helper in
+ * `src/core/review/artifacts/write.ts`.
  */
 
-import * as fs from "fs/promises";
-import * as path from "path";
+import { writeReviewArtifacts } from "../../core/review/artifacts/write";
+import type { ReviewArtifactPaths } from "../../core/review/artifacts/types";
 import type { GitlabClient } from "../api/client";
 import type { GitlabMr, GitlabMrChanges, GitlabNote } from "../types";
 
-export type GitlabReviewArtifactPaths = {
-  diffPath: string;
-  commentsPath: string;
-  descriptionPath: string;
-};
+export type GitlabReviewArtifactPaths = ReviewArtifactPaths;
 
 export type GitlabReviewArtifacts = GitlabReviewArtifactPaths & {
   mr: GitlabMr;
@@ -62,33 +60,25 @@ export async function computeReviewArtifacts(
 ): Promise<GitlabReviewArtifacts> {
   const { client, projectId, mrIid, outDir } = opts;
 
-  await fs.mkdir(outDir, { recursive: true });
-
   const [mr, changes, notes] = await Promise.all([
     client.getMr(projectId, mrIid),
     client.getMrChanges(projectId, mrIid),
     client.listNotes(projectId, mrIid),
   ]);
 
-  const diffPath = path.join(outDir, "mr.diff");
-  const commentsPath = path.join(outDir, "existing_comments.json");
-  const descriptionPath = path.join(outDir, "mr_description.txt");
+  const paths = await writeReviewArtifacts(
+    outDir,
+    {
+      diff: buildDiffContent(changes),
+      comments: notes,
+      description: buildDescriptionContent(mr),
+    },
+    {
+      diff: "mr.diff",
+      comments: "existing_comments.json",
+      description: "mr_description.txt",
+    },
+  );
 
-  const diffContent = buildDiffContent(changes);
-  const descriptionContent = buildDescriptionContent(mr);
-
-  await Promise.all([
-    fs.writeFile(diffPath, diffContent),
-    fs.writeFile(commentsPath, JSON.stringify(notes, null, 2)),
-    fs.writeFile(descriptionPath, descriptionContent),
-  ]);
-
-  return {
-    diffPath,
-    commentsPath,
-    descriptionPath,
-    mr,
-    changes,
-    notes,
-  };
+  return { ...paths, mr, changes, notes };
 }

--- a/src/gitlab/operations/tracking-note.ts
+++ b/src/gitlab/operations/tracking-note.ts
@@ -29,7 +29,7 @@ export type TrackingNoteTelemetry = NonNullable<
 >;
 export type TrackingNoteOptions = ReviewTrackingFields;
 
-const SECURITY_BADGE =
+export const SECURITY_BADGE =
   "![security](https://img.shields.io/badge/security%20review-enabled-blue?style=flat-square&logo=shield) ";
 
 const STATE_HEADER: Record<TrackingNoteState, string> = {

--- a/src/gitlab/operations/tracking-note.ts
+++ b/src/gitlab/operations/tracking-note.ts
@@ -3,44 +3,31 @@
  *
  * The tracking note carries a hidden HTML marker so we can find and
  * update the same note across retries instead of creating duplicates.
+ *
+ * The state machine (running/success/failure), telemetry shape, and
+ * formatting helpers are platform-agnostic and live in
+ * `src/core/review/tracking/`. This file owns the GitLab-specific body
+ * rendering, including the markdown layout, the security badge, the
+ * error-details accordion, and the hidden marker conventions.
  */
+
+import {
+  formatCostUsd,
+  formatDurationMs,
+} from "../../core/review/tracking/format";
+import type {
+  ReviewTrackingFields,
+  ReviewTrackingState,
+} from "../../core/review/tracking/types";
 
 export const DROID_TRACKING_MARKER = "<!-- droid-tracking-note -->";
 export const DROID_SECURITY_BADGE_MARKER = "<!-- droid-security-badge -->";
 
-export type TrackingNoteState = "running" | "success" | "failure";
-
-export type TrackingNoteTelemetry = {
-  totalNumTurns?: number | null;
-  totalDurationMs?: number | null;
-  totalCostUsd?: number | null;
-  pass1SessionId?: string | null;
-  pass2SessionId?: string | null;
-};
-
-export interface TrackingNoteOptions {
-  state: TrackingNoteState;
-  pipelineUrl?: string | null;
-  jobUrl?: string | null;
-  triggerUsername?: string | null;
-  errorDetails?: string | null;
-  securityReviewRan?: boolean;
-  telemetry?: TrackingNoteTelemetry | null;
-}
-
-function formatDurationMs(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remSec = Math.round(seconds - minutes * 60);
-  return `${minutes}m ${remSec}s`;
-}
-
-function formatCostUsd(usd: number): string {
-  if (usd >= 1) return `$${usd.toFixed(2)}`;
-  return `$${usd.toFixed(4)}`;
-}
+export type TrackingNoteState = ReviewTrackingState;
+export type TrackingNoteTelemetry = NonNullable<
+  ReviewTrackingFields["telemetry"]
+>;
+export type TrackingNoteOptions = ReviewTrackingFields;
 
 const SECURITY_BADGE =
   "![security](https://img.shields.io/badge/security%20review-enabled-blue?style=flat-square&logo=shield) ";

--- a/src/gitlab/prompts/candidates.ts
+++ b/src/gitlab/prompts/candidates.ts
@@ -1,148 +1,35 @@
 /**
- * GitLab Pass-1 (candidate generation) prompt.
+ * GitLab Pass-1 (candidate generation) prompt — thin adapter.
  *
- * Direct port of the GitHub Action's
- * `src/create-prompt/templates/review-candidates-prompt.ts` with PR→MR
- * terminology and GitLab-specific entity numbering. The /review skill
- * itself is platform-agnostic and contains the two-pass methodology; this
- * file is the runtime harness that tells Droid which pass it's in, where
- * the input artifacts live on disk, and where to write the candidate JSON.
+ * Delegates to the platform-agnostic builder in
+ * `src/core/review/prompts/candidates.ts` after mapping the GitLab
+ * context shape onto the shared `ReviewPromptContext` and supplying
+ * `GITLAB_TERMINOLOGY` (PR→MR labels, GitLab MCP tool names, etc.).
  *
- * STRICT contract: this prompt MUST NOT instruct the model to call the
- * GitLab posting tool (`gitlab_mr___submit_review`). Posting only happens
- * in Pass 2. Tool gating is also enforced at the `droid exec` level by
- * excluding `gitlab_mr___submit_review` from `--enabled-tools` during
- * Pass 1.
+ * The GitLab posting tool is exposed only in Pass 2; this Pass 1 prompt
+ * MUST NOT instruct the model to call it. The shared builder enforces
+ * that, plus tool gating at the `droid exec` level via `--enabled-tools`.
  */
 
+import { generateCandidatesPrompt } from "../../core/review/prompts/candidates";
+import { GITLAB_TERMINOLOGY } from "./terminology";
 import type { GitlabReviewPromptContext } from "./types";
 
 export function generateGitlabReviewCandidatesPrompt(
   ctx: GitlabReviewPromptContext,
 ): string {
-  const {
-    projectPath,
-    mrIid,
-    sourceBranch,
-    targetBranch,
-    headSha,
-    diffPath,
-    commentsPath,
-    descriptionPath,
-    candidatesPath,
-    includeSuggestions,
-    securityReviewEnabled,
-  } = ctx;
-
-  const bodyFieldDescription = includeSuggestions
-    ? "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation.\n" +
-      "    Follow the suggestion block rules from the review skill when including suggestions."
-    : "  - `body`: Comment text starting with priority tag [P0|P1|P2], then title, then 1 paragraph explanation";
-
-  const sideFieldDescription = includeSuggestions
-    ? '  - `side`: "RIGHT" for new/modified code (default). Use "LEFT" only for removed code **without** suggestions.\n' +
-      "    If you include a suggestion block, choose a RIGHT-side anchor and keep it unchanged so the validator can reuse it."
-    : '  - `side`: "RIGHT" for new/modified code (default), "LEFT" only for removed code';
-
-  const skillInstruction = includeSuggestions
-    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure — including suggestion block rules."
-    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 1: Candidate Generation** procedure. Do NOT include code suggestion blocks.";
-
-  const securitySubagentInstruction = securityReviewEnabled
-    ? `
-
-## Security Review (run concurrently)
-
-In addition to the code review, you MUST also spawn a \`security-reviewer\` subagent via the Task tool.
-This subagent runs **concurrently** with the code review subagents during Step 2.
-
-Spawn it with:
-- \`subagent_type\`: "security-reviewer"
-- \`description\`: "Security review"
-- \`prompt\`: Include the full MR context (project, MR IID, head SHA, target branch) and the paths to precomputed data files (diff, description, existing comments). The security-reviewer will invoke the security-review skill and return a JSON array of security findings.
-
-**IMPORTANT**: Spawn the security-reviewer in the SAME response as the code review subagents so they all run in parallel.
-
-After all subagents complete (both code review and security-reviewer), merge the security findings into the \`comments\` array alongside code review findings. Security findings use the same schema but are prefixed with \`[security]\` in their body (e.g., \`[P1] [security] Title\`).
-`
-    : "";
-
-  return `You are a senior staff software engineer and expert code reviewer.
-
-Your task: Review MR !${mrIid} in ${projectPath} and generate a JSON file with **high-confidence, actionable** review comments that pinpoint genuine issues.
-
-${skillInstruction}${securitySubagentInstruction}
-
-<context>
-Project: ${projectPath}
-MR IID: ${mrIid}
-MR Source Branch: ${sourceBranch}
-MR Head SHA: ${headSha}
-MR Target Branch: ${targetBranch}
-
-Precomputed data files:
-- MR Description: \`${descriptionPath}\`
-- Full MR Diff: \`${diffPath}\`
-- Existing Comments: \`${commentsPath}\`
-</context>
-
-<output_spec>
-Write output to \`${candidatesPath}\` using this exact schema:
-
-\`\`\`json
-{
-  "version": 1,
-  "meta": {
-    "project": "group/project",
-    "mrIid": 123,
-    "headSha": "<head sha>",
-    "targetBranch": "main",
-    "generatedAt": "<ISO timestamp>"
-  },
-  "comments": [
-    {
-      "path": "src/index.ts",
-      "body": "[P1] Title\\n\\n1 paragraph.",
-      "line": 42,
-      "startLine": null,
-      "side": "RIGHT",
-      "commit_id": "<head sha>"
-    }
-  ],
-  "reviewSummary": {
-    "body": "1-3 sentence overall assessment"
-  }
-}
-\`\`\`
-
-<schema_details>
-- **version**: Always \`1\`
-
-- **meta**: Metadata object
-  - \`project\`: "${projectPath}"
-  - \`mrIid\`: ${mrIid}
-  - \`headSha\`: "${headSha}"
-  - \`targetBranch\`: "${targetBranch}"
-  - \`generatedAt\`: ISO 8601 timestamp (e.g., "2024-01-15T10:30:00Z")
-
-- **comments**: Array of comment objects
-  - \`path\`: Relative file path (use the new_path from the diff, e.g., "src/index.ts")
-${bodyFieldDescription}
-  - \`line\`: Target line number in the new file (single-line) or end line number (multi-line). Must be ≥ 0.
-  - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
-${sideFieldDescription}
-  - \`commit_id\`: "${headSha}"
-
-- **reviewSummary**:
-  - \`body\`: 1-3 sentence overall assessment
-</schema_details>
-</output_spec>
-
-<critical_constraints>
-**DO NOT** post to GitLab.
-**DO NOT** invoke any MR mutation tools (\`gitlab_mr___submit_review\`, \`gitlab_mr___create_mr_note\`, \`gitlab_mr___update_mr_note\`, \`gitlab_mr___update_mr_description\`, \`gitlab_mr___update_tracking_note\`, etc.).
-**DO NOT** modify any files other than writing to \`${candidatesPath}\`.
-Output ONLY the JSON file—no additional commentary.
-</critical_constraints>
-`;
+  return generateCandidatesPrompt({
+    terminology: GITLAB_TERMINOLOGY,
+    entityNumber: ctx.mrIid,
+    repoOrProject: ctx.projectPath,
+    headRef: ctx.sourceBranch,
+    headSha: ctx.headSha,
+    baseRef: ctx.targetBranch,
+    diffPath: ctx.diffPath,
+    commentsPath: ctx.commentsPath,
+    descriptionPath: ctx.descriptionPath,
+    candidatesPath: ctx.candidatesPath,
+    includeSuggestions: ctx.includeSuggestions,
+    securityReviewEnabled: ctx.securityReviewEnabled,
+  });
 }

--- a/src/gitlab/prompts/terminology.ts
+++ b/src/gitlab/prompts/terminology.ts
@@ -10,6 +10,7 @@ export const GITLAB_TERMINOLOGY: ReviewTerminology = {
   headRefLabel: "MR Source Branch",
   headShaLabel: "MR Head SHA",
   baseRefLabel: "MR Target Branch",
+  baseRefShortLabel: "target branch",
   descriptionLabel: "MR Description",
   diffLabel: "Full MR Diff",
   metaRepoKey: "project",
@@ -32,7 +33,7 @@ export const GITLAB_TERMINOLOGY: ReviewTerminology = {
   summaryPostingExtraExclusion: "",
   approvalChangesNote:
     "Do not approve the MR or request changes (GitLab approval rules are handled out-of-band).",
-  securityBadgeInstruction: `If any approved comments contain \`[security]\` in their body, ensure a security badge is prepended to the tracking note body: \`${SECURITY_BADGE.trim()}\`. This indicates that security analysis was performed as part of the review.`,
+  securityBadgeInstruction: `If any approved comments contain \`[security]\` in their body, ensure a security badge is prepended to the tracking note body using exactly this markdown image (no surrounding backticks or code fences): ${SECURITY_BADGE.trim()} — this indicates that security analysis was performed as part of the review.`,
 };
 
 /**

--- a/src/gitlab/prompts/terminology.ts
+++ b/src/gitlab/prompts/terminology.ts
@@ -1,4 +1,5 @@
 import type { ReviewTerminology } from "../../core/review/prompts/types";
+import { SECURITY_BADGE } from "../operations/tracking-note";
 
 export const GITLAB_TERMINOLOGY: ReviewTerminology = {
   entityNoun: "MR",
@@ -31,8 +32,7 @@ export const GITLAB_TERMINOLOGY: ReviewTerminology = {
   summaryPostingExtraExclusion: "",
   approvalChangesNote:
     "Do not approve the MR or request changes (GitLab approval rules are handled out-of-band).",
-  securityBadgeInstruction:
-    "If any approved comments contain `[security]` in their body, prepend a security badge to the tracking note: `![Security Review](https://img.shields.io/badge/security%20review-ran-blue)`. This indicates that security analysis was performed as part of the review.",
+  securityBadgeInstruction: `If any approved comments contain \`[security]\` in their body, ensure a security badge is prepended to the tracking note body: \`${SECURITY_BADGE.trim()}\`. This indicates that security analysis was performed as part of the review.`,
 };
 
 /**

--- a/src/gitlab/prompts/terminology.ts
+++ b/src/gitlab/prompts/terminology.ts
@@ -1,0 +1,48 @@
+import type { ReviewTerminology } from "../../core/review/prompts/types";
+
+export const GITLAB_TERMINOLOGY: ReviewTerminology = {
+  entityNoun: "MR",
+  entityNumberSigil: "!",
+  platformName: "GitLab",
+  repoLabel: "Project",
+  entityNumberLabel: "MR IID",
+  headRefLabel: "MR Source Branch",
+  headShaLabel: "MR Head SHA",
+  baseRefLabel: "MR Target Branch",
+  descriptionLabel: "MR Description",
+  diffLabel: "Full MR Diff",
+  metaRepoKey: "project",
+  metaEntityNumberKey: "mrIid",
+  metaBaseRefKey: "targetBranch",
+  repoExample: "group/project",
+  pathFieldDescription:
+    'Relative file path (use the new_path from the diff, e.g., "src/index.ts")',
+  lineFieldDescription:
+    "Target line number in the new file (single-line) or end line number (multi-line). Must be ≥ 0.",
+  mutationToolForbiddance:
+    "(`gitlab_mr___submit_review`, `gitlab_mr___create_mr_note`, `gitlab_mr___update_mr_note`, `gitlab_mr___update_mr_description`, `gitlab_mr___update_tracking_note`, etc.)",
+  submitReviewToolName: "gitlab_mr___submit_review",
+  submitReviewExtraArg: "", // populated dynamically below via factory
+  submitReviewBodyExclusionTrailer:
+    " (we use a separate tracking note for the summary)",
+  updateTrackingToolName: "gitlab_mr___update_tracking_note",
+  trackingCommentName: "sticky tracking note",
+  summaryEntityName: "top-level note",
+  summaryPostingExtraExclusion: "",
+  approvalChangesNote:
+    "Do not approve the MR or request changes (GitLab approval rules are handled out-of-band).",
+  securityBadgeInstruction:
+    "If any approved comments contain `[security]` in their body, prepend a security badge to the tracking note: `![Security Review](https://img.shields.io/badge/security%20review-ran-blue)`. This indicates that security analysis was performed as part of the review.",
+};
+
+/**
+ * Build the GitLab terminology with the runtime MR IID baked into the
+ * "passing them in the comments array parameter along with mr_iid: N" arg.
+ * GitLab's submit_review tool needs the IID re-asserted in the call.
+ */
+export function gitlabTerminologyFor(mrIid: number): ReviewTerminology {
+  return {
+    ...GITLAB_TERMINOLOGY,
+    submitReviewExtraArg: ` along with \`mr_iid: ${mrIid}\``,
+  };
+}

--- a/src/gitlab/prompts/validator.ts
+++ b/src/gitlab/prompts/validator.ts
@@ -1,132 +1,37 @@
 /**
- * GitLab Pass-2 (validator) prompt.
+ * GitLab Pass-2 (validator) prompt — thin adapter.
  *
- * Direct port of the GitHub Action's
- * `src/create-prompt/templates/review-validator-prompt.ts` with PR→MR
- * terminology and the GitLab MCP tool names. The validator reads the
- * candidates JSON produced by Pass 1 from disk, validates each one,
- * writes a refined JSON, and posts the approved findings as a single
- * batched call to `gitlab_mr___submit_review`.
+ * Delegates to the platform-agnostic builder in
+ * `src/core/review/prompts/validator.ts` after mapping the GitLab
+ * context shape onto the shared `ReviewPromptContext` and supplying
+ * `gitlabTerminologyFor(mrIid)` (which bakes the MR IID into the
+ * submit_review call hint, since GitLab's tool requires `mr_iid` to be
+ * re-asserted in the invocation).
  *
- * Pass 2 is the only place where the posting tool is exposed (via
+ * Pass 2 is the only place the GitLab posting tool is exposed (via
  * `--enabled-tools` on the second `droid exec` invocation).
  */
 
+import { generateValidatorPrompt } from "../../core/review/prompts/validator";
+import { gitlabTerminologyFor } from "./terminology";
 import type { GitlabReviewPromptContext } from "./types";
 
 export function generateGitlabReviewValidatorPrompt(
   ctx: GitlabReviewPromptContext,
 ): string {
-  const {
-    projectPath,
-    mrIid,
-    sourceBranch,
-    targetBranch,
-    headSha,
-    diffPath,
-    commentsPath,
-    descriptionPath,
-    candidatesPath,
-    validatedPath,
-    includeSuggestions,
-  } = ctx;
-
-  const skillInstruction = includeSuggestions
-    ? "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure — including suggestion block rules."
-    : "Invoke the 'review' skill to load the review methodology, then execute its **Pass 2: Validation** procedure. Do NOT include code suggestion blocks.";
-
-  return `You are validating candidate review comments for MR !${mrIid} in ${projectPath}.
-
-IMPORTANT: This is Phase 2 (validator) of a two-pass review pipeline.
-
-${skillInstruction}
-
-### Context
-
-* Project: ${projectPath}
-* MR IID: ${mrIid}
-* MR Source Branch: ${sourceBranch}
-* MR Head SHA: ${headSha}
-* MR Target Branch: ${targetBranch}
-
-### Inputs
-
-Read these files before validating:
-* MR Description: \`${descriptionPath}\`
-* Candidates: \`${candidatesPath}\`
-* Full MR Diff: \`${diffPath}\`
-* Existing Comments: \`${commentsPath}\`
-
-If the diff is large, read in chunks (offset/limit). **Do not proceed until you have read the ENTIRE diff.**
-
-### Critical Requirements
-
-1. You MUST read and validate **every** candidate before posting anything.
-2. Preserve ordering: keep results in the same order as candidates.
-3. **Posting rule (STRICT):** Only post comments where \`status === "approved"\`. Never post rejected items.
-
-### Output: Write \`${validatedPath}\`
-
-\`\`\`json
-{
-  "version": 1,
-  "meta": {
-    "project": "${projectPath}",
-    "mrIid": ${mrIid},
-    "headSha": "${headSha}",
-    "targetBranch": "${targetBranch}",
-    "validatedAt": "<ISO timestamp>"
-  },
-  "results": [
-    {
-      "status": "approved",
-      "comment": {
-        "path": "src/index.ts",
-        "body": "[P1] Title\\n\\n1 paragraph.",
-        "line": 42,
-        "startLine": null,
-        "side": "RIGHT",
-        "commit_id": "${headSha}"
-      }
-    },
-    {
-      "status": "rejected",
-      "candidate": {
-        "path": "src/other.ts",
-        "body": "[P2] ...",
-        "line": 10,
-        "startLine": null,
-        "side": "RIGHT",
-        "commit_id": "${headSha}"
-      },
-      "reason": "Not a real bug because ..."
-    }
-  ],
-  "reviewSummary": {
-    "status": "approved",
-    "body": "1-3 sentence overall assessment"
-  }
-}
-\`\`\`
-
-Notes:
-* Use \`commit_id\` = \`${headSha}\`.
-* \`results\` MUST have exactly one entry per candidate, in the same order.
-
-Tooling note:
-* If the tools list includes \`ApplyPatch\` (common for OpenAI models like GPT-5.2), use \`ApplyPatch\` to create/update the file at the exact path.
-* Otherwise, use \`Create\` (or \`Edit\` if overwriting) to write the file.
-
-### Post approved items
-
-After writing \`${validatedPath}\`, post comments ONLY for \`status === "approved"\`:
-
-* Collect all approved comments and submit them as a **single batched review** via \`gitlab_mr___submit_review\`, passing them in the \`comments\` array parameter along with \`mr_iid: ${mrIid}\`.
-* Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
-* Do **NOT** include a \`body\` parameter in \`submit_review\` (we use a separate tracking note for the summary).
-* Use \`gitlab_mr___update_tracking_note\` to update the sticky tracking note with the review summary.
-* If any approved comments contain \`[security]\` in their body, prepend a security badge to the tracking note: \`![Security Review](https://img.shields.io/badge/security%20review-ran-blue)\`. This indicates that security analysis was performed as part of the review.
-* Do **NOT** post the summary as a separate top-level note.
-* Do not approve the MR or request changes (GitLab approval rules are handled out-of-band).
-`;
+  return generateValidatorPrompt({
+    terminology: gitlabTerminologyFor(ctx.mrIid),
+    entityNumber: ctx.mrIid,
+    repoOrProject: ctx.projectPath,
+    headRef: ctx.sourceBranch,
+    headSha: ctx.headSha,
+    baseRef: ctx.targetBranch,
+    diffPath: ctx.diffPath,
+    commentsPath: ctx.commentsPath,
+    descriptionPath: ctx.descriptionPath,
+    candidatesPath: ctx.candidatesPath,
+    validatedPath: ctx.validatedPath,
+    includeSuggestions: ctx.includeSuggestions,
+    securityReviewEnabled: ctx.securityReviewEnabled,
+  });
 }

--- a/test/core/review/tracking/format.test.ts
+++ b/test/core/review/tracking/format.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatCostUsd,
+  formatDurationMs,
+} from "../../../../src/core/review/tracking/format";
+
+describe("formatDurationMs", () => {
+  it("renders sub-second durations in ms", () => {
+    expect(formatDurationMs(0)).toBe("0ms");
+    expect(formatDurationMs(750)).toBe("750ms");
+  });
+
+  it("renders sub-minute durations to one decimal in seconds", () => {
+    expect(formatDurationMs(1500)).toBe("1.5s");
+    expect(formatDurationMs(59999)).toBe("60.0s");
+  });
+
+  it("renders multi-minute durations as `Xm Ys`", () => {
+    expect(formatDurationMs(60000)).toBe("1m 0s");
+    expect(formatDurationMs(90000)).toBe("1m 30s");
+    expect(formatDurationMs(125000)).toBe("2m 5s");
+  });
+
+  it("carries the remainder cleanly when seconds round up to 60", () => {
+    // Pre-fix bug: 119600ms produced "1m 60s" because remSec rounded to 60.
+    expect(formatDurationMs(119600)).toBe("2m 0s");
+    expect(formatDurationMs(179600)).toBe("3m 0s");
+    expect(formatDurationMs(239600)).toBe("4m 0s");
+  });
+});
+
+describe("formatCostUsd", () => {
+  it("uses 4 decimals under $1", () => {
+    expect(formatCostUsd(0.0042)).toBe("$0.0042");
+    expect(formatCostUsd(0.5)).toBe("$0.5000");
+  });
+
+  it("uses 2 decimals at $1 or above", () => {
+    expect(formatCostUsd(1)).toBe("$1.00");
+    expect(formatCostUsd(12.345)).toBe("$12.35");
+  });
+});


### PR DESCRIPTION
## Summary
After Phase 1 GitLab support landed in #93 (squash-merged as `84946f2`), the GitHub and GitLab review paths had several pieces of duplicated or shape-overlapping code. This PR pulls the genuinely shared parts into a new platform-agnostic `src/core/review/` module and converts the platform-specific files into thin adapters / collaborators.
## Changes
New shared module `src/core/review/` (8 files, 566 LOC):
- `prompts/{types,candidates,validator}.ts` — shared Pass 1 / Pass 2 prompt templates plus the `ReviewTerminology` shape.
- `artifacts/{types,write}.ts` — `ReviewArtifactPaths` / `ReviewArtifactContents` shapes and a `writeReviewArtifacts(outDir, contents, names)` helper (`mkdir` + parallel `writeFile×3`).
- `tracking/{types,format}.ts` — `ReviewTrackingState` / `ReviewTrackingTelemetry` / `ReviewTrackingFields` types and `formatDurationMs` / `formatCostUsd` helpers.
- `triggers/parse-command.ts` — `parseDroidCommand(text)` with the regex set for `|review|security|...`.
Modified adapters / collaborators:
- `src/create-prompt/templates/review-{candidates,validator}-prompt.ts` — now thin adapters onto the shared templates.
- `src/create-prompt/terminology.ts` (new) — `GITHUB_TERMINOLOGY`.
- `src/create-prompt/types.ts` — re-exports the shared type.
- `src/github/utils/command-parser.ts` — re-exports the core parser/types so existing imports still resolve.
- `src/gitlab/prompts/{candidates,validator,terminology}.ts` — now thin.
- `src/gitlab/data/review-artifacts.ts` — uses the shared writer.
- `src/gitlab/operations/tracking-note.ts` — uses the shared types/formatters.
## Implementation Details
Commit-by-commit:
1. `fdda9ef` **prompts** — Pass 1 (candidate generation) and Pass 2 (validator) prompts were ~95% identical text. Extracted into `src/core/review/prompts/` (shared template + `ReviewTerminology` shape); the GH and GL files are now ~40 LOC thin adapters that map their context onto the shared shape and supply terminology constants. ~280 LOC of literal duplicated prompt text eliminated.
2. `20b98bc` **artifact writer** — `ReviewArtifactPaths` + `ReviewArtifactContents` shapes plus a `writeReviewArtifacts(outDir, contents, names)` helper. GL adopts it; GH keeps its three-helper public API (pinned by tests) but re-exports the shared type via the existing `ReviewArtifacts` alias. The platform-specific fetch mechanics (git+gh CLI vs REST) stay separate — they're fundamentally different.
3. `f7eb40a` **sticky-comment contracts** — `ReviewTrackingState`, `ReviewTrackingTelemetry`, `ReviewTrackingFields` types plus `formatDurationMs` / `formatCostUsd` helpers move to core. GitLab's tracking-note builder uses them; GitHub's MCP-comment-server pattern is untouched (different architecture today). Identical telemetry rendering guaranteed.
4. `e9aa6a4` **command parser** — `parseDroidCommand(text)` (the regex set for `|review|security|...`) moves to `src/core/review/triggers/parse-command.ts`. GH `extractCommandFromContext` (which scans GH webhook payloads) keeps its location and re-exports the shared types/parser so all existing imports still resolve. When GitLab ports its trigger path, it can reuse the parser directly.
### Scoping note
The initial inventory estimated 4 dedupe candidates with ~500 LOC saved. Reading the actual code revealed that **only the prompts (commit 1) had real textual duplication** (~280 LOC). The other three commits are smaller-bore: shared *contracts* (types, formatters, parser regex) rather than shared *implementations*, because the platform mechanics genuinely diverge:
- Artifact fetching — GH shells out via git+gh CLI with shallow-clone unshallowing + 50MB-buffered fallback; GL uses parallel REST calls. Sharing the fetcher would be more harm than good.
- Sticky comment — GH builds the rich body from inside the agent via an MCP tool; GL builds it from CI in TypeScript. Sharing the renderer would require unifying the architectures.
So commits 2–4 are intentionally minimal: they share **just** the parts that should never drift apart between platforms (types, telemetry text, command regex), without forcing the implementations into a shared mold they don't want to fit.
### Out of scope (deferred)
- Sharing the artifact *fetchers* — divergent mechanics.
- Sharing the sticky-comment *renderer* — divergent architectures.
- Porting GitLab's trigger matcher (`checkContainsTrigger` equivalent) — that's the next forward task, not dedupe.
- Anything related to `fill` (parked with #94).
## Testing
- `tsc --noEmit`: clean
- `bun test`: **445 pass / 0 fail** (same baseline as `dev`)
- prettier: clean
Next: end-to-end smoke test on both platforms after merge (GH self-review on the PR, GL via the mirror at `factory-components/droid-action`).
## Related Issues
- Builds on #93 (Phase 1 GitLab support, merged as `84946f2`)
- `fill`-related work parked with #94