### PR TITLE
Merge dev into main: model-policy fallback and clear review error surfacing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -297,6 +297,7 @@ runs:
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare-validator.ts
       env:
         GITHUB_TOKEN: ${{ steps.prepare.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
@@ -349,6 +350,9 @@ runs:
         TRIGGER_USERNAME: ${{ github.event.comment.user.login || github.event.issue.user.login || github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
+        DROID_ERROR_MESSAGE: ${{ steps.droid.outputs.error_message || '' }}
+        DROID_VALIDATOR_ERROR_MESSAGE: ${{ steps.droid_validator.outputs.error_message || '' }}
+        MODEL_FALLBACK_NOTE: ${{ steps.prepare.outputs.model_fallback_note || steps.prepare_validator.outputs.model_fallback_note || steps.droid.outputs.model_fallback_note || steps.droid_validator.outputs.model_fallback_note || '' }}
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         AUTOMATIC_REVIEW: ${{ inputs.automatic_review }}

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -4,6 +4,7 @@ import { promisify } from "util";
 import { stat } from "fs/promises";
 import { parse as parseShellArgs } from "shell-quote";
 import { retryWithBackoff } from "./utils/retry";
+import { isModelPolicyError, stripModelArgs } from "./utils/model-policy-error";
 
 const execAsync = promisify(exec);
 
@@ -256,14 +257,39 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
   // retryWithBackoff so backoff timing lives in one place (3 total attempts,
   // 5s then 10s delays).
   let lastExitCode = 1;
+  let currentDroidArgs = config.droidArgs;
+  let modelArgsStripped = false;
+  type ResultEvent = { is_error?: boolean; result?: string };
+  let lastResultEvent: ResultEvent | null = null;
+  // Fast client-side failures (e.g. an invalid --model value) print to
+  // stderr and exit before any stream-json result event is emitted, so keep
+  // a bounded tail of stderr as an error-message fallback.
+  const STDERR_TAIL_LIMIT = 1500;
+  let stderrTail = "";
+  // Indirection defeats TS control-flow narrowing: the variables are only
+  // assigned inside stream handler closures, so direct reads after the
+  // retry loop would otherwise be narrowed to their initial values.
+  const getLastResultEvent = (): ResultEvent | null => lastResultEvent;
+  const getStderrTail = (): string => stderrTail;
 
   const runDroidOnce = (): Promise<number> => {
-    const droidProcess = spawn(droidExecutable, config.droidArgs, {
-      stdio: ["ignore", "pipe", "inherit"],
+    stderrTail = "";
+    const droidProcess = spawn(droidExecutable, currentDroidArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
         ...config.env,
       },
+    });
+
+    droidProcess.stderr.on("data", (data) => {
+      const text = data.toString();
+      process.stderr.write(text);
+      stderrTail = (stderrTail + text).slice(-STDERR_TAIL_LIMIT);
+    });
+
+    droidProcess.stderr.on("error", (error) => {
+      console.error("Error reading Droid stderr:", error);
     });
 
     // Handle Droid process errors
@@ -293,6 +319,17 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
               sessionId = detectedSessionId;
               console.log(`Detected Droid session: ${sessionId}`);
             }
+          }
+          if (
+            typeof parsed === "object" &&
+            parsed !== null &&
+            parsed.type === "result"
+          ) {
+            lastResultEvent = {
+              is_error: parsed.is_error === true,
+              result:
+                typeof parsed.result === "string" ? parsed.result : undefined,
+            };
           }
           const sanitizedOutput = sanitizeJsonOutput(parsed, showFullOutput);
 
@@ -340,6 +377,28 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
         lastExitCode = await runDroidOnce();
         if (lastExitCode !== 0) {
           console.log(`Droid Exec exited with code ${lastExitCode}`);
+          // If the failure was caused by the org's model policy rejecting
+          // the requested model, retry without --model so droid exec falls
+          // back to the organization's default model.
+          const resultEvent = getLastResultEvent();
+          if (
+            !modelArgsStripped &&
+            resultEvent?.is_error &&
+            isModelPolicyError(resultEvent.result) &&
+            currentDroidArgs.some(
+              (arg) => arg === "--model" || arg.startsWith("--model="),
+            )
+          ) {
+            modelArgsStripped = true;
+            currentDroidArgs = stripModelArgs(currentDroidArgs);
+            console.warn(
+              "The requested model is not allowed by the organization's model policy; retrying with the organization's default model",
+            );
+            core.setOutput(
+              "model_fallback_note",
+              "The requested model is not allowed by your organization's model policy, so Droid retried with your organization's default model. Set the model input (e.g. `review_model`) to an approved model to control which model is used.",
+            );
+          }
           throw new Error(`Droid Exec exited with code ${lastExitCode}`);
         }
       },
@@ -352,6 +411,20 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
     console.error(
       `Droid Exec failed after 3 total attempts (exit code: ${lastExitCode})`,
     );
+    const finalResultEvent = getLastResultEvent();
+    const finalStderrTail = getStderrTail().trim();
+    const rawErrorMessage =
+      finalResultEvent?.is_error && finalResultEvent.result?.trim()
+        ? finalResultEvent.result.trim()
+        : finalStderrTail
+          ? `Droid Exec exited with code ${lastExitCode}:\n${finalStderrTail}`
+          : `Droid Exec exited with code ${lastExitCode}`;
+    const errorMessage =
+      rawErrorMessage.length > 2000
+        ? `${rawErrorMessage.slice(0, 2000)}…`
+        : rawErrorMessage;
+    console.error(`Droid Exec failed: ${errorMessage}`);
+    core.setOutput("error_message", errorMessage);
     core.setOutput("conclusion", "failure");
     process.exit(lastExitCode);
   }

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -4,7 +4,12 @@ import { promisify } from "util";
 import { stat } from "fs/promises";
 import { parse as parseShellArgs } from "shell-quote";
 import { retryWithBackoff } from "./utils/retry";
-import { isModelPolicyError, stripModelArgs } from "./utils/model-policy-error";
+import {
+  condenseInvalidModelError,
+  isInvalidModelError,
+  isModelPolicyError,
+  stripModelArgs,
+} from "./utils/model-policy-error";
 
 const execAsync = promisify(exec);
 
@@ -377,26 +382,36 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
         lastExitCode = await runDroidOnce();
         if (lastExitCode !== 0) {
           console.log(`Droid Exec exited with code ${lastExitCode}`);
-          // If the failure was caused by the org's model policy rejecting
-          // the requested model, retry without --model so droid exec falls
-          // back to the organization's default model.
+          // If the failure was caused by the requested model being rejected
+          // (blocked by the org's model policy, or not a recognized model
+          // id), retry without --model so droid exec falls back to the
+          // organization's default model.
           const resultEvent = getLastResultEvent();
+          const policyBlocked =
+            resultEvent?.is_error === true &&
+            isModelPolicyError(resultEvent.result);
+          const invalidModel = isInvalidModelError(getStderrTail());
           if (
             !modelArgsStripped &&
-            resultEvent?.is_error &&
-            isModelPolicyError(resultEvent.result) &&
+            (policyBlocked || invalidModel) &&
             currentDroidArgs.some(
               (arg) => arg === "--model" || arg.startsWith("--model="),
             )
           ) {
             modelArgsStripped = true;
             currentDroidArgs = stripModelArgs(currentDroidArgs);
+            const reason = policyBlocked
+              ? "is not allowed by your organization's model policy"
+              : "is not a recognized model id";
             console.warn(
-              "The requested model is not allowed by the organization's model policy; retrying with the organization's default model",
+              `The requested model ${reason}; retrying with the organization's default model`,
             );
             core.setOutput(
               "model_fallback_note",
-              "The requested model is not allowed by your organization's model policy, so Droid retried with your organization's default model. Set the model input (e.g. `review_model`) to an approved model to control which model is used.",
+              `The requested model ${reason}, so Droid retried with your organization's default model. ` +
+                "Set the model input (e.g. `review_model`) to an " +
+                "[available model](https://docs.factory.ai/models) approved " +
+                "by your organization to control which model is used.",
             );
           }
           throw new Error(`Droid Exec exited with code ${lastExitCode}`);
@@ -412,7 +427,10 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
       `Droid Exec failed after 3 total attempts (exit code: ${lastExitCode})`,
     );
     const finalResultEvent = getLastResultEvent();
-    const finalStderrTail = getStderrTail().trim();
+    let finalStderrTail = getStderrTail().trim();
+    if (isInvalidModelError(finalStderrTail)) {
+      finalStderrTail = condenseInvalidModelError(finalStderrTail);
+    }
     const rawErrorMessage =
       finalResultEvent?.is_error && finalResultEvent.result?.trim()
         ? finalResultEvent.result.trim()

--- a/base-action/src/utils/model-policy-error.ts
+++ b/base-action/src/utils/model-policy-error.ts
@@ -17,6 +17,39 @@ export function isModelPolicyError(text: string | undefined | null): boolean {
 }
 
 /**
+ * Matches the fast client-side failure droid exec prints to stderr when the
+ * --model value is not a recognized model id.
+ */
+export function isInvalidModelError(text: string | undefined | null): boolean {
+  if (!text) {
+    return false;
+  }
+  return /Invalid model:/i.test(text);
+}
+
+/**
+ * An invalid --model value makes droid exec dump the full list of available
+ * models (twice, with one line per dump that is hundreds of characters
+ * wide). Condense that output down to the meaningful lines so it can be
+ * embedded in a PR comment without sideways scrolling.
+ */
+export function condenseInvalidModelError(text: string): string {
+  const kept: string[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (/^Available built-in models:$/i.test(trimmed)) continue;
+    if (/^No custom models configured/i.test(trimmed)) continue;
+    // Drop raw model-list dumps (long comma-separated lines)
+    if (trimmed.split(", ").length >= 5) continue;
+    if (kept[kept.length - 1] === trimmed) continue;
+    kept.push(trimmed);
+  }
+  const condensed = kept.join("\n");
+  return condensed || text;
+}
+
+/**
  * Remove `--model <value>` and `--reasoning-effort <value>` (including
  * `--flag=value` forms) from an argv array so droid exec falls back to the
  * organization's default model.

--- a/base-action/src/utils/model-policy-error.ts
+++ b/base-action/src/utils/model-policy-error.ts
@@ -1,0 +1,44 @@
+/**
+ * Matches the 403 errors returned by the Factory API when a request uses a
+ * model that the organization's model policy does not allow, including the
+ * explicit opt-in variant ("This model requires explicit organization
+ * opt-in by an admin.").
+ */
+const MODEL_POLICY_ERROR_PATTERNS = [
+  /not available due to your organization['’]s security settings/i,
+  /requires explicit organization opt-in/i,
+];
+
+export function isModelPolicyError(text: string | undefined | null): boolean {
+  if (!text) {
+    return false;
+  }
+  return MODEL_POLICY_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Remove `--model <value>` and `--reasoning-effort <value>` (including
+ * `--flag=value` forms) from an argv array so droid exec falls back to the
+ * organization's default model.
+ */
+export function stripModelArgs(args: string[]): string[] {
+  const stripped: string[] = [];
+  let skipNext = false;
+
+  for (const arg of args) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (arg === "--model" || arg === "--reasoning-effort") {
+      skipNext = true;
+      continue;
+    }
+    if (arg.startsWith("--model=") || arg.startsWith("--reasoning-effort=")) {
+      continue;
+    }
+    stripped.push(arg);
+  }
+
+  return stripped;
+}

--- a/base-action/test/model-policy-error.test.ts
+++ b/base-action/test/model-policy-error.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isModelPolicyError,
+  stripModelArgs,
+} from "../src/utils/model-policy-error";
+
+describe("isModelPolicyError", () => {
+  it("matches the model policy 403 message", () => {
+    expect(
+      isModelPolicyError(
+        `403 {"detail":"This model is not available due to your organization's security settings.","status":403}`,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches with a curly apostrophe", () => {
+    expect(
+      isModelPolicyError(
+        "This model is not available due to your organization’s security settings.",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the explicit opt-in 403 message", () => {
+    expect(
+      isModelPolicyError(
+        "403 This model requires explicit organization opt-in by an admin.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isModelPolicyError("429 Too Many Requests")).toBe(false);
+    expect(isModelPolicyError(undefined)).toBe(false);
+  });
+});
+
+describe("stripModelArgs", () => {
+  it("removes --model and its value", () => {
+    expect(
+      stripModelArgs(["exec", "--model", "gpt-5.2", "-f", "prompt.txt"]),
+    ).toEqual(["exec", "-f", "prompt.txt"]);
+  });
+
+  it("removes --reasoning-effort and its value", () => {
+    expect(
+      stripModelArgs(["exec", "--reasoning-effort", "high", "-f", "p.txt"]),
+    ).toEqual(["exec", "-f", "p.txt"]);
+  });
+
+  it("removes --flag=value forms", () => {
+    expect(
+      stripModelArgs(["exec", "--model=gpt-5.2", "--reasoning-effort=high"]),
+    ).toEqual(["exec"]);
+  });
+
+  it("removes both flags while preserving other args", () => {
+    expect(
+      stripModelArgs([
+        "exec",
+        "--output-format",
+        "stream-json",
+        "--model",
+        "kimi-k2.6",
+        "--reasoning-effort",
+        "high",
+        "--tag",
+        "code-review",
+      ]),
+    ).toEqual([
+      "exec",
+      "--output-format",
+      "stream-json",
+      "--tag",
+      "code-review",
+    ]);
+  });
+
+  it("returns args unchanged when no model flags are present", () => {
+    const args = ["exec", "--output-format", "stream-json", "-f", "p.txt"];
+    expect(stripModelArgs(args)).toEqual(args);
+  });
+});

--- a/base-action/test/model-policy-error.test.ts
+++ b/base-action/test/model-policy-error.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+  condenseInvalidModelError,
+  isInvalidModelError,
   isModelPolicyError,
   stripModelArgs,
 } from "../src/utils/model-policy-error";
@@ -32,6 +34,41 @@ describe("isModelPolicyError", () => {
   it("does not match unrelated errors", () => {
     expect(isModelPolicyError("429 Too Many Requests")).toBe(false);
     expect(isModelPolicyError(undefined)).toBe(false);
+  });
+});
+
+describe("isInvalidModelError", () => {
+  it("matches the CLI invalid-model stderr output", () => {
+    expect(isInvalidModelError("Invalid model: gpt-image-1")).toBe(true);
+  });
+
+  it("does not match unrelated output", () => {
+    expect(isInvalidModelError("500 Internal Server Error")).toBe(false);
+    expect(isInvalidModelError(undefined)).toBe(false);
+  });
+});
+
+describe("condenseInvalidModelError", () => {
+  it("drops the model-list dump and dedupes repeated lines", () => {
+    const dump = [
+      "claude-opus-5, claude-sonnet-5, gpt-5.4, gpt-5.2, kimi-k3, glm-5.2",
+      "",
+      "No custom models configured. Add them to ~/.factory/settings.json",
+      "Invalid model: gpt-image-1",
+      "",
+      "Available built-in models:",
+      "  auto, claude-opus-5, claude-sonnet-5, gpt-5.4, gpt-5.2, kimi-k3",
+      "",
+      "No custom models configured. Add them to ~/.factory/settings.json",
+      "Invalid model: gpt-image-1",
+    ].join("\n");
+
+    expect(condenseInvalidModelError(dump)).toBe("Invalid model: gpt-image-1");
+  });
+
+  it("returns the original text when nothing would remain", () => {
+    const listOnly = "a, b, c, d, e, f";
+    expect(condenseInvalidModelError(listOnly)).toBe(listOnly);
   });
 });
 

--- a/gitlab/examples/README.md
+++ b/gitlab/examples/README.md
@@ -9,10 +9,10 @@ your-project/
     └── droid-review.yml            # self-contained droid-review config
 ```
 
-| File                          | Where it lives in your project                     | Purpose                                                                                       |
-| ----------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `factory/droid-review.yml`    | drop verbatim                                      | Self-contained config: includes the remote Component, sets inputs, wires CI/CD variables.     |
-| `.gitlab-ci.yml`              | append one `include:` line if the file exists      | Project-root entry point. Just needs to include `factory/droid-review.yml`.                   |
+| File                       | Where it lives in your project                | Purpose                                                                                   |
+| -------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `factory/droid-review.yml` | drop verbatim                                 | Self-contained config: includes the remote Component, sets inputs, wires CI/CD variables. |
+| `.gitlab-ci.yml`           | append one `include:` line if the file exists | Project-root entry point. Just needs to include `factory/droid-review.yml`.               |
 
 The two required CI/CD variables (`FACTORY_API_KEY`, `GITLAB_TOKEN`) are set
 in the GitLab UI under **Project → Settings → CI/CD → Variables** (or at

--- a/review/action.yml
+++ b/review/action.yml
@@ -85,6 +85,7 @@ runs:
         bun run ${{ github.action_path }}/../src/entrypoints/generate-review-prompt.ts
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
@@ -123,6 +124,7 @@ runs:
         bun run ${{ github.action_path }}/../src/entrypoints/prepare-validator.ts
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
@@ -158,3 +160,6 @@ runs:
         TRIGGER_USERNAME: ${{ github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: "true"
         DROID_SUCCESS: ${{ steps.validator.outcome == 'success' }}
+        DROID_ERROR_MESSAGE: ${{ steps.review.outputs.error_message || '' }}
+        DROID_VALIDATOR_ERROR_MESSAGE: ${{ steps.validator.outputs.error_message || '' }}
+        MODEL_FALLBACK_NOTE: ${{ steps.prompt.outputs.model_fallback_note || steps.prepare_validator.outputs.model_fallback_note || steps.review.outputs.model_fallback_note || steps.validator.outputs.model_fallback_note || '' }}

--- a/src/core/review/artifacts/write.ts
+++ b/src/core/review/artifacts/write.ts
@@ -1,10 +1,5 @@
 import * as fs from "fs/promises";
 import * as path from "path";
-import type {
-  ReviewArtifactContents,
-  ReviewArtifactNames,
-  ReviewArtifactPaths,
-} from "./types";
 import type { ReviewArtifactContents, ReviewArtifactPaths } from "./types";
 
 /**

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -16,6 +16,7 @@ import { generateReviewCandidatesPrompt } from "../create-prompt/templates/revie
 import { generateSecurityCandidatesPrompt } from "../create-prompt/templates/security-review-prompt";
 import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
 import { resolveReviewConfig } from "../utils/review-depth";
+import { applyModelPolicyFallback } from "../utils/model-policy";
 import { retryWithBackoff } from "../utils/retry";
 
 async function run() {
@@ -185,17 +186,29 @@ async function run() {
         ? process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim()
         : process.env.REVIEW_MODEL?.trim();
 
-    const { model, reasoningEffort } = resolveReviewConfig({
-      reviewModel: rawModel,
-      reasoningEffort: process.env.REASONING_EFFORT?.trim(),
-      reviewDepth: process.env.REVIEW_DEPTH?.trim(),
-    });
+    const { model, reasoningEffort, fallbackNote } =
+      await applyModelPolicyFallback(
+        resolveReviewConfig({
+          reviewModel: rawModel,
+          reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+          reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+        }),
+        {
+          flowLabel:
+            reviewType === "security" ? "security review" : "code review",
+          modelInputName:
+            reviewType === "security" ? "security_model" : "review_model",
+        },
+      );
 
     if (model) {
       droidArgParts.push(`--model "${model}"`);
     }
     if (reasoningEffort) {
       droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
+    }
+    if (fallbackNote) {
+      core.setOutput("model_fallback_note", fallbackNote);
     }
 
     if (normalizedUserArgs) {

--- a/src/entrypoints/gitlab-prepare.ts
+++ b/src/entrypoints/gitlab-prepare.ts
@@ -36,6 +36,7 @@ import { computeReviewArtifacts } from "../gitlab/data/review-artifacts";
 import { generateGitlabReviewCandidatesPrompt } from "../gitlab/prompts/candidates";
 import type { GitlabReviewPromptContext } from "../gitlab/prompts/types";
 import { resolveReviewConfig } from "../utils/review-depth";
+import { applyModelPolicyFallback } from "../utils/model-policy";
 import { setupDroidSettings } from "../../base-action/src/setup-droid-settings";
 
 export type PrepareState = {
@@ -246,22 +247,32 @@ async function run(): Promise<void> {
     `Artifacts written:\n  ${artifacts.diffPath}\n  ${artifacts.commentsPath}\n  ${artifacts.descriptionPath}`,
   );
 
-  const resolved = resolveReviewConfig({
-    reviewModel: context.inputs.reviewModel,
-    reasoningEffort: context.inputs.reasoningEffort,
-    reviewDepth: context.inputs.reviewDepth,
-  });
+  const resolved = await applyModelPolicyFallback(
+    resolveReviewConfig({
+      reviewModel: context.inputs.reviewModel,
+      reasoningEffort: context.inputs.reasoningEffort,
+      reviewDepth: context.inputs.reviewDepth,
+    }),
+    { flowLabel: "code review", modelInputName: "review_model" },
+  );
   console.log(
     `Resolved review config: depth=${context.inputs.reviewDepth} ` +
       `explicitModel=${context.inputs.reviewModel || "(empty)"} ` +
       `explicitEffort=${context.inputs.reasoningEffort || "(empty)"} ` +
-      `=> model=${resolved.model} effort=${resolved.reasoningEffort ?? "(none)"}`,
+      `=> model=${resolved.model ?? "(org default)"} effort=${resolved.reasoningEffort ?? "(none)"}`,
   );
+  if (resolved.fallbackNote) {
+    console.warn(resolved.fallbackNote);
+  }
 
-  await writeResolvedEnvShim(resolved.model, resolved.reasoningEffort ?? null, {
-    DROID_MR_IID: String(mrIid),
-    DROID_TRACKING_NOTE_ID: String(trackingNoteId),
-  });
+  await writeResolvedEnvShim(
+    resolved.model ?? null,
+    resolved.reasoningEffort ?? null,
+    {
+      DROID_MR_IID: String(mrIid),
+      DROID_TRACKING_NOTE_ID: String(trackingNoteId),
+    },
+  );
 
   const candidatesPath = candidatesFilePath();
   const validatedPath = validatedFilePath();
@@ -296,7 +307,7 @@ async function run(): Promise<void> {
     shouldRunReview: true,
     trackingNoteId,
     promptPath,
-    resolvedModel: resolved.model,
+    resolvedModel: resolved.model ?? null,
     resolvedReasoningEffort: resolved.reasoningEffort ?? null,
     diffPath: artifacts.diffPath,
     commentsPath: artifacts.commentsPath,

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -114,6 +114,12 @@ async function run() {
       actionFailed = true;
       errorDetails = prepareError;
     } else {
+      const droidErrorMessage =
+        process.env.DROID_VALIDATOR_ERROR_MESSAGE?.trim() ||
+        process.env.DROID_ERROR_MESSAGE?.trim();
+      if (process.env.DROID_SUCCESS === "false" && droidErrorMessage) {
+        errorDetails = droidErrorMessage;
+      }
       // Check for existence of output file and parse it if available
       try {
         const outputFile = process.env.OUTPUT_FILE;
@@ -159,6 +165,7 @@ async function run() {
       branchName: undefined,
       triggerUsername,
       errorDetails,
+      notice: process.env.MODEL_FALLBACK_NOTE?.trim() || undefined,
       securityReviewRan: process.env.AUTOMATIC_SECURITY_REVIEW === "true",
     };
 

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -16,8 +16,18 @@ export type CommentUpdateInput = {
   branchName?: string;
   triggerUsername?: string;
   errorDetails?: string;
+  notice?: string;
   securityReviewRan?: boolean;
 };
+
+const MODEL_POLICY_ERROR_PATTERN =
+  /not available due to your organization['’]s security settings/i;
+
+const MODEL_POLICY_HINT =
+  "> [!TIP]\n" +
+  "> The selected model is not allowed by your organization's model policy. " +
+  "Set the `review_model` input (or `security_model` / `fill_model`) to a " +
+  "model approved by your organization.";
 
 export const SECURITY_REVIEW_BADGE =
   "![Security Review](https://img.shields.io/badge/security%20review-ran-blue)";
@@ -81,6 +91,7 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     branchName,
     triggerUsername,
     errorDetails,
+    notice,
     securityReviewRan,
   } = input;
 
@@ -202,6 +213,14 @@ export function updateCommentBody(input: CommentUpdateInput): string {
   // Add error details if available
   if (actionFailed && errorDetails) {
     newBody += `\n\n\`\`\`\n${errorDetails}\n\`\`\``;
+    if (MODEL_POLICY_ERROR_PATTERN.test(errorDetails)) {
+      newBody += `\n\n${MODEL_POLICY_HINT}`;
+    }
+  }
+
+  // Surface model fallback notices (e.g. review model blocked by org policy)
+  if (notice) {
+    newBody += `\n\n> [!NOTE]\n> ${notice}`;
   }
 
   newBody += `\n\n---\n`;
@@ -210,6 +229,13 @@ export function updateCommentBody(input: CommentUpdateInput): string {
   // Remove any existing View job run, branch links from the bottom
   bodyContent = bodyContent.replace(/\n?\[View job run\]\([^\)]+\)/g, "");
   bodyContent = bodyContent.replace(/\n?\[View branch\]\([^\)]+\)/g, "");
+
+  // Remove stale model-policy notices from previous runs
+  bodyContent = bodyContent
+    .replace(/^> \[!(?:NOTE|TIP)\]\r?\n(?:^>.*(?:\r?\n)?)+/gim, (block) =>
+      /model policy/i.test(block) ? "" : block,
+    )
+    .trim();
 
   // Remove any existing duration info at the bottom
   bodyContent = bodyContent.replace(/\n*---\n*Duration: [0-9]+m? [0-9]+s/g, "");

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -21,13 +21,22 @@ export type CommentUpdateInput = {
 };
 
 const MODEL_POLICY_ERROR_PATTERN =
-  /not available due to your organization['’]s security settings/i;
+  /not available due to your organization['’]s security settings|requires explicit organization opt-in/i;
+
+const INVALID_MODEL_ERROR_PATTERN = /Invalid model:/i;
 
 const MODEL_POLICY_HINT =
   "> [!TIP]\n" +
   "> The selected model is not allowed by your organization's model policy. " +
-  "Set the `review_model` input (or `security_model` / `fill_model`) to a " +
-  "model approved by your organization.";
+  "Set the `review_model` input (or `security_model` / `fill_model`) to an " +
+  "[available model](https://docs.factory.ai/models) approved by your " +
+  "organization.";
+
+const INVALID_MODEL_HINT =
+  "> [!TIP]\n" +
+  "> The selected model is not a recognized model id. Set the " +
+  "`review_model` input (or `security_model` / `fill_model`) to an " +
+  "[available model](https://docs.factory.ai/models).";
 
 export const SECURITY_REVIEW_BADGE =
   "![Security Review](https://img.shields.io/badge/security%20review-ran-blue)";
@@ -218,6 +227,8 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     newBody += `\n\n\`\`\`\n${errorDetails}\n\`\`\``;
     if (MODEL_POLICY_ERROR_PATTERN.test(errorDetails)) {
       newBody += `\n\n${MODEL_POLICY_HINT}`;
+    } else if (INVALID_MODEL_ERROR_PATTERN.test(errorDetails)) {
+      newBody += `\n\n${INVALID_MODEL_HINT}`;
     }
   }
 

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -96,8 +96,11 @@ export function updateCommentBody(input: CommentUpdateInput): string {
   } = input;
 
   // Extract content from the original comment body
-  // First, remove the "Droid is working…" message (and support legacy wording)
-  const workingPattern = /Droid is working[…\.]{1,3}(?:\s*<img[^>]*>)?/i;
+  // First, remove the in-progress message (and support legacy wording),
+  // including the automatic review/security variants, so a failed run does
+  // not keep saying "Droid is reviewing code…" under the error header.
+  const workingPattern =
+    /Droid is (?:working|reviewing code and running a security check|reviewing code|running a security check)[…\.]{1,3}(?:\s*<img[^>]*>)?/i;
   let bodyContent = originalBody.replace(workingPattern, "").trim();
 
   // Remove initial placeholder follow-up text when present

--- a/src/tag/commands/fill.ts
+++ b/src/tag/commands/fill.ts
@@ -9,6 +9,7 @@ import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import { isEntityContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
+import { applyModelPolicyFallback } from "../../utils/model-policy";
 
 type FillCommandOptions = {
   context: GitHubContext;
@@ -94,9 +95,15 @@ export async function prepareFillMode({
   droidArgParts.push('--tag "droid-fill"');
 
   // Add model override if specified
-  const fillModel = process.env.FILL_MODEL?.trim();
+  const { model: fillModel, fallbackNote } = await applyModelPolicyFallback(
+    { model: process.env.FILL_MODEL?.trim() },
+    { flowLabel: "PR description fill", modelInputName: "fill_model" },
+  );
   if (fillModel) {
     droidArgParts.push(`--model "${fillModel}"`);
+  }
+  if (fallbackNote) {
+    core.setOutput("model_fallback_note", fallbackNote);
   }
 
   if (normalizedUserArgs) {

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -10,6 +10,7 @@ import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
 import type { PrepareResult } from "../../prepare/types";
 import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
 import { resolveReviewConfig } from "../../utils/review-depth";
+import { applyModelPolicyFallback } from "../../utils/model-policy";
 
 export async function prepareReviewValidatorMode({
   context,
@@ -102,17 +103,24 @@ export async function prepareReviewValidatorMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const { model, reasoningEffort } = resolveReviewConfig({
-    reviewModel: process.env.REVIEW_MODEL?.trim(),
-    reasoningEffort: process.env.REASONING_EFFORT?.trim(),
-    reviewDepth: process.env.REVIEW_DEPTH?.trim(),
-  });
+  const { model, reasoningEffort, fallbackNote } =
+    await applyModelPolicyFallback(
+      resolveReviewConfig({
+        reviewModel: process.env.REVIEW_MODEL?.trim(),
+        reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+        reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+      }),
+      { flowLabel: "code review", modelInputName: "review_model" },
+    );
 
   if (model) {
     droidArgParts.push(`--model "${model}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
+  }
+  if (fallbackNote) {
+    core.setOutput("model_fallback_note", fallbackNote);
   }
 
   if (normalizedUserArgs) {

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -12,6 +12,7 @@ import { generateReviewCandidatesPrompt } from "../../create-prompt/templates/re
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { resolveReviewConfig } from "../../utils/review-depth";
+import { applyModelPolicyFallback } from "../../utils/model-policy";
 import { retryWithBackoff } from "../../utils/retry";
 
 type ReviewCommandOptions = {
@@ -161,17 +162,24 @@ export async function prepareReviewMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const { model, reasoningEffort } = resolveReviewConfig({
-    reviewModel: process.env.REVIEW_MODEL?.trim(),
-    reasoningEffort: process.env.REASONING_EFFORT?.trim(),
-    reviewDepth: process.env.REVIEW_DEPTH?.trim(),
-  });
+  const { model, reasoningEffort, fallbackNote } =
+    await applyModelPolicyFallback(
+      resolveReviewConfig({
+        reviewModel: process.env.REVIEW_MODEL?.trim(),
+        reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+        reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+      }),
+      { flowLabel: "code review", modelInputName: "review_model" },
+    );
 
   if (model) {
     droidArgParts.push(`--model "${model}"`);
   }
   if (reasoningEffort) {
     droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
+  }
+  if (fallbackNote) {
+    core.setOutput("model_fallback_note", fallbackNote);
   }
 
   if (normalizedUserArgs) {

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -11,6 +11,7 @@ import { isEntityContext } from "../../github/context";
 import { generateSecurityCandidatesPrompt } from "../../create-prompt/templates/security-review-prompt";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
+import { applyModelPolicyFallback } from "../../utils/model-policy";
 
 type SecurityReviewCommandOptions = {
   context: GitHubContext;
@@ -150,10 +151,18 @@ export async function prepareSecurityReviewMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const securityModel =
-    process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim();
+  const { model: securityModel, fallbackNote } = await applyModelPolicyFallback(
+    {
+      model:
+        process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim(),
+    },
+    { flowLabel: "security review", modelInputName: "security_model" },
+  );
   if (securityModel) {
     droidArgParts.push(`--model "${securityModel}"`);
+  }
+  if (fallbackNote) {
+    core.setOutput("model_fallback_note", fallbackNote);
   }
 
   if (normalizedUserArgs) {

--- a/src/tag/commands/security-scan.ts
+++ b/src/tag/commands/security-scan.ts
@@ -8,6 +8,7 @@ import { isEntityContext } from "../../github/context";
 import { generateSecurityReportPrompt } from "../../create-prompt/templates/security-report-prompt";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
+import { applyModelPolicyFallback } from "../../utils/model-policy";
 
 export type ScanScope = { type: "full" } | { type: "scheduled"; days: number };
 
@@ -87,10 +88,18 @@ export async function prepareSecurityScanMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
 
   // Add model override if specified (prefer SECURITY_MODEL, fallback to REVIEW_MODEL)
-  const securityModel =
-    process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim();
+  const { model: securityModel, fallbackNote } = await applyModelPolicyFallback(
+    {
+      model:
+        process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim(),
+    },
+    { flowLabel: "security scan", modelInputName: "security_model" },
+  );
   if (securityModel) {
     droidArgParts.push(`--model "${securityModel}"`);
+  }
+  if (fallbackNote) {
+    core.setOutput("model_fallback_note", fallbackNote);
   }
 
   if (normalizedUserArgs) {

--- a/src/utils/model-policy.ts
+++ b/src/utils/model-policy.ts
@@ -1,0 +1,171 @@
+import * as core from "@actions/core";
+
+/**
+ * Subset of the Factory org model policy returned by
+ * GET /api/organization/managed-settings. Unknown fields are ignored.
+ */
+export type ModelPolicy = {
+  allowedModelIds?: string[];
+  blockedModelIds?: string[];
+  allowAllFactoryModels?: boolean;
+};
+
+const DEFAULT_FACTORY_API_BASE_URL = "https://app.factory.ai";
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Matches the 403 error returned by the Factory API when a request uses a
+ * model that the organization's model policy does not allow.
+ */
+const MODEL_POLICY_ERROR_PATTERN =
+  /not available due to your organization['’]s security settings/i;
+
+export function isModelPolicyError(text: string | undefined | null): boolean {
+  if (!text) {
+    return false;
+  }
+  return MODEL_POLICY_ERROR_PATTERN.test(text);
+}
+
+/**
+ * Fetch the organization's model policy using the Factory API key.
+ * Returns null when the org has no policy or when the policy cannot be
+ * determined (network error, unexpected payload, etc). Callers must treat
+ * null as "no restriction" so a policy lookup failure never breaks a run.
+ */
+export async function fetchModelPolicy(
+  factoryApiKey: string,
+  options?: { baseUrl?: string; timeoutMs?: number },
+): Promise<ModelPolicy | null> {
+  const baseUrl =
+    options?.baseUrl ||
+    process.env.FACTORY_API_BASE_URL ||
+    DEFAULT_FACTORY_API_BASE_URL;
+  const timeoutMs = options?.timeoutMs ?? FETCH_TIMEOUT_MS;
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/$/, "")}/api/organization/managed-settings`,
+      {
+        headers: {
+          Authorization: `Bearer ${factoryApiKey}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+
+    if (!response.ok) {
+      console.warn(
+        `Model policy lookup returned HTTP ${response.status}; proceeding without a policy check`,
+      );
+      return null;
+    }
+
+    const payload: unknown = await response.json();
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      (payload as { success?: unknown }).success !== true
+    ) {
+      return null;
+    }
+
+    const settings = (payload as { settings?: unknown }).settings;
+    if (typeof settings !== "object" || settings === null) {
+      return null;
+    }
+
+    const rawPolicy = (settings as { modelPolicy?: unknown }).modelPolicy;
+    if (typeof rawPolicy !== "object" || rawPolicy === null) {
+      return null;
+    }
+
+    const policy = rawPolicy as Record<string, unknown>;
+    const toStringArray = (value: unknown): string[] | undefined =>
+      Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === "string")
+        : undefined;
+
+    return {
+      allowedModelIds: toStringArray(policy.allowedModelIds),
+      blockedModelIds: toStringArray(policy.blockedModelIds),
+      allowAllFactoryModels:
+        typeof policy.allowAllFactoryModels === "boolean"
+          ? policy.allowAllFactoryModels
+          : undefined,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Model policy lookup failed (${message}); proceeding without a policy check`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Conservative client-side mirror of the server-side model policy check.
+ * Only returns false when the policy definitively disallows the model;
+ * any ambiguity resolves to allowed (the server remains the enforcer).
+ */
+export function isModelAllowedByPolicy(
+  modelId: string,
+  policy: ModelPolicy | null | undefined,
+): boolean {
+  if (!policy) {
+    return true;
+  }
+  if (policy.blockedModelIds?.includes(modelId)) {
+    return false;
+  }
+  if (policy.allowAllFactoryModels === true) {
+    return true;
+  }
+  if (policy.allowedModelIds && policy.allowedModelIds.length > 0) {
+    return policy.allowedModelIds.includes(modelId);
+  }
+  return true;
+}
+
+export type PolicyCheckedModelConfig = {
+  model?: string;
+  reasoningEffort?: string;
+  fallbackNote?: string;
+};
+
+/**
+ * Pre-flight check of a resolved model against the org's model policy.
+ * When the model is disallowed, drops the model (and reasoning effort) so
+ * `droid exec` falls back to the organization's default model, and returns
+ * a note describing the fallback for surfacing in the tracking comment.
+ */
+export async function applyModelPolicyFallback(
+  config: { model?: string; reasoningEffort?: string },
+  options: { flowLabel: string; modelInputName: string },
+): Promise<PolicyCheckedModelConfig> {
+  const { model, reasoningEffort } = config;
+  const factoryApiKey = process.env.FACTORY_API_KEY;
+
+  if (!model || !factoryApiKey) {
+    return { model, reasoningEffort };
+  }
+
+  const policy = await fetchModelPolicy(factoryApiKey);
+  if (isModelAllowedByPolicy(model, policy)) {
+    return { model, reasoningEffort };
+  }
+
+  const fallbackNote =
+    `The ${options.flowLabel} model \`${model}\` is not allowed by your ` +
+    `organization's model policy, so Droid used your organization's default ` +
+    `model instead. Set the \`${options.modelInputName}\` input to an ` +
+    `approved model to control which model is used.`;
+
+  core.warning(
+    `Model "${model}" is not allowed by the organization's model policy; ` +
+      `omitting --model so droid exec uses the organization's default model`,
+  );
+
+  return { fallbackNote };
+}

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -499,4 +499,69 @@ describe("updateCommentBody", () => {
       expect(occurrences).toBe(1);
     });
   });
+
+  describe("model policy errors and fallback notices", () => {
+    const policyError = `403 {"detail":"This model is not available due to your organization's security settings.","status":403}`;
+
+    it("adds an actionable hint when the error is a model policy 403", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        actionFailed: true,
+        errorDetails: policyError,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("**Droid encountered an error");
+      expect(result).toContain(policyError);
+      expect(result).toContain("`review_model`");
+      expect(result).toContain("model approved by your organization");
+    });
+
+    it("does not add the hint for unrelated errors", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        actionFailed: true,
+        errorDetails: "500 Internal Server Error",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("500 Internal Server Error");
+      expect(result).not.toContain("`review_model`");
+    });
+
+    it("renders a fallback notice on success", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        notice:
+          "The code review model `gpt-5.2` is not allowed by your organization's model policy, so Droid used your organization's default model instead.",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("> [!NOTE]");
+      expect(result).toContain("`gpt-5.2`");
+    });
+
+    it("does not duplicate a stale notice on subsequent updates", () => {
+      const notice =
+        "The code review model `gpt-5.2` is not allowed by your organization's model policy, so Droid used your organization's default model instead.";
+      const firstPass = updateCommentBody({
+        ...baseInput,
+        currentBody: "Droid is working…\n\nReview summary content",
+        notice,
+      });
+
+      const secondPass = updateCommentBody({
+        ...baseInput,
+        currentBody: firstPass,
+        notice,
+      });
+
+      const occurrences = secondPass.split("> [!NOTE]").length - 1;
+      expect(occurrences).toBe(1);
+      expect(secondPass).toContain("Review summary content");
+    });
+  });
 });

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -42,6 +42,31 @@ describe("updateCommentBody", () => {
       expect(result).toContain("**Droid encountered an error after 45s**");
     });
 
+    it("strips the review/security progress message on failure", () => {
+      const input = {
+        ...baseInput,
+        currentBody: "Droid is reviewing code and running a security check…",
+        actionFailed: true,
+        errorDetails: "Droid Exec exited with code 1",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("**Droid encountered an error");
+      expect(result).not.toContain("Droid is reviewing code");
+      expect(result).not.toContain("running a security check");
+    });
+
+    it("strips the security-only progress message", () => {
+      const input = {
+        ...baseInput,
+        currentBody: "Droid is running a security check…",
+        executionDetails: { duration_ms: 60000 },
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).not.toContain("running a security check");
+    });
+
     it("includes error details when provided", () => {
       const input = {
         ...baseInput,

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -540,7 +540,23 @@ describe("updateCommentBody", () => {
       expect(result).toContain("**Droid encountered an error");
       expect(result).toContain(policyError);
       expect(result).toContain("`review_model`");
-      expect(result).toContain("model approved by your organization");
+      expect(result).toContain("approved by your organization");
+      expect(result).toContain("https://docs.factory.ai/models");
+    });
+
+    it("adds a hint with the models docs link for invalid-model errors", () => {
+      const input: CommentUpdateInput = {
+        ...baseInput,
+        currentBody: "Droid is working…",
+        actionFailed: true,
+        errorDetails:
+          "Droid Exec exited with code 1:\nInvalid model: gpt-image-1",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("not a recognized model id");
+      expect(result).toContain("`review_model`");
+      expect(result).toContain("https://docs.factory.ai/models");
     });
 
     it("does not add the hint for unrelated errors", () => {

--- a/test/model-policy.test.ts
+++ b/test/model-policy.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  applyModelPolicyFallback,
+  fetchModelPolicy,
+  isModelAllowedByPolicy,
+  isModelPolicyError,
+} from "../src/utils/model-policy";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.FACTORY_API_KEY;
+
+function mockFetch(handler: () => Promise<Response> | Response) {
+  globalThis.fetch = Object.assign(async () => handler(), {
+    preconnect: () => {},
+  }) as unknown as typeof fetch;
+}
+
+function managedSettingsResponse(modelPolicy: unknown): Response {
+  return new Response(
+    JSON.stringify({ success: true, settings: { modelPolicy } }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApiKey === undefined) {
+    delete process.env.FACTORY_API_KEY;
+  } else {
+    process.env.FACTORY_API_KEY = originalApiKey;
+  }
+});
+
+describe("isModelPolicyError", () => {
+  it("matches the model policy 403 message with a straight apostrophe", () => {
+    expect(
+      isModelPolicyError(
+        `403 {"detail":"This model is not available due to your organization's security settings."}`,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the model policy 403 message with a curly apostrophe", () => {
+    expect(
+      isModelPolicyError(
+        "This model is not available due to your organization’s security settings.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isModelPolicyError("500 Internal Server Error")).toBe(false);
+    expect(isModelPolicyError(undefined)).toBe(false);
+    expect(isModelPolicyError("")).toBe(false);
+  });
+});
+
+describe("isModelAllowedByPolicy", () => {
+  it("allows any model when there is no policy", () => {
+    expect(isModelAllowedByPolicy("gpt-5.2", null)).toBe(true);
+    expect(isModelAllowedByPolicy("gpt-5.2", undefined)).toBe(true);
+  });
+
+  it("denies models on the block list", () => {
+    expect(
+      isModelAllowedByPolicy("gpt-5.2", { blockedModelIds: ["gpt-5.2"] }),
+    ).toBe(false);
+  });
+
+  it("allows everything when allowAllFactoryModels is true", () => {
+    expect(
+      isModelAllowedByPolicy("gpt-5.2", {
+        allowAllFactoryModels: true,
+        allowedModelIds: ["claude-opus-5"],
+      }),
+    ).toBe(true);
+  });
+
+  it("enforces a non-empty allow list", () => {
+    const policy = { allowedModelIds: ["claude-opus-5", "kimi-k3"] };
+    expect(isModelAllowedByPolicy("claude-opus-5", policy)).toBe(true);
+    expect(isModelAllowedByPolicy("gpt-5.2", policy)).toBe(false);
+  });
+
+  it("treats an empty allow list as unrestricted", () => {
+    expect(isModelAllowedByPolicy("gpt-5.2", { allowedModelIds: [] })).toBe(
+      true,
+    );
+  });
+});
+
+describe("fetchModelPolicy", () => {
+  it("parses the model policy from managed settings", async () => {
+    mockFetch(() =>
+      managedSettingsResponse({
+        allowedModelIds: ["claude-opus-5"],
+        allowAllFactoryModels: false,
+      }),
+    );
+
+    const policy = await fetchModelPolicy("fk-test");
+    expect(policy).toEqual({
+      allowedModelIds: ["claude-opus-5"],
+      blockedModelIds: undefined,
+      allowAllFactoryModels: false,
+    });
+  });
+
+  it("returns null when the org has no model policy", async () => {
+    mockFetch(() =>
+      Response.json({ success: true, settings: { ideAutoConnect: true } }),
+    );
+
+    expect(await fetchModelPolicy("fk-test")).toBeNull();
+  });
+
+  it("returns null on non-OK responses", async () => {
+    mockFetch(() => new Response("nope", { status: 401 }));
+
+    expect(await fetchModelPolicy("fk-test")).toBeNull();
+  });
+
+  it("returns null on malformed payloads", async () => {
+    mockFetch(() => new Response("not json", { status: 200 }));
+
+    expect(await fetchModelPolicy("fk-test")).toBeNull();
+  });
+
+  it("returns null on network errors", async () => {
+    mockFetch(() => {
+      throw new Error("connection refused");
+    });
+
+    expect(await fetchModelPolicy("fk-test")).toBeNull();
+  });
+});
+
+describe("applyModelPolicyFallback", () => {
+  const options = { flowLabel: "code review", modelInputName: "review_model" };
+
+  it("keeps the model when it is allowed by the policy", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    mockFetch(() => managedSettingsResponse({ allowedModelIds: ["gpt-5.2"] }));
+
+    const result = await applyModelPolicyFallback(
+      { model: "gpt-5.2", reasoningEffort: "high" },
+      options,
+    );
+    expect(result).toEqual({ model: "gpt-5.2", reasoningEffort: "high" });
+  });
+
+  it("drops the model and returns a note when the policy disallows it", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    mockFetch(() =>
+      managedSettingsResponse({ allowedModelIds: ["claude-opus-5"] }),
+    );
+
+    const result = await applyModelPolicyFallback(
+      { model: "gpt-5.2", reasoningEffort: "high" },
+      options,
+    );
+    expect(result.model).toBeUndefined();
+    expect(result.reasoningEffort).toBeUndefined();
+    expect(result.fallbackNote).toContain("`gpt-5.2`");
+    expect(result.fallbackNote).toContain("`review_model`");
+  });
+
+  it("keeps the model when the policy lookup fails", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    mockFetch(() => {
+      throw new Error("connection refused");
+    });
+
+    const result = await applyModelPolicyFallback(
+      { model: "gpt-5.2", reasoningEffort: "high" },
+      options,
+    );
+    expect(result).toEqual({ model: "gpt-5.2", reasoningEffort: "high" });
+  });
+
+  it("skips the check when there is no API key", async () => {
+    delete process.env.FACTORY_API_KEY;
+    let fetchCalled = false;
+    mockFetch(() => {
+      fetchCalled = true;
+      return managedSettingsResponse({ allowedModelIds: ["claude-opus-5"] });
+    });
+
+    const result = await applyModelPolicyFallback(
+      { model: "gpt-5.2" },
+      options,
+    );
+    expect(result.model).toBe("gpt-5.2");
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("passes through when no model was requested", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    let fetchCalled = false;
+    mockFetch(() => {
+      fetchCalled = true;
+      return managedSettingsResponse({ allowedModelIds: ["claude-opus-5"] });
+    });
+
+    const result = await applyModelPolicyFallback({}, options);
+    expect(result.model).toBeUndefined();
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
Brings the latest changes from `dev` into `main`.

### Highlights
- **feat(review):** Graceful fallback when the org model policy blocks the selected model (#106)
  - Pre-flight: prepare steps fetch the org model policy (`GET /api/organization/managed-settings`) and omit `--model`/`--reasoning-effort` when the selected model is disallowed, so `droid exec` uses the org default. Fails open on any lookup error. Wired into review candidates + validator, security review/scan, PR description fill, and the GitLab prepare entrypoint.
  - Reactive backstop: `base-action` detects the model-policy 403 (including the explicit opt-in variant) in the exec result and retries once without `--model`; invalid/unrecognized model ids fall back the same way instead of failing the run.
  - Error surfacing: `base-action` exposes the final result error (or a condensed stderr tail) as an `error_message` output, rendered in the tracking comment with actionable TIP hints linking to https://docs.factory.ai/models; successful fallbacks render a NOTE so model switches are never silent; stale 'Droid is reviewing code…' progress text is stripped from final comments.
  - Motivated by a customer whose review workflows died with an opaque 403 after tightening their model allowlist while `review_depth` presets still selected blocked models.

### Commits included
- 3a9aaeb feat(review): fall back on invalid model ids and condense model-list error dumps
- 98bf871 fix(review): strip stale review/security progress text from the final tracking comment
- 52c8513 feat(review): fall back gracefully when the org model policy blocks the selected model

### Validation
- 492 bun tests pass, typecheck and format:check clean in root and `base-action`
- Verified end to end on factory-mono test PRs: policy/invalid-model fallback produces a passing check with a NOTE in the tracking comment (17310, 17311); genuine failures fail the check and surface the real error with hints (17303, 17305)

Please review and merge once CI passes.