### PR TITLE
Merge dev into main: mask GitHub App installation token in Actions logs

### DIFF
--- a/src/entrypoints/get-token.ts
+++ b/src/entrypoints/get-token.ts
@@ -14,6 +14,7 @@ async function run() {
     let token: string;
     if (overrideToken) {
       console.log("Using provided GitHub token");
+      core.setSecret(overrideToken);
       token = overrideToken;
     } else {
       console.log("Requesting OIDC token...");

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -116,6 +116,11 @@ async function exchangeForAppToken(oidcToken: string): Promise<string> {
     throw new Error("App token not found in response");
   }
 
+  // Runtime-generated tokens are not known to the Actions runner, so they are
+  // printed verbatim in step `env:` headers and outputs unless registered
+  // with the log masker.
+  core.setSecret(appTokenData.token);
+
   return appTokenData.token;
 }
 
@@ -126,6 +131,7 @@ export async function setupGitHubToken(): Promise<string> {
 
     if (providedToken) {
       console.log("Using provided GITHUB_TOKEN for authentication");
+      core.setSecret(providedToken);
       core.setOutput("GITHUB_TOKEN", providedToken);
       return providedToken;
     }

--- a/test/github/token.test.ts
+++ b/test/github/token.test.ts
@@ -34,6 +34,7 @@ describe("setupGitHubToken", () => {
     process.env.OVERRIDE_GITHUB_TOKEN = "override-token";
 
     const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const setSecretSpy = spyOn(core, "setSecret").mockImplementation(() => {});
     const getIdTokenSpy = spyOn(core, "getIDToken").mockResolvedValue(
       "oidc-token",
     );
@@ -41,10 +42,12 @@ describe("setupGitHubToken", () => {
     const result = await setupGitHubToken();
 
     expect(result).toBe("override-token");
+    expect(setSecretSpy).toHaveBeenCalledWith("override-token");
     expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "override-token");
     expect(getIdTokenSpy).not.toHaveBeenCalled();
 
     setOutputSpy.mockRestore();
+    setSecretSpy.mockRestore();
     getIdTokenSpy.mockRestore();
   });
 
@@ -58,6 +61,7 @@ describe("setupGitHubToken", () => {
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const setSecretSpy = spyOn(core, "setSecret").mockImplementation(() => {});
     const getIdTokenSpy = spyOn(core, "getIDToken").mockResolvedValue(
       "oidc-token",
     );
@@ -70,10 +74,12 @@ describe("setupGitHubToken", () => {
     expect(result).toBe("app-token");
     expect(getIdTokenSpy).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setSecretSpy).toHaveBeenCalledWith("app-token");
     expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "app-token");
     expect(retrySpy).toHaveBeenCalledTimes(2);
 
     setOutputSpy.mockRestore();
+    setSecretSpy.mockRestore();
     getIdTokenSpy.mockRestore();
     retrySpy.mockRestore();
   });


### PR DESCRIPTION
Promotes the fix from #126 to `main`.

## Problem

The GitHub App installation token was never registered with the Actions log masker, so it rendered in plaintext everywhere the runner echoes an expanded environment:

- the `##[group]Run …` `env:` header of every step downstream of token creation (`GITHUB_TOKEN: ghs_…`)
- inside the `INPUT_MCP_TOOLS` JSON blob, where the token sits in each MCP server's `env` map rather than on a line that looks like a credential

Measured on a real run of `droid-review` in factory-mono: **7 plaintext `ghs_` occurrences per run**, across two distinct tokens (main + validator). On the same env header, `FACTORY_API_KEY` rendered as `***` while `GITHUB_TOKEN` did not, which isolates the cause to the missing masker registration rather than anything in the runner.

## Fix

`core.setSecret()` on the token as soon as it exists, on both the OIDC-exchange path and the provided-token path, before it can reach any log sink.

## Verification

Re-ran an existing review job on factory-mono PR #18617 so the only variable was the action tip:

| | pre-fix | post-fix |
|---|---|---|
| `ghs_` hits in log | 7 | 0 |
| MCP config `"GITHUB_TOKEN"` | plaintext x4 | `"***"` x4 |
| step `env:` header | plaintext x3 | `***` x4 |
| conclusion | success | success |

Review completed normally, so masking does not disturb the token's downstream use in the MCP servers or the comment updater.

## Follow-up

Tags `v1`-`v6` still point at pre-fix commits. Consumers pinned to a version tag keep leaking until those are moved; `@dev` and `@main` consumers are covered by this merge.