### PR TITLE
fix(github): survive GraphQL responses that carry no envelope

### DIFF
--- a/src/github/data/pr-fetcher.ts
+++ b/src/github/data/pr-fetcher.ts
@@ -1,6 +1,7 @@
 import type { Octokits } from "../api/client";
 import { PR_QUERY, REPO_DEFAULT_BRANCH_QUERY } from "../api/queries/github";
 import type { GitHubPullRequest } from "../types";
+import { retryWithBackoff } from "../../utils/retry";
 
 /**
  * Represents the PR data needed by fill and review commands
@@ -16,8 +17,124 @@ export type PRBranchData = {
 type PullRequestQueryResponse = {
   repository: {
     pullRequest: GitHubPullRequest | null;
-  };
+  } | null;
 };
+
+type RepoDefaultBranchQueryResponse = {
+  repository: {
+    defaultBranchRef: {
+      name: string;
+    } | null;
+  } | null;
+};
+
+const GRAPHQL_RETRY_OPTIONS = {
+  maxAttempts: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 4000,
+};
+
+type OctokitHttpResponse = {
+  status: number;
+  headers: Record<string, string | number | undefined>;
+  data: unknown;
+};
+
+/**
+ * Structural type for an `@octokit/request` hook. Octokit types
+ * `request.hook` as `any`, so it is spelled out here to keep the capture below
+ * type-checked.
+ */
+type OctokitRequestHook = (
+  request: (options: unknown) => Promise<OctokitHttpResponse>,
+  options: unknown,
+) => Promise<OctokitHttpResponse>;
+
+/**
+ * Summarizes a value for an error message without dumping a whole response.
+ */
+function describePayload(payload: unknown): string {
+  if (payload === undefined) {
+    return "undefined";
+  }
+  if (payload === null) {
+    return "null";
+  }
+  if (typeof payload === "string") {
+    const preview = payload.slice(0, 200);
+    return `string(${JSON.stringify(preview)}${payload.length > 200 ? "…" : ""})`;
+  }
+  if (typeof payload !== "object") {
+    return `${typeof payload}(${String(payload)})`;
+  }
+  return `object with keys [${Object.keys(payload).join(", ")}]`;
+}
+
+/**
+ * Runs a GraphQL query and returns one top-level field of the response.
+ *
+ * `@octokit/graphql` resolves `response.data.data` and only throws when the
+ * body carries an `errors` array, so an HTTP 200 whose body is not a GraphQL
+ * envelope (an HTML error page, or JSON without a `data` key) resolves
+ * `undefined`. Dereferencing that directly turned a transient GitHub answer
+ * into a `TypeError` that killed the whole action step, so the shape is checked
+ * here and the request is retried: the same query has been observed to succeed
+ * minutes earlier in the same job.
+ *
+ * A present-but-null field is returned as-is; GraphQL nulls a field the token
+ * may not read, which is a stable "not found" answer rather than a broken
+ * response, and the caller reports it without burning retries.
+ */
+async function fetchGraphQLField<T>({
+  octokits,
+  query,
+  variables,
+  field,
+  queryDescription,
+}: {
+  octokits: Octokits;
+  query: string;
+  variables: Record<string, string | number>;
+  field: string;
+  queryDescription: string;
+}): Promise<T> {
+  return retryWithBackoff(async () => {
+    // The HTTP response is captured through a request hook because
+    // `@octokit/graphql` hands back only the `data` member, which leaves an
+    // unexpected body impossible to diagnose from the action log.
+    let httpStatus: number | undefined;
+    let httpContentType: string | undefined;
+    let httpBody: unknown;
+
+    const captureResponse: OctokitRequestHook = async (request, options) => {
+      const response = await request(options);
+      httpStatus = response.status;
+      httpContentType = String(response.headers["content-type"] ?? "");
+      httpBody = response.data;
+      return response;
+    };
+
+    const payload = await octokits.graphql<Record<string, unknown>>(query, {
+      ...variables,
+      request: { hook: captureResponse },
+    });
+
+    if (
+      payload === null ||
+      typeof payload !== "object" ||
+      !(field in payload)
+    ) {
+      throw new Error(
+        `${queryDescription} returned no "${field}" field ` +
+          `(GraphQL data: ${describePayload(payload)}; ` +
+          `HTTP ${httpStatus ?? "unknown"} ${httpContentType || "unknown content-type"}, ` +
+          `body: ${describePayload(httpBody)})`,
+      );
+    }
+
+    return payload[field] as T;
+  }, GRAPHQL_RETRY_OPTIONS);
+}
 
 /**
  * Fetches PR branch information needed for fill/review commands.
@@ -35,20 +152,25 @@ export async function fetchPRBranchData({
   prNumber: number;
 }): Promise<PRBranchData> {
   try {
-    const prResult = await octokits.graphql<PullRequestQueryResponse>(
-      PR_QUERY,
-      {
+    const repositoryResult = await fetchGraphQLField<
+      PullRequestQueryResponse["repository"]
+    >({
+      octokits,
+      query: PR_QUERY,
+      variables: {
         owner: repository.owner,
         repo: repository.repo,
         number: prNumber,
       },
-    );
+      field: "repository",
+      queryDescription: `PR query for ${repository.owner}/${repository.repo}#${prNumber}`,
+    });
 
-    if (!prResult.repository.pullRequest) {
+    const pullRequest = repositoryResult?.pullRequest;
+
+    if (!pullRequest) {
       throw new Error(`PR #${prNumber} not found`);
     }
-
-    const pullRequest = prResult.repository.pullRequest;
 
     return {
       baseRefName: pullRequest.baseRefName,
@@ -59,17 +181,13 @@ export async function fetchPRBranchData({
     };
   } catch (error) {
     console.error(`Failed to fetch PR branch data:`, error);
-    throw new Error(`Failed to fetch PR branch data for PR #${prNumber}`);
+    throw new Error(
+      `Failed to fetch PR branch data for PR #${prNumber}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
 }
-
-type RepoDefaultBranchQueryResponse = {
-  repository: {
-    defaultBranchRef: {
-      name: string;
-    } | null;
-  };
-};
 
 /**
  * Fetches the repository's default branch name.
@@ -83,25 +201,34 @@ export async function fetchRepoDefaultBranch({
   repository: { owner: string; repo: string };
 }): Promise<string> {
   try {
-    const result = await octokits.graphql<RepoDefaultBranchQueryResponse>(
-      REPO_DEFAULT_BRANCH_QUERY,
-      {
+    const repositoryResult = await fetchGraphQLField<
+      RepoDefaultBranchQueryResponse["repository"]
+    >({
+      octokits,
+      query: REPO_DEFAULT_BRANCH_QUERY,
+      variables: {
         owner: repository.owner,
         repo: repository.repo,
       },
-    );
+      field: "repository",
+      queryDescription: `Default branch query for ${repository.owner}/${repository.repo}`,
+    });
 
-    if (!result.repository.defaultBranchRef) {
+    const defaultBranchRef = repositoryResult?.defaultBranchRef;
+
+    if (!defaultBranchRef) {
       throw new Error(
         `Default branch not found for ${repository.owner}/${repository.repo}`,
       );
     }
 
-    return result.repository.defaultBranchRef.name;
+    return defaultBranchRef.name;
   } catch (error) {
     console.error(`Failed to fetch default branch:`, error);
     throw new Error(
-      `Failed to fetch default branch for ${repository.owner}/${repository.repo}`,
+      `Failed to fetch default branch for ${repository.owner}/${repository.repo}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     );
   }
 }

--- a/test/github/data/pr-fetcher.test.ts
+++ b/test/github/data/pr-fetcher.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { graphql } from "@octokit/graphql";
+import { Octokit } from "@octokit/rest";
+import type { Octokits } from "../../../src/github/api/client";
+import {
+  fetchPRBranchData,
+  fetchRepoDefaultBranch,
+} from "../../../src/github/data/pr-fetcher";
+
+type StubResponse = {
+  status?: number;
+  contentType?: string;
+  body: string;
+};
+
+/**
+ * Builds an Octokits whose GraphQL client talks to a stubbed fetch, so the real
+ * @octokit/graphql envelope handling stays under test.
+ */
+function createStubOctokits(responses: StubResponse[]): {
+  octokits: Octokits;
+  requestCount: () => number;
+} {
+  let calls = 0;
+
+  const stubFetch = async () => {
+    const response = responses[Math.min(calls, responses.length - 1)]!;
+    calls += 1;
+    return new Response(response.body, {
+      status: response.status ?? 200,
+      headers: {
+        "content-type": response.contentType ?? "application/json",
+      },
+    });
+  };
+
+  return {
+    octokits: {
+      rest: new Octokit({ auth: "stub-token" }),
+      graphql: graphql.defaults({
+        headers: { authorization: "token stub-token" },
+        request: { fetch: stubFetch },
+      }),
+    },
+    requestCount: () => calls,
+  };
+}
+
+function prEnvelope(pullRequest: Record<string, unknown> | null): StubResponse {
+  return { body: JSON.stringify({ data: { repository: { pullRequest } } }) };
+}
+
+const VALID_PR = {
+  title: "fix(frontend): stabilize session navigation",
+  body: "description",
+  baseRefName: "dev",
+  headRefName: "ross/app-1930-session-nav",
+  headRefOid: "abc123",
+};
+
+const REPOSITORY = { owner: "Factory-AI", repo: "factory-mono" };
+
+describe("pr-fetcher", () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("fetchPRBranchData", () => {
+    it("returns the branch data from a well formed response", async () => {
+      const { octokits, requestCount } = createStubOctokits([
+        prEnvelope(VALID_PR),
+      ]);
+
+      const result = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      });
+
+      expect(result).toEqual({
+        baseRefName: "dev",
+        headRefName: "ross/app-1930-session-nav",
+        headRefOid: "abc123",
+        title: "fix(frontend): stabilize session navigation",
+        body: "description",
+      });
+      expect(requestCount()).toBe(1);
+    });
+
+    it("defaults a null PR body to an empty string", async () => {
+      const { octokits } = createStubOctokits([
+        prEnvelope({ ...VALID_PR, body: null }),
+      ]);
+
+      const result = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      });
+
+      expect(result.body).toBe("");
+    });
+
+    it("reports the response instead of crashing when a 200 carries no GraphQL envelope", async () => {
+      const { octokits } = createStubOctokits([
+        {
+          contentType: "text/html",
+          body: "<html><body>unavailable</body></html>",
+        },
+      ]);
+
+      const error = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      // The crash signature this guards against: a TypeError from
+      // dereferencing `prResult.repository` on an undefined payload.
+      expect(error!.message).not.toContain("is not an object");
+      expect(error!.message).toContain(
+        'PR query for Factory-AI/factory-mono#19051 returned no "repository" field',
+      );
+      expect(error!.message).toContain("HTTP 200 text/html");
+      expect(error!.message).toContain("<html><body>unavailable</body>");
+      expect(error!.message).toContain(
+        "Failed to fetch PR branch data for PR #19051",
+      );
+    }, 15000);
+
+    it("reports the response when a 200 body is JSON without a data member", async () => {
+      const { octokits } = createStubOctokits([{ body: "{}" }]);
+
+      const error = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).not.toContain("is not an object");
+      expect(error!.message).toContain('returned no "repository" field');
+    }, 15000);
+
+    it("recovers when only the first attempt returns a malformed response", async () => {
+      const { octokits, requestCount } = createStubOctokits([
+        { contentType: "text/html", body: "<html>unavailable</html>" },
+        prEnvelope(VALID_PR),
+      ]);
+
+      const result = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      });
+
+      expect(result.headRefName).toBe("ross/app-1930-session-nav");
+      expect(requestCount()).toBe(2);
+    }, 15000);
+
+    it("does not retry a null repository, which is a stable answer", async () => {
+      const { octokits, requestCount } = createStubOctokits([
+        { body: JSON.stringify({ data: { repository: null } }) },
+      ]);
+
+      const error = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).not.toContain("is not an object");
+      expect(error!.message).toContain("PR #19051 not found");
+      expect(requestCount()).toBe(1);
+    });
+
+    it("does not retry a null pull request, which is a stable answer", async () => {
+      const { octokits, requestCount } = createStubOctokits([prEnvelope(null)]);
+
+      const error = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("PR #19051 not found");
+      expect(requestCount()).toBe(1);
+    });
+
+    it("surfaces GraphQL error messages returned alongside a null data member", async () => {
+      const { octokits } = createStubOctokits([
+        {
+          body: JSON.stringify({
+            data: null,
+            errors: [{ message: "Bad credentials" }],
+          }),
+        },
+      ]);
+
+      const error = await fetchPRBranchData({
+        octokits,
+        repository: REPOSITORY,
+        prNumber: 19051,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("Bad credentials");
+    }, 15000);
+  });
+
+  describe("fetchRepoDefaultBranch", () => {
+    it("returns the default branch name", async () => {
+      const { octokits } = createStubOctokits([
+        {
+          body: JSON.stringify({
+            data: { repository: { defaultBranchRef: { name: "dev" } } },
+          }),
+        },
+      ]);
+
+      await expect(
+        fetchRepoDefaultBranch({ octokits, repository: REPOSITORY }),
+      ).resolves.toBe("dev");
+    });
+
+    it("reports the response instead of crashing when a 200 carries no GraphQL envelope", async () => {
+      const { octokits } = createStubOctokits([
+        { contentType: "text/html", body: "<html>unavailable</html>" },
+      ]);
+
+      const error = await fetchRepoDefaultBranch({
+        octokits,
+        repository: REPOSITORY,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).not.toContain("is not an object");
+      expect(error!.message).toContain(
+        'Default branch query for Factory-AI/factory-mono returned no "repository" field',
+      );
+      expect(error!.message).toContain(
+        "Failed to fetch default branch for Factory-AI/factory-mono",
+      );
+    }, 15000);
+
+    it("does not retry a null repository, which is a stable answer", async () => {
+      const { octokits, requestCount } = createStubOctokits([
+        { body: JSON.stringify({ data: { repository: null } }) },
+      ]);
+
+      const error = await fetchRepoDefaultBranch({
+        octokits,
+        repository: REPOSITORY,
+      }).then(
+        () => undefined,
+        (caught: unknown) => caught as Error,
+      );
+
+      expect(error).toBeDefined();
+      expect(error!.message).toContain(
+        "Default branch not found for Factory-AI/factory-mono",
+      );
+      expect(requestCount()).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## What happened

`Droid Auto Review` run [32616161689](https://github.com/Factory-AI/factory-mono/actions/runs/32616161689) on [factory-mono#19051](https://github.com/Factory-AI/factory-mono/pull/19051) went red in the `Prepare validator` step:

```
Failed to fetch PR branch data: 42 |         repo: repository.repo,
...
47 |     if (!prResult.repository.pullRequest) {
              ^
TypeError: undefined is not an object (evaluating 'prResult.repository')
      at fetchPRBranchData (/home/runner/work/_actions/Factory-AI/droid-action/dev/src/github/data/pr-fetcher.ts:47:10)
```

Two details from that log correct the first reading of this failure:

- **The review was not skipped before it started.** `Pass 1 candidates validated: 1 comments found` printed 40 ms earlier, so pass 1 ran for 13 minutes and produced a finding. What the crash killed was `Run Droid Exec (validator)` — the pass that posts the comments. The finding was computed and thrown away.
- **It is transient, not a broken code path.** `fetchPRBranchData` had already succeeded in the same job at `03:46:11` with the same query and the same repository (`Checking out PR #19051 branch for diff computation...`). It failed at `04:00:20` on the second call. Auth was fine either way (`OIDC token successfully obtained` / `App token successfully obtained` immediately before the crash). 1 failure in 78 runs of the workflow over 08-22..08-23.

The check does not block merge, so #19051 merged 99 minutes later with the review check red and no review posted.

## Root cause

`@octokit/graphql` returns `response.data.data` and throws only when the body carries an `errors` array:

```js
return request(requestOptions).then((response) => {
  if (response.data.errors) { throw new GraphqlResponseError(...); }
  return response.data.data;
});
```

So an HTTP 200 whose body is **not** a GraphQL envelope — an HTML error page, or JSON with no `data` member — resolves `undefined`. `prResult.repository` then throws. The `TypeError` wording pins it precisely: a GraphQL error payload would have thrown `GraphqlResponseError` instead, and a nulled `repository` field would have read `null is not an object`. `prResult` itself was `undefined`, i.e. GitHub answered 200 with something that was not a GraphQL response.

The old `catch` also discarded the cause (`Failed to fetch PR branch data for PR #19051`), which is why the raw response never reached the log.

## Reproduction

Driving the real `@octokit/graphql` with a stubbed fetch that returns `200 text/html`, before the fix:

```
[html-200] graphql() resolved to: undefined
Failed to fetch PR branch data: 42 |         repo: repository.repo,
...
47 |     if (!prResult.repository.pullRequest) {
              ^
TypeError: undefined is not an object (evaluating 'prResult.repository')
      at fetchPRBranchData (src/github/data/pr-fetcher.ts:47:10)
```

Byte-for-byte the CI signature, including the interleaved source excerpt. After the fix the same input produces:

```
Failed to fetch PR branch data for PR #19051: PR query for Factory-AI/factory-mono#19051
returned no "repository" field (GraphQL data: undefined; HTTP 200 text/html,
body: string("<html><body>unavailable</body></html>"))
```

## The change

Both fetchers in `src/github/data/pr-fetcher.ts` now go through one `fetchGraphQLField` helper that:

1. **Checks the response shape before reading it** and fails with the payload instead of a `TypeError`.
2. **Retries the request** via `utils/retry.ts` (3 attempts, 1s/2s backoff), which is what actually keeps the check green — this repo's `AGENTS.md` already prescribes `utils/retry.ts` for GitHub API operations, and the same query demonstrably succeeded minutes earlier in the same job.
3. **Captures the HTTP status, content type and body** through a per-call `request.hook`, because `@octokit/graphql` hands back only the `data` member and otherwise the next occurrence would be just as undiagnosable as this one.

A present-but-null `repository` or `pullRequest` is a stable "not found" answer, so it is reported immediately and costs one request, not three. The wrapping errors now carry their cause.

**Scope.** `pr-fetcher.ts` was the only module dereferencing a GraphQL response without optional chaining (`rg '\.repository\.' src`); `src/mcp/github-pr-server.ts:405` already reads `threadLookupQuery?.repository?.pullRequest?...`. Both functions here are fixed, which covers every entry point that reads this query: `generate-review-prompt`, `review`, `review-validator`, `security-review`, `fill` and `security-scan`.

## Validation

- `bun test test/github/data/pr-fetcher.test.ts` — 11 pass / 0 fail (new file).
- `bun test` — 588 pass / 0 fail across 54 files.
- `bun run typecheck` — clean. `bun run format:check` — clean.
- **Mutation-checked**, per the repo's rule against tests that cannot fail. Each mutation was applied to the fix and the suite re-run:

  | Mutation | Result |
  | --- | --- |
  | baseline (fixed) | 11 pass / 0 fail |
  | restore the original unguarded `pr-fetcher.ts` | **8 fail** |
  | `maxAttempts: 3` -> `1` (no retry) | **1 fail** |
  | drop the captured HTTP body | **1 fail** |
  | drop the captured content type | **1 fail** |
  | retry the stable not-found answer | **2 fail** |
  | wrapper drops the cause (PR fetch) | **5 fail** |
  | wrapper drops the cause (default branch) | **2 fail** |
  | stop defaulting a null PR body to `""` | **1 fail** |

  Only the two happy-path tests survive reverting the fix, which is the intended shape.

---

[Workstream](https://app.factory.ai/software-factory/workstreams/can-you-monitor-linear-and-the) · [Change](https://app.factory.ai/software-factory/changes/2a92c804-520e-4c49-9184-ce275ab392d9)


Closes AUT-2291
