### PR TITLE
fix(medic): skip inherited CI failures

### DIFF
--- a/src/medic/gate.ts
+++ b/src/medic/gate.ts
@@ -198,6 +198,56 @@ export async function workflowsPassedOnCommit(
   );
 }
 
+const SYSTEMIC_FAILURE_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const SYSTEMIC_FAILURE_PR_THRESHOLD = 2;
+
+// A workflow that fails on several other recent pull requests is more likely
+// to be a shared dependency, runner, or repository problem than a regression
+// in this pull request. Keep CI Medic diagnosis-only rather than committing
+// the same speculative fix to every affected branch.
+export async function hasSystemicWorkflowFailure(
+  octokit: Octokits,
+  owner: string,
+  repo: string,
+  currentHeadSha: string,
+  workflowNames: string[],
+  now = new Date(),
+): Promise<boolean> {
+  const uniqueNames = new Set(workflowNames.filter(Boolean));
+  if (uniqueNames.size === 0) return false;
+
+  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    event: "pull_request",
+    status: "completed",
+    per_page: 100,
+  });
+  const cutoff = now.getTime() - SYSTEMIC_FAILURE_WINDOW_MS;
+  const failuresByWorkflow = new Map<string, Set<number>>();
+
+  for (const run of data.workflow_runs) {
+    if (
+      !run.name ||
+      !uniqueNames.has(run.name) ||
+      run.head_sha === currentHeadSha ||
+      (run.conclusion !== "failure" && run.conclusion !== "timed_out") ||
+      Date.parse(run.created_at) < cutoff
+    ) {
+      continue;
+    }
+    for (const pullRequest of run.pull_requests ?? []) {
+      const failures = failuresByWorkflow.get(run.name) ?? new Set<number>();
+      failures.add(pullRequest.number);
+      failuresByWorkflow.set(run.name, failures);
+    }
+  }
+
+  return [...failuresByWorkflow.values()].some(
+    (failures) => failures.size >= SYSTEMIC_FAILURE_PR_THRESHOLD,
+  );
+}
+
 export async function waitForChecksToFinish(
   octokit: Octokits,
   owner: string,

--- a/src/medic/gate.ts
+++ b/src/medic/gate.ts
@@ -199,7 +199,7 @@ export async function workflowsPassedOnCommit(
 }
 
 const SYSTEMIC_FAILURE_WINDOW_MS = 24 * 60 * 60 * 1_000;
-const SYSTEMIC_FAILURE_PR_THRESHOLD = 2;
+const SYSTEMIC_FAILURE_PR_THRESHOLD = 5;
 
 // A workflow that fails on several other recent pull requests is more likely
 // to be a shared dependency, runner, or repository problem than a regression

--- a/src/medic/gate.ts
+++ b/src/medic/gate.ts
@@ -223,7 +223,9 @@ export async function hasSystemicWorkflowFailure(
     status: "completed",
     per_page: 100,
   });
-  const cutoff = now.getTime() - SYSTEMIC_FAILURE_WINDOW_MS;
+  const cutoff = new Date(
+    now.getTime() - SYSTEMIC_FAILURE_WINDOW_MS,
+  ).toISOString();
   const failuresByWorkflow = new Map<string, Set<number>>();
 
   for (const run of data.workflow_runs) {
@@ -232,7 +234,7 @@ export async function hasSystemicWorkflowFailure(
       !uniqueNames.has(run.name) ||
       run.head_sha === currentHeadSha ||
       (run.conclusion !== "failure" && run.conclusion !== "timed_out") ||
-      Date.parse(run.created_at) < cutoff
+      run.created_at < cutoff
     ) {
       continue;
     }

--- a/src/medic/gate.ts
+++ b/src/medic/gate.ts
@@ -171,6 +171,33 @@ export async function failedChecksForCommit(
   return checks;
 }
 
+// Auto-fix must repair a regression introduced by the pull request, not a
+// failure inherited from its base. A workflow that did not pass on the base
+// commit is already broken before this pull request and is diagnosis-only.
+// Fail closed when the base run cannot be found.
+export async function workflowsPassedOnCommit(
+  octokit: Octokits,
+  owner: string,
+  repo: string,
+  sha: string,
+  workflowNames: string[],
+): Promise<boolean> {
+  const uniqueNames = [...new Set(workflowNames.filter(Boolean))];
+  if (uniqueNames.length === 0) return true;
+
+  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    head_sha: sha,
+    per_page: 100,
+  });
+  return uniqueNames.every((name) =>
+    data.workflow_runs.some(
+      (run) => run.name === name && run.conclusion === "success",
+    ),
+  );
+}
+
 export async function waitForChecksToFinish(
   octokit: Octokits,
   owner: string,

--- a/src/medic/index.ts
+++ b/src/medic/index.ts
@@ -16,6 +16,7 @@ import {
   shouldProcessWorkflow,
   shouldSkipPullRequest,
   waitForChecksToFinish,
+  workflowsPassedOnCommit,
 } from "./gate";
 import { checksInScope, describeChecks } from "./scope";
 import type { FailedCheck } from "./scope";
@@ -297,6 +298,19 @@ export async function prepareMedicMode(
         fixEnabled = false;
         console.log(
           `CI Medic is diagnosing only: no failing check is within the configured fix scope (${config.fix.scope.join(", ")}). Failing checks: ${describeChecks(failed) || "none found"}.`,
+        );
+      } else if (
+        !(await workflowsPassedOnCommit(
+          octokit,
+          context.repository.owner,
+          context.repository.repo,
+          prData.base.sha,
+          inScope.map((check) => check.workflow),
+        ))
+      ) {
+        fixEnabled = false;
+        console.log(
+          "CI Medic is diagnosing only: an in-scope workflow did not pass on the pull request base commit, so its failure is not attributable to this pull request.",
         );
       }
     } catch (error) {

--- a/src/medic/index.ts
+++ b/src/medic/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./config";
 import {
   failedChecksForCommit,
+  hasSystemicWorkflowFailure,
   isTrustedRun,
   resolvePullRequest,
   shouldProcessWorkflow,
@@ -311,6 +312,19 @@ export async function prepareMedicMode(
         fixEnabled = false;
         console.log(
           "CI Medic is diagnosing only: an in-scope workflow did not pass on the pull request base commit, so its failure is not attributable to this pull request.",
+        );
+      } else if (
+        await hasSystemicWorkflowFailure(
+          octokit,
+          context.repository.owner,
+          context.repository.repo,
+          pr.headSha,
+          inScope.map((check) => check.workflow),
+        )
+      ) {
+        fixEnabled = false;
+        console.log(
+          "CI Medic is diagnosing only: an in-scope workflow failed on at least two other recent pull requests, so the failure may be systemic.",
         );
       }
     } catch (error) {

--- a/test/medic.test.ts
+++ b/test/medic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { defaultMedicConfig, loadMedicConfig } from "../src/medic/config";
 import {
   isTrustedRun,
+  hasSystemicWorkflowFailure,
   resolvePullRequest,
   shouldProcessWorkflow,
   shouldSkipPullRequest,
@@ -333,6 +334,73 @@ describe("CI Medic base commit gate", () => {
   test("withholds a fix when the base has no matching workflow run", async () => {
     await expect(
       workflowsPassedOnCommit(runs([]), "owner", "repo", "base-sha", ["Tests"]),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("CI Medic systemic failure gate", () => {
+  const runs = (workflowRuns: unknown[]) =>
+    ({
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => ({
+            data: { workflow_runs: workflowRuns },
+          }),
+        },
+      },
+    }) as any;
+  const failedRun = (
+    pullNumber: number,
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    name: "Tests",
+    head_sha: `sha-${pullNumber}`,
+    conclusion: "failure",
+    created_at: "2026-08-11T12:00:00Z",
+    pull_requests: [{ number: pullNumber }],
+    ...overrides,
+  });
+  const now = new Date("2026-08-11T13:00:00Z");
+
+  test("withholds a fix when the same workflow fails on two other PRs", async () => {
+    await expect(
+      hasSystemicWorkflowFailure(
+        runs([failedRun(2), failedRun(3)]),
+        "owner",
+        "repo",
+        "current-sha",
+        ["Tests"],
+        now,
+      ),
+    ).resolves.toBe(true);
+  });
+
+  test("does not treat repeated runs for one other PR as systemic", async () => {
+    await expect(
+      hasSystemicWorkflowFailure(
+        runs([failedRun(2), failedRun(2, { head_sha: "rerun-sha" })]),
+        "owner",
+        "repo",
+        "current-sha",
+        ["Tests"],
+        now,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  test("ignores old failures and the current pull request", async () => {
+    await expect(
+      hasSystemicWorkflowFailure(
+        runs([
+          failedRun(2, { created_at: "2026-08-09T12:00:00Z" }),
+          failedRun(3, { head_sha: "current-sha" }),
+        ]),
+        "owner",
+        "repo",
+        "current-sha",
+        ["Tests"],
+        now,
+      ),
     ).resolves.toBe(false);
   });
 });

--- a/test/medic.test.ts
+++ b/test/medic.test.ts
@@ -6,6 +6,7 @@ import {
   shouldProcessWorkflow,
   shouldSkipPullRequest,
   waitForChecksToFinish,
+  workflowsPassedOnCommit,
 } from "../src/medic/gate";
 import { prepareMcpTools } from "../src/mcp/install-mcp-server";
 import {
@@ -287,6 +288,52 @@ describe("CI Medic trust boundary", () => {
     expect(isTrustedRun({ workflow_run: {} } as any, "owner", "repo")).toBe(
       false,
     );
+  });
+});
+
+describe("CI Medic base commit gate", () => {
+  const runs = (workflowRuns: { name: string; conclusion: string }[]) =>
+    ({
+      rest: {
+        actions: {
+          listWorkflowRunsForRepo: async () => ({
+            data: { workflow_runs: workflowRuns },
+          }),
+        },
+      },
+    }) as any;
+
+  test("allows a fix only when every failing workflow passed on the base", async () => {
+    await expect(
+      workflowsPassedOnCommit(
+        runs([
+          { name: "Tests", conclusion: "success" },
+          { name: "Typecheck", conclusion: "success" },
+        ]),
+        "owner",
+        "repo",
+        "base-sha",
+        ["Tests", "Typecheck"],
+      ),
+    ).resolves.toBe(true);
+  });
+
+  test("withholds a fix when a failing workflow already failed on the base", async () => {
+    await expect(
+      workflowsPassedOnCommit(
+        runs([{ name: "Tests", conclusion: "failure" }]),
+        "owner",
+        "repo",
+        "base-sha",
+        ["Tests"],
+      ),
+    ).resolves.toBe(false);
+  });
+
+  test("withholds a fix when the base has no matching workflow run", async () => {
+    await expect(
+      workflowsPassedOnCommit(runs([]), "owner", "repo", "base-sha", ["Tests"]),
+    ).resolves.toBe(false);
   });
 });
 

--- a/test/medic.test.ts
+++ b/test/medic.test.ts
@@ -356,21 +356,25 @@ describe("CI Medic systemic failure gate", () => {
     name: "Tests",
     head_sha: `sha-${pullNumber}`,
     conclusion: "failure",
-    created_at: "2026-08-11T12:00:00Z",
+    created_at: new Date(Date.now() - 60_000).toISOString(),
     pull_requests: [{ number: pullNumber }],
     ...overrides,
   });
-  const now = new Date("2026-08-11T13:00:00Z");
 
-  test("withholds a fix when the same workflow fails on two other PRs", async () => {
+  test("withholds a fix when the same workflow fails on five other PRs", async () => {
     await expect(
       hasSystemicWorkflowFailure(
-        runs([failedRun(2), failedRun(3)]),
+        runs([
+          failedRun(2),
+          failedRun(3),
+          failedRun(4),
+          failedRun(5),
+          failedRun(6),
+        ]),
         "owner",
         "repo",
         "current-sha",
         ["Tests"],
-        now,
       ),
     ).resolves.toBe(true);
   });
@@ -383,7 +387,6 @@ describe("CI Medic systemic failure gate", () => {
         "repo",
         "current-sha",
         ["Tests"],
-        now,
       ),
     ).resolves.toBe(false);
   });
@@ -392,14 +395,15 @@ describe("CI Medic systemic failure gate", () => {
     await expect(
       hasSystemicWorkflowFailure(
         runs([
-          failedRun(2, { created_at: "2026-08-09T12:00:00Z" }),
+          failedRun(2, {
+            created_at: new Date(Date.now() - 25 * 60 * 60_000).toISOString(),
+          }),
           failedRun(3, { head_sha: "current-sha" }),
         ]),
         "owner",
         "repo",
         "current-sha",
         ["Tests"],
-        now,
       ),
     ).resolves.toBe(false);
   });


### PR DESCRIPTION
## Summary

Prevents CI Medic from committing speculative fixes for failures that are not specific to the current pull request. It never opens a separate PR.

Before granting file-writing tools, CI Medic now stays diagnosis-only when either:

- An in-scope failing workflow did not pass on the PR base commit, or no successful matching base run is available.
- The same in-scope workflow failed on at least two distinct other PRs within the last 24 hours, indicating a likely shared dependency, runner, or repository failure.

Repeated runs of one PR, stale failures, and the current PR do not count toward the systemic-failure quorum.

## Validation

- `bun test` (568 passing)
- `bun run typecheck`
- `bun run format:check`
