### PR TITLE
feat(gitlab): org-wide review guidelines via org_guidelines_source input

### DIFF
--- a/docs/gitlab-setup.md
+++ b/docs/gitlab-setup.md
@@ -88,6 +88,61 @@ the `droid-review` job. Expect ~5-10 minutes for a typical change.
 | `security_block_on_critical` | `"true"`  | Block merge on CRITICAL security findings. (Mirrors GitHub action; surface-level parity.)                                                    |
 | `security_block_on_high`     | `"false"` | Block merge on HIGH security findings. (Mirrors GitHub action; surface-level parity.)                                                        |
 | `settings`                   | `""`      | Droid Exec settings as a JSON string or a path to a JSON file. Merged into `~/.factory/droid/settings.json` before each `droid exec` call.   |
+| `org_guidelines_source`      | `""`      | Org-wide review guidelines source: a local file path on the runner, an http(s) URL to the raw markdown, a git clone URL ending in `.git`, or a GitLab project path (e.g. `my-group/review-guidelines`) cloned with `$CI_JOB_TOKEN`. Empty = disabled. |
+| `org_guidelines_ref`         | `""`      | Git sources only: branch or tag of the org guidelines repo. Empty = default branch.                                                          |
+| `org_guidelines_path`        | `"review-guidelines.md"` | Git sources only: path of the guidelines markdown file inside the org guidelines repo.                                        |
+
+## Org-wide review guidelines
+
+Repository-specific guidelines live in the project itself at
+`.factory/skills/review-guidelines/SKILL.md` (same as the GitHub action).
+To apply one set of guidelines across every project in your org, point
+`org_guidelines_source` at a single markdown file:
+
+```yaml
+include:
+  - project: "factory-components/droid-action"
+    ref: main
+    file: "/templates/droid-review.yml"
+    inputs:
+      org_guidelines_source: "my-group/review-guidelines" # project path (see below for other forms)
+      org_guidelines_path: "review-guidelines.md"
+```
+
+`org_guidelines_source` accepts, in order of lookup:
+
+- **A git clone URL** (ending in `.git`, or `ssh://` / `git@` form). Cloned
+  as-is; `org_guidelines_ref` / `org_guidelines_path` select the file.
+- **An http(s) URL** to the raw markdown. Fetched with `curl`; URLs on the
+  same GitLab instance get a `JOB-TOKEN` header, so the repository files
+  API works for private repos, e.g.
+  `https://gitlab.com/api/v4/projects/<id>/repository/files/review-guidelines.md/raw?ref=main`.
+  Any other public URL works too.
+- **A local file path** on the runner. Useful with a group-level
+  **file-type CI/CD variable**: define `DROID_ORG_GUIDELINES` (type: File)
+  on the group and set `org_guidelines_source: "$DROID_ORG_GUIDELINES"`.
+  No network access or allowlisting needed.
+- **A GitLab project path** (e.g. `my-group/review-guidelines`, anything
+  that is not a URL or an existing file). Cloned from `$CI_SERVER_HOST`
+  with `$CI_JOB_TOKEN`; add your projects (or the parent group) to the
+  guidelines repo's **job token allowlist** (guidelines repo → Settings →
+  CI/CD → Job token permissions).
+
+Before each review, the job materializes the file as a **user-level**
+`org-review-guidelines` skill on the runner
+(`~/.factory/skills/org-review-guidelines/SKILL.md`). Because it lives
+outside the project tree, it never collides with a project's own
+`review-guidelines` skill — both apply, and the project-level skill takes
+precedence on conflicts.
+
+Notes:
+
+- The guidelines file is plain markdown; if it starts with `---` YAML
+  frontmatter it is installed verbatim as the skill file.
+- An unreachable source logs a warning and the review proceeds without
+  org guidelines; it never fails the pipeline.
+- Set the inputs once in a group-level include (or in each project's
+  `factory/droid-review.yml`) to roll out org-wide.
 
 ## What you get
 

--- a/gitlab/examples/factory/droid-review.yml
+++ b/gitlab/examples/factory/droid-review.yml
@@ -24,6 +24,8 @@ include:
       automatic_security_review: "false" # enable to flag vulns alongside the regular review
       security_block_on_critical: "true" # block merge on CRITICAL findings (when security review is on)
       security_block_on_high: "false" # block merge on HIGH findings
+      # org_guidelines_source: "my-group/review-guidelines" # org-wide guidelines: file path, raw URL, clone URL, or project path
+      # org_guidelines_path: "review-guidelines.md" # git sources only: markdown file inside the repo
 
 droid-review:
   variables:

--- a/gitlab/install-org-guidelines.sh
+++ b/gitlab/install-org-guidelines.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Installs organization-wide review guidelines as a user-level skill.
+#
+# Reads (all optional; no-op when ORG_GUIDELINES_SOURCE is empty):
+#   ORG_GUIDELINES_SOURCE Where the guidelines markdown lives. One of:
+#                         - a local file path on the runner (e.g. a
+#                           group-level file-type CI/CD variable)
+#                         - an http(s) URL to the raw markdown
+#                         - a git source: a clone URL ending in `.git`,
+#                           an ssh:// / git@ URL, or a GitLab project
+#                           path ("group/repo") cloned from
+#                           $CI_SERVER_HOST with $CI_JOB_TOKEN
+#   ORG_GUIDELINES_REF    Git sources only: branch or tag. Empty =
+#                         default branch.
+#   ORG_GUIDELINES_PATH   Git sources only: guidelines markdown file
+#                         inside the repo (default: review-guidelines.md).
+#
+# Writes ~/.factory/skills/org-review-guidelines/SKILL.md. The user-level
+# skills directory is distinct from the project's .factory/skills, so this
+# never collides with a repo-level `review-guidelines` skill.
+#
+# Failures are warnings, not job failures: a broken guidelines source
+# should not block code review.
+set -u
+
+if [ -z "${ORG_GUIDELINES_SOURCE:-}" ]; then
+  exit 0
+fi
+
+ORG_GUIDELINES_PATH="${ORG_GUIDELINES_PATH:-review-guidelines.md}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+GUIDELINES_FILE=""
+
+fetch_from_git() {
+  local clone_url="$1"
+  local -a clone_args=(--depth 1 --quiet)
+  if [ -n "${ORG_GUIDELINES_REF:-}" ]; then
+    clone_args+=(--branch "$ORG_GUIDELINES_REF")
+  fi
+  # Never echo clone_url: it may embed the job token.
+  if ! git clone "${clone_args[@]}" "$clone_url" "$WORK_DIR/repo"; then
+    echo "WARNING: could not clone org guidelines repo '$ORG_GUIDELINES_SOURCE'" \
+      "(ref: '${ORG_GUIDELINES_REF:-default}'); skipping org review guidelines." >&2
+    exit 0
+  fi
+  if [ ! -f "$WORK_DIR/repo/$ORG_GUIDELINES_PATH" ]; then
+    echo "WARNING: '$ORG_GUIDELINES_PATH' not found in org guidelines repo" \
+      "'$ORG_GUIDELINES_SOURCE'; skipping org review guidelines." >&2
+    exit 0
+  fi
+  GUIDELINES_FILE="$WORK_DIR/repo/$ORG_GUIDELINES_PATH"
+}
+
+fetch_from_url() {
+  local url="$1"
+  local -a curl_args=(--retry 3 --retry-delay 2 -fsSL)
+  # Same-instance URLs (e.g. the /projects/:id/repository/files/.../raw
+  # API) authenticate with the job token; other hosts get a plain fetch.
+  case "$url" in
+    "https://${CI_SERVER_HOST:-}/"* | "http://${CI_SERVER_HOST:-}/"*)
+      curl_args+=(--header "JOB-TOKEN: ${CI_JOB_TOKEN:-}")
+      ;;
+  esac
+  if ! curl "${curl_args[@]}" "$url" -o "$WORK_DIR/guidelines.md"; then
+    echo "WARNING: could not fetch org guidelines from '$url';" \
+      "skipping org review guidelines." >&2
+    exit 0
+  fi
+  GUIDELINES_FILE="$WORK_DIR/guidelines.md"
+}
+
+case "$ORG_GUIDELINES_SOURCE" in
+  *.git | ssh://* | git@*)
+    fetch_from_git "$ORG_GUIDELINES_SOURCE"
+    ;;
+  http://* | https://*)
+    fetch_from_url "$ORG_GUIDELINES_SOURCE"
+    ;;
+  file://*)
+    fetch_from_git "$ORG_GUIDELINES_SOURCE"
+    ;;
+  *)
+    if [ -f "$ORG_GUIDELINES_SOURCE" ]; then
+      # Local file already on the runner (e.g. file-type CI/CD variable).
+      GUIDELINES_FILE="$ORG_GUIDELINES_SOURCE"
+    else
+      # Treat as a GitLab project path on the current instance; the
+      # guidelines repo must allowlist this project for job-token access.
+      fetch_from_git "https://gitlab-ci-token:${CI_JOB_TOKEN:-}@${CI_SERVER_HOST:-gitlab.com}/${ORG_GUIDELINES_SOURCE}.git"
+    fi
+    ;;
+esac
+
+SKILL_DIR="$HOME/.factory/skills/org-review-guidelines"
+mkdir -p "$SKILL_DIR"
+
+if head -n 1 "$GUIDELINES_FILE" | grep -q '^---[[:space:]]*$'; then
+  # File already carries skill frontmatter; install verbatim.
+  cp "$GUIDELINES_FILE" "$SKILL_DIR/SKILL.md"
+else
+  {
+    echo "---"
+    echo "name: org-review-guidelines"
+    echo "description: Organization-wide code review guidelines. Always load and apply these when reviewing code. Project-level review guidelines take precedence on conflicts."
+    echo "---"
+    cat "$GUIDELINES_FILE"
+  } >"$SKILL_DIR/SKILL.md"
+fi
+
+echo "Installed org review guidelines from '$ORG_GUIDELINES_SOURCE'" \
+  "to $SKILL_DIR/SKILL.md"

--- a/templates/droid-review.yml
+++ b/templates/droid-review.yml
@@ -64,6 +64,31 @@ spec:
         Merged into ~/.factory/droid/settings.json on the runner before
         `droid exec` runs. Mirrors the GitHub action's `settings` input.
       default: ""
+    org_guidelines_source:
+      description: |
+        Where organization-wide review guidelines live. Accepts a local
+        file path on the runner (e.g. a group-level file-type CI/CD
+        variable), an http(s) URL to the raw markdown (same-instance
+        URLs authenticate with $CI_JOB_TOKEN), a git clone URL ending
+        in `.git`, or a GitLab project path (e.g. "my-group/review-
+        guidelines") cloned from $CI_SERVER_HOST using $CI_JOB_TOKEN
+        (add the consuming projects to the guidelines repo's job-token
+        allowlist). The guidelines are installed as a user-level
+        `org-review-guidelines` skill on the runner, separate from a
+        project's own `.factory/skills/review-guidelines` skill; both
+        apply, and the project-level skill wins on conflicts.
+        Empty = disabled.
+      default: ""
+    org_guidelines_ref:
+      description: |
+        Git sources only: branch or tag of the org guidelines repo to
+        clone. Empty = the repo's default branch.
+      default: ""
+    org_guidelines_path:
+      description: |
+        Git sources only: path of the guidelines markdown file inside
+        the org guidelines repo.
+      default: "review-guidelines.md"
     droid_action_repo:
       description: |
         Git repo (clone URL) of droid-action. Defaults to the gitlab.com
@@ -105,6 +130,9 @@ droid-review:
     SECURITY_BLOCK_ON_CRITICAL: "$[[ inputs.security_block_on_critical ]]"
     SECURITY_BLOCK_ON_HIGH: "$[[ inputs.security_block_on_high ]]"
     DROID_SETTINGS: "$[[ inputs.settings ]]"
+    ORG_GUIDELINES_SOURCE: "$[[ inputs.org_guidelines_source ]]"
+    ORG_GUIDELINES_REF: "$[[ inputs.org_guidelines_ref ]]"
+    ORG_GUIDELINES_PATH: "$[[ inputs.org_guidelines_path ]]"
     DROID_SUCCESS: "true"
   before_script:
     - apt-get update -qq
@@ -124,6 +152,10 @@ droid-review:
         cp -r "$DROID_ACTION_DIR/.factory/droids/." ~/.factory/droids/
         echo "Copied custom droids from $DROID_ACTION_DIR/.factory/droids to ~/.factory/droids"
       fi
+    # Install org-wide review guidelines (if configured) as a user-level
+    # `org-review-guidelines` skill so they apply alongside, and never
+    # shadow, a project's own `.factory/skills/review-guidelines` skill.
+    - bash "$DROID_ACTION_DIR/gitlab/install-org-guidelines.sh"
   script:
     - export PATH="$HOME/.local/bin:$PATH"
     - |


### PR DESCRIPTION
## Summary

Lets GitLab orgs apply one set of custom review guidelines across every project, without colliding with the existing per-repo `.factory/skills/review-guidelines` feature.

New CI/CD component inputs:

| Input | Default | Purpose |
| --- | --- | --- |
| `org_guidelines_source` | `""` | Where the org guidelines markdown lives (empty = disabled) |
| `org_guidelines_ref` | `""` | Git sources only: branch/tag (empty = default branch) |
| `org_guidelines_path` | `"review-guidelines.md"` | Git sources only: file path inside the repo |

`org_guidelines_source` accepts four forms, dispatched by `gitlab/install-org-guidelines.sh` (new, invoked from the component's `before_script`):

- **Local file path** on the runner, e.g. a group-level file-type CI/CD variable (`"$DROID_ORG_GUIDELINES"`). No network, no allowlisting.
- **http(s) URL** to the raw markdown. Same-instance URLs get a `JOB-TOKEN` header so the private repository-files API works; public URLs fetch plainly.
- **Git clone URL** (`*.git`, `ssh://`, `git@`).
- **GitLab project path** (`my-group/review-guidelines`), cloned from `$CI_SERVER_HOST` with `$CI_JOB_TOKEN` (guidelines repo must allowlist consuming projects).

## How it avoids overlapping the existing feature

The file is installed as a **user-level** skill at `~/.factory/skills/org-review-guidelines/SKILL.md` (frontmatter added unless the file already has some). The runner's `$HOME` is ephemeral and outside the project tree, so it can never shadow a project's own `review-guidelines` skill; both are discovered by droid exec and the org skill's description states project-level guidelines win on conflicts.

Failure handling: unreachable source or missing file logs a warning and the review proceeds; the pipeline never fails because of guidelines. The clone URL is never echoed so the job token can't leak into logs.

## Changes

- `gitlab/install-org-guidelines.sh` (new): source dispatch + skill installation
- `templates/droid-review.yml`: 3 spec inputs, job variables, `before_script` hook
- `docs/gitlab-setup.md`: inputs table + "Org-wide review guidelines" section
- `gitlab/examples/factory/droid-review.yml`: commented sample inputs

## Testing

- 9/9 local functional tests of the script: no-op when unset, git clone with frontmatter wrapping, verbatim install when frontmatter exists, pinned tag, HTTP fetch (local server), unreachable URL warns + exits 0, local-file copy, project-path URL construction with no token leakage in output, missing file in repo warns + exits 0.
- `bash -n` syntax check passed.
- Not run: `bun test` / `typecheck` / `format` (no bun in the dev environment; no TypeScript touched). YAML edits mirror adjacent entries but a `glab ci lint` or one real MR pipeline run is recommended before tagging.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>