### PR TITLE
Merge dev into main: shorten action description for the Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Droid by Factory"
-description: "Flexible GitHub automation platform with Droid. Auto-detects mode based on event type: PR reviews, @droid mentions, or custom automation."
+description: "Flexible GitHub automation with Droid: PR reviews, @droid mentions, or custom automation, auto-detected from the event."
 branding:
   icon: "at-sign"
   color: "orange"


### PR DESCRIPTION
Brings the sub-125-char `action.yml` description (#114) into main so the v6 tag can be re-pointed for Marketplace publishing.