### PR TITLE
chore: shorten the action description under the 125-char marketplace limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Droid by Factory"
-description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
+description: "Flexible GitHub automation with Droid: PR reviews, @droid mentions, or custom automation, auto-detected from the event."
 branding:
   icon: "at-sign"
   color: "orange"


### PR DESCRIPTION
Marketplace publishing rejects `action.yml` descriptions of 125 characters or more; ours was 139. Rewords it to 119 characters with the same meaning.