### PR TITLE
chore: rename action to "Droid by Factory" for the marketplace listing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Factory Droid Action"
+name: "Droid by Factory"
 description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
 branding:
   icon: "at-sign"

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Droid Exec Action v1.0"
+name: "Factory Droid Action"
 description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
 branding:
   icon: "at-sign"


### PR DESCRIPTION
The Marketplace listing name comes from the `name:` field in `action.yml` and is permanent once listed. Renames "Droid Exec Action v1.0" to "Droid by Factory" ahead of the first Marketplace publish of v6.