### PR TITLE
fix(security): mask GitHub App installation token in Actions logs

### DIFF
--- a/src/entrypoints/get-token.ts
+++ b/src/entrypoints/get-token.ts
@@ -14,6 +14,7 @@ async function run() {
     let token: string;
     if (overrideToken) {
       console.log("Using provided GitHub token");
+      core.setSecret(overrideToken);
       token = overrideToken;
     } else {
       console.log("Requesting OIDC token...");

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -116,6 +116,11 @@ async function exchangeForAppToken(oidcToken: string): Promise<string> {
     throw new Error("App token not found in response");
   }
 
+  // Runtime-generated tokens are not known to the Actions runner, so they are
+  // printed verbatim in step `env:` headers and outputs unless registered
+  // with the log masker.
+  core.setSecret(appTokenData.token);
+
   return appTokenData.token;
 }
 
@@ -126,6 +131,7 @@ export async function setupGitHubToken(): Promise<string> {
 
     if (providedToken) {
       console.log("Using provided GITHUB_TOKEN for authentication");
+      core.setSecret(providedToken);
       core.setOutput("GITHUB_TOKEN", providedToken);
       return providedToken;
     }

--- a/test/github/token.test.ts
+++ b/test/github/token.test.ts
@@ -34,6 +34,7 @@ describe("setupGitHubToken", () => {
     process.env.OVERRIDE_GITHUB_TOKEN = "override-token";
 
     const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const setSecretSpy = spyOn(core, "setSecret").mockImplementation(() => {});
     const getIdTokenSpy = spyOn(core, "getIDToken").mockResolvedValue(
       "oidc-token",
     );
@@ -41,10 +42,12 @@ describe("setupGitHubToken", () => {
     const result = await setupGitHubToken();
 
     expect(result).toBe("override-token");
+    expect(setSecretSpy).toHaveBeenCalledWith("override-token");
     expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "override-token");
     expect(getIdTokenSpy).not.toHaveBeenCalled();
 
     setOutputSpy.mockRestore();
+    setSecretSpy.mockRestore();
     getIdTokenSpy.mockRestore();
   });
 
@@ -58,6 +61,7 @@ describe("setupGitHubToken", () => {
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const setSecretSpy = spyOn(core, "setSecret").mockImplementation(() => {});
     const getIdTokenSpy = spyOn(core, "getIDToken").mockResolvedValue(
       "oidc-token",
     );
@@ -70,10 +74,12 @@ describe("setupGitHubToken", () => {
     expect(result).toBe("app-token");
     expect(getIdTokenSpy).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setSecretSpy).toHaveBeenCalledWith("app-token");
     expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "app-token");
     expect(retrySpy).toHaveBeenCalledTimes(2);
 
     setOutputSpy.mockRestore();
+    setSecretSpy.mockRestore();
     getIdTokenSpy.mockRestore();
     retrySpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

Externally reported: the Factory Droid GitHub App installation token appeared unmasked in raw Actions logs. GitHub Actions only masks values registered with the log masker (`core.setSecret()` or workflow-level `secrets.*`), and this codebase never called `setSecret`, so the runtime-exchanged token leaked through two vectors on every run:

1. **Step `env:` headers.** The composite actions (`action.yml`, `review/action.yml`, `security/action.yml`) inject `steps.token.outputs.github_token` / `steps.prepare.outputs.github_token` into later steps via `env:`, and the runner prints each step's expanded `env:` block in the raw log.
2. **`INPUT_MCP_TOOLS` JSON.** `install-mcp-server.ts` embeds the raw token in the MCP server config emitted as the `mcp_tools` output, which lands in the same printed `env:` blocks.

## Fix

Register the token with the Actions log masker at every acquisition point, which masks all downstream occurrences (env headers, embedded JSON, error messages):

- `src/github/token.ts`: `core.setSecret()` on the exchanged app token immediately after parsing the token-exchange response, and on the `OVERRIDE_GITHUB_TOKEN` path. Covers `prepare.ts`, `prepare-validator.ts`, and the OIDC path of `get-token.ts`. (The OIDC token itself is already masked inside `core.getIDToken`.)
- `src/entrypoints/get-token.ts`: `core.setSecret()` on the override-token branch, which bypasses `setupGitHubToken`.
- `test/github/token.test.ts`: both tests now assert `setSecret` is called with the token, so a regression fails CI.

## GitLab surface audited: not affected

- `GITLAB_TOKEN` is a user-provided **masked** CI/CD variable; GitLab masks its value anywhere in job logs.
- The CI template strips it from the droid exec environment (`env -u GITLAB_TOKEN -u OVERRIDE_GITLAB_TOKEN`).
- The `.droid-debug/` artifacts (state file, resolved-env shim, prompts, pass logs) contain no secrets, and `GitlabClient` never logs the token.

## Impact notes

- Installation tokens expire after 1 hour, so tokens in historical logs are dead; **no credential rotation is required**. `FACTORY_API_KEY` was never exposed (always a workflow secret).
- Exposure: unauthenticated token theft from live runs on public repos; read-to-write escalation for log readers on private repos.
- Follow-up (not in this PR): re-point release tags so mutable-ref consumers pick this up, then publish a GHSA crediting the reporter.

## Validation

- `bun test`: 613 pass, 0 fail (full suite); targeted token tests pass on this branch
- `bun run typecheck`: clean
- `prettier --check` on changed files: clean

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
