### PR TITLE
feat(steward): concise comments and per-PR queued concurrency

### DIFF
--- a/src/steward/index.ts
+++ b/src/steward/index.ts
@@ -270,7 +270,7 @@ export async function prepareStewardMode(
         owner: context.repository.owner,
         repo: context.repository.repo,
         issue_number: pr.number,
-        body: `## CI Steward\n\nRun limit reached (${config.max_runs_per_pr} per pull request). The remaining failures need a human.\n\n${STEWARD_BUDGET_MARKER}`,
+        body: `## CI Steward\n\nCI Steward has reached the lifetime limit of ${config.max_runs_per_pr} runs for this pull request. A human should investigate the remaining failures.\n\n${STEWARD_BUDGET_MARKER}`,
       });
     }
     return skippedResult("max_runs_per_pr");

--- a/src/steward/index.ts
+++ b/src/steward/index.ts
@@ -270,7 +270,7 @@ export async function prepareStewardMode(
         owner: context.repository.owner,
         repo: context.repository.repo,
         issue_number: pr.number,
-        body: `## CI Steward\n\nCI Steward has reached the lifetime limit of ${config.max_runs_per_pr} runs for this pull request. A human should investigate the remaining failures.\n\n${STEWARD_BUDGET_MARKER}`,
+        body: `## CI Steward\n\nRun limit reached (${config.max_runs_per_pr} per pull request). The remaining failures need a human.\n\n${STEWARD_BUDGET_MARKER}`,
       });
     }
     return skippedResult("max_runs_per_pr");
@@ -343,7 +343,7 @@ export async function prepareStewardMode(
   }
 
   const runMarker = `${STEWARD_RUN_MARKER_PREFIX}${context.runId} count=${stewardRuns + 1} sha=${pr.headSha} -->`;
-  const trackingBody = `## CI Steward\n\nCI Steward is analyzing the completed workflow run [${run.name}](${run.html_url}) and the other checks for this commit.\n\n${runMarker}`;
+  const trackingBody = `## CI Steward\n\nDiagnosing [${run.name}](${run.html_url}) and the other checks on this commit.\n\n${runMarker}`;
   const comment = trackingComment
     ? await octokit.rest.issues.updateComment({
         owner: context.repository.owner,
@@ -401,7 +401,9 @@ If a failure is flaky or infrastructure-related and retries are allowed, rerun t
 
 This pull request may have been analyzed before. Read the existing review comments first and do not repost a suggestion that already exists for the same file and line.
 
-Report your findings by updating the existing CI Steward comment with a concise diagnosis, actions taken, and what remains. Update that one comment; do not create additional pull request comments.
+Report by updating the existing CI Steward comment; never create additional pull request comments. Keep the comment short and scannable:
+- Under the "## CI Steward" heading, write one bullet per failed check: check name, verdict (real, flaky, infrastructure, or configuration), and the action taken (fixed in a linked commit, retried, or none), with at most one sentence of explanation.
+- No log excerpts, no restated pull request context, no next-steps section, no closing summary.
 
 Additional repository instructions:
 ${config.instructions || "(none)"}`;

--- a/src/steward/postrun.ts
+++ b/src/steward/postrun.ts
@@ -116,14 +116,14 @@ async function main() {
     await revertProtectedPaths(baseSha, violations);
     await $`git push`.nothrow();
     await updateTrackingComment(
-      `## CI Steward\n\nReverted changes to protected paths; [the run](${runUrl}) needs human review:\n\n${violations.map((file) => `- \`${file}\``).join("\n")}`,
+      `## CI Steward\n\nThis run tried to modify protected paths and the changes were reverted:\n\n${violations.map((file) => `- \`${file}\``).join("\n")}\n\nA human should review [the run](${runUrl}).`,
     );
     process.exit(1);
   }
 
   if (!succeeded) {
     await updateTrackingComment(
-      `## CI Steward\n\nRun did not finish; see [the run](${runUrl}).`,
+      `## CI Steward\n\nCI Steward did not finish. See [the run](${runUrl}) for details.`,
     );
   }
 }

--- a/src/steward/postrun.ts
+++ b/src/steward/postrun.ts
@@ -116,14 +116,14 @@ async function main() {
     await revertProtectedPaths(baseSha, violations);
     await $`git push`.nothrow();
     await updateTrackingComment(
-      `## CI Steward\n\nThis run tried to modify protected paths and the changes were reverted:\n\n${violations.map((file) => `- \`${file}\``).join("\n")}\n\nA human should review [the run](${runUrl}).`,
+      `## CI Steward\n\nReverted changes to protected paths; [the run](${runUrl}) needs human review:\n\n${violations.map((file) => `- \`${file}\``).join("\n")}`,
     );
     process.exit(1);
   }
 
   if (!succeeded) {
     await updateTrackingComment(
-      `## CI Steward\n\nCI Steward did not finish. See [the run](${runUrl}) for details.`,
+      `## CI Steward\n\nRun did not finish; see [the run](${runUrl}).`,
     );
   }
 }

--- a/templates/droid-ci-steward.yml
+++ b/templates/droid-ci-steward.yml
@@ -13,27 +13,24 @@ permissions:
   pull-requests: write
   id-token: write
 
-# Keyed on the pull request rather than the commit. Two workflows failing on
-# one commit raise two workflow_run events, and separate groups let both spend
-# a run from the budget for the same commit.
-# Runs are serialized per branch rather than cancelled. Concurrency applies to
-# the whole workflow, including runs whose job is skipped by the condition
-# below, so cancel-in-progress would let a passing workflow's skipped run kill
-# an in-flight diagnosis for a failing one.
-concurrency:
-  group: ci-steward-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: false
-
 jobs:
   ci-steward:
-    # Fork pull requests are not processed. workflow_run runs in the base
-    # repository with write-scoped tokens and secrets, so checking out a fork's
-    # commit here and running commands against it would hand a pull request
-    # author the app token, the workflow token, and the Factory API key.
+    # Only process same-repo pull request runs. Watched workflows may also run
+    # on push, and fork pull requests must never reach a checkout here:
+    # workflow_run executes in the base repository with write-scoped tokens
+    # and secrets, so running a fork's commit would hand a pull request author
+    # the app token, the workflow token, and the Factory API key.
     if: >
+      github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion != 'success' &&
       github.event.workflow_run.conclusion != 'cancelled'
+    # Job-level so skipped events never enter the group. Keyed per pull
+    # request, and runs queue rather than cancel: a cancelled run has already
+    # spent a unit of the budget and can be killed mid-diagnosis or mid-fix.
+    concurrency:
+      group: ci-steward-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       # Check out the head branch (not the merge commit) so CI Steward can


### PR DESCRIPTION
## Summary

Stacked on #120 (rename). Two changes:

**Less verbose comments**
- Tracking comment: "Diagnosing [run] and the other checks on this commit." (was a full sentence about analyzing the completed workflow run)
- The prompt now pins the final report format: one bullet per failed check (name, verdict, action taken, at most one sentence of explanation), no log excerpts, no restated context, no closing summary.
- The budget-exhausted and post-run comments keep their original wording.

**Template concurrency (`templates/droid-ci-steward.yml`)**
- Concurrency moves to the job level, keyed on the pull request number (head branch as fallback), with `cancel-in-progress: false`: runs queue per PR instead of cancelling, so a newer workflow_run event can no longer kill an in-flight diagnosis or fix that already spent budget.
- The template also gains the `workflow_run.event == 'pull_request'` guard the production factory-mono workflow already has.

Companion factory-mono PR applies the same concurrency change to the live workflow.

## Validation

- `bun test`: 568 pass, 0 fail
- `bun run typecheck`: clean
- `bun run format:check`: clean
