### PR TITLE
Merge dev into main: rename action for the Marketplace listing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Factory Droid Action"
+name: "Droid by Factory"
 description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
 branding:
   icon: "at-sign"

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Droid Exec Action v1.0"
+name: "Factory Droid Action"
 description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
 branding:
   icon: "at-sign"


### PR DESCRIPTION
Brings the action rename to "Droid by Factory" (#112) into main so the v6 tag can be re-pointed before the first Marketplace publish.