### PR TITLE
feat(review): tag tracking comments for classification

### DIFF
--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -172,7 +172,7 @@ async function run() {
       owner: context.repository.owner,
       repo: context.repository.repo,
       droidCommentId: commentId.toString(),
-      includePrReviewMarker: true,
+      prValidationSource: "review",
       allowedTools,
       mode: "tag",
       context,

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -172,6 +172,7 @@ async function run() {
       owner: context.repository.owner,
       repo: context.repository.repo,
       droidCommentId: commentId.toString(),
+      includePrReviewMarker: true,
       allowedTools,
       mode: "tag",
       context,

--- a/src/entrypoints/generate-review-prompt.ts
+++ b/src/entrypoints/generate-review-prompt.ts
@@ -18,11 +18,17 @@ import { normalizeDroidArgs, parseAllowedTools } from "../utils/parse-tools";
 import { resolveReviewConfig } from "../utils/review-depth";
 import { applyModelPolicyFallback } from "../utils/model-policy";
 import { retryWithBackoff } from "../utils/retry";
+import { DroidRunType, setDroidRunType } from "../run-type";
 
 async function run() {
   try {
     const githubToken = process.env.GITHUB_TOKEN!;
     const reviewType = process.env.REVIEW_TYPE || "code";
+    const runType =
+      reviewType === "security"
+        ? DroidRunType.SecurityReview
+        : DroidRunType.Review;
+    setDroidRunType(runType);
     const commentId = parseInt(process.env.DROID_COMMENT_ID || "0");
 
     if (!commentId) {
@@ -123,11 +129,6 @@ async function run() {
       includeSuggestions,
     });
 
-    // Set run type
-    const runType =
-      reviewType === "security" ? "droid-security-review" : "droid-review";
-    core.exportVariable("DROID_EXEC_RUN_TYPE", runType);
-
     const rawUserArgs = process.env.DROID_ARGS || "";
     const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
     const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
@@ -172,7 +173,7 @@ async function run() {
       owner: context.repository.owner,
       repo: context.repository.repo,
       droidCommentId: commentId.toString(),
-      prValidationSource: "review",
+      runType,
       allowedTools,
       mode: "tag",
       context,

--- a/src/entrypoints/github-post-review.ts
+++ b/src/entrypoints/github-post-review.ts
@@ -32,6 +32,10 @@ import {
   type GitHubReviewCommentPayload,
   type GitHubReviewCreateClient,
 } from "../github/operations/reviews";
+import {
+  parsePrValidationRunType,
+  type PrValidationRunType,
+} from "../run-type";
 
 export const MAX_GITHUB_REVIEW_COMMENTS = 30;
 export const MAX_GITHUB_REVIEW_BODY_BYTES = 60 * 1024;
@@ -207,6 +211,7 @@ async function createReview(
   comments: GitHubInlineComment[],
   fallback: FallbackFinding[],
   commitId: string | null,
+  runType?: PrValidationRunType,
 ): Promise<number | undefined> {
   return createGitHubCommentReview({
     client,
@@ -215,6 +220,7 @@ async function createReview(
     prNumber,
     comments,
     commitId,
+    runType,
     ...(fallback.length > 0 ? { body: fallbackReviewBody(fallback) } : {}),
   });
 }
@@ -236,6 +242,7 @@ export async function postGitHubReview(options: {
   comments: ValidatedReviewComment[];
   diff: string;
   commitId?: string | null;
+  runType?: PrValidationRunType;
 }): Promise<GitHubPostReviewResult> {
   const { client, owner, repo, prNumber, comments, diff } = options;
   const commitId = options.commitId ?? null;
@@ -268,6 +275,7 @@ export async function postGitHubReview(options: {
       prepared.inline,
       fallback.included,
       commitId,
+      options.runType,
     );
     result.posted = prepared.inline.length;
     result.fallbackPosted = fallback.included.length;
@@ -341,6 +349,7 @@ export async function run(
       comments: parsed.approved,
       diff,
       commitId: parsed.commitId,
+      runType: parsePrValidationRunType(process.env.DROID_EXEC_RUN_TYPE),
     });
   }
 

--- a/src/entrypoints/prepare-validator.ts
+++ b/src/entrypoints/prepare-validator.ts
@@ -6,6 +6,7 @@ import { setupGitHubToken } from "../github/token";
 import { createOctokit } from "../github/api/client";
 import { parseGitHubContext, isEntityContext } from "../github/context";
 import { prepareReviewValidatorMode } from "../tag/commands/review-validator";
+import { DroidRunType, setDroidRunType } from "../run-type";
 
 async function run() {
   try {
@@ -14,6 +15,8 @@ async function run() {
     if (!isEntityContext(context) || !context.isPR) {
       throw new Error("prepare-validator requires a pull request context");
     }
+    const runType = DroidRunType.Review;
+    setDroidRunType(runType);
 
     // Validate that Pass 1 produced a valid candidates JSON file.
     // If the file is missing or invalid, skip Pass 2 gracefully rather than
@@ -57,12 +60,12 @@ async function run() {
     if (!trackingCommentId || Number.isNaN(trackingCommentId)) {
       throw new Error("DROID_COMMENT_ID is required for validator run");
     }
-
     const result = await prepareReviewValidatorMode({
       context,
       octokit,
       githubToken,
       trackingCommentId,
+      runType,
     });
 
     core.setOutput("github_token", githubToken);

--- a/src/entrypoints/prepare-validator.ts
+++ b/src/entrypoints/prepare-validator.ts
@@ -6,7 +6,7 @@ import { setupGitHubToken } from "../github/token";
 import { createOctokit } from "../github/api/client";
 import { parseGitHubContext, isEntityContext } from "../github/context";
 import { prepareReviewValidatorMode } from "../tag/commands/review-validator";
-import { DroidRunType, setDroidRunType } from "../run-type";
+import { DroidRunType, parseDroidRunType, setDroidRunType } from "../run-type";
 
 async function run() {
   try {
@@ -15,7 +15,8 @@ async function run() {
     if (!isEntityContext(context) || !context.isPR) {
       throw new Error("prepare-validator requires a pull request context");
     }
-    const runType = DroidRunType.Review;
+    const runType =
+      parseDroidRunType(process.env.DROID_EXEC_RUN_TYPE) ?? DroidRunType.Review;
     setDroidRunType(runType);
 
     // Validate that Pass 1 produced a valid candidates JSON file.

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -16,6 +16,7 @@ import { GITHUB_SERVER_URL } from "../github/api/config";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
 import { fetchDroidComment } from "../github/operations/comments/fetch-droid-comment";
 import { readReviewPostOutcome } from "../core/review/tracking/results";
+import { parsePrValidationRunType } from "../run-type";
 
 export async function readReviewPostResults() {
   const filePath =
@@ -183,6 +184,10 @@ async function run() {
       notice: process.env.MODEL_FALLBACK_NOTE?.trim() || undefined,
       securityReviewRan: process.env.AUTOMATIC_SECURITY_REVIEW === "true",
       review,
+      prCommentRunType: parsePrValidationRunType(
+        process.env.DROID_EXEC_RUN_TYPE,
+      ),
+      prCommentKind: isPRReviewComment ? "inline-comment" : "issue-comment",
     };
 
     const updatedBody = updateCommentBody(commentInput);

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -1,5 +1,11 @@
 import { GITHUB_SERVER_URL } from "../api/config";
 import type { ReviewPostOutcome } from "../../core/review/tracking/types";
+import {
+  prepareDroidTrackingCommentBody,
+  readPrCommentRunType,
+  type PrCommentKind,
+  type PrCommentRunType,
+} from "./comments/common";
 
 export type ExecutionDetails = {
   cost_usd?: number;
@@ -20,6 +26,8 @@ export type CommentUpdateInput = {
   notice?: string;
   securityReviewRan?: boolean;
   review?: ReviewPostOutcome | null;
+  prCommentRunType?: PrCommentRunType;
+  prCommentKind?: PrCommentKind;
 };
 
 const MODEL_POLICY_ERROR_PATTERN =
@@ -303,5 +311,16 @@ export function updateCommentBody(input: CommentUpdateInput): string {
   // Add the cleaned body content
   newBody += bodyContent;
 
-  return newBody.trim();
+  if (
+    !input.prCommentRunType &&
+    !readPrCommentRunType(originalBody, input.prCommentKind ?? "issue-comment")
+  ) {
+    return newBody.trim();
+  }
+  return prepareDroidTrackingCommentBody(
+    newBody.trim(),
+    originalBody,
+    input.prCommentRunType,
+    input.prCommentKind,
+  );
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -1,4 +1,7 @@
 import { GITHUB_SERVER_URL } from "../../api/config";
+import { sanitizeContent } from "../../utils/sanitizer";
+
+export const DROID_PR_REVIEW_MARKER = "<!-- factory-pr-review -->";
 
 export function createJobRunLink(
   owner: string,
@@ -18,7 +21,36 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
-export type CommentType = "default" | "security" | "review_and_security";
+export type CommentType =
+  | "default"
+  | "review"
+  | "security"
+  | "security_scan"
+  | "review_and_security";
+
+function isReviewCommentType(type: CommentType): boolean {
+  return (
+    type === "review" || type === "security" || type === "review_and_security"
+  );
+}
+
+export function appendPrReviewMarker(content: string): string {
+  if (content.includes(DROID_PR_REVIEW_MARKER)) {
+    return content;
+  }
+  const trimmedContent = content.trimEnd();
+  return trimmedContent
+    ? `${trimmedContent}\n\n${DROID_PR_REVIEW_MARKER}`
+    : DROID_PR_REVIEW_MARKER;
+}
+
+export function prepareDroidCommentBody(
+  content: string,
+  includePrReviewMarker: boolean,
+): string {
+  const sanitized = sanitizeContent(content);
+  return includePrReviewMarker ? appendPrReviewMarker(sanitized) : sanitized;
+}
 
 export function createCommentBody(
   jobRunLink: string,
@@ -28,13 +60,15 @@ export function createCommentBody(
   let message: string;
   if (type === "review_and_security") {
     message = "Droid is reviewing code and running a security check…";
-  } else if (type === "security") {
+  } else if (type === "security" || type === "security_scan") {
     message = "Droid is running a security check…";
   } else {
     message = "Droid is working…";
   }
 
-  return `${message}
+  const body = `${message}
 
 ${jobRunLink}${branchLink}`;
+
+  return isReviewCommentType(type) ? appendPrReviewMarker(body) : body;
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -1,10 +1,9 @@
 import { GITHUB_SERVER_URL } from "../../api/config";
 import { sanitizeContent } from "../../utils/sanitizer";
+import type { PrValidationRunType } from "../../../run-type";
 
-export type PrValidationSource = "review";
-
-export function createPrValidationMarker(source: PrValidationSource): string {
-  return `<!-- factory-pr-validation: source=${source} -->`;
+export function createPrValidationMarker(runType: PrValidationRunType): string {
+  return `<!-- factory-pr-validation: run-type=${runType} -->`;
 }
 
 export function createJobRunLink(
@@ -29,9 +28,9 @@ export type CommentType = "default" | "security" | "review_and_security";
 
 export function appendPrValidationMarker(
   content: string,
-  source: PrValidationSource,
+  runType: PrValidationRunType,
 ): string {
-  const marker = createPrValidationMarker(source);
+  const marker = createPrValidationMarker(runType);
   if (content.includes(marker)) {
     return content;
   }
@@ -41,11 +40,11 @@ export function appendPrValidationMarker(
 
 export function prepareDroidCommentBody(
   content: string,
-  prValidationSource?: PrValidationSource,
+  prValidationRunType?: PrValidationRunType,
 ): string {
   const sanitized = sanitizeContent(content);
-  return prValidationSource
-    ? appendPrValidationMarker(sanitized, prValidationSource)
+  return prValidationRunType
+    ? appendPrValidationMarker(sanitized, prValidationRunType)
     : sanitized;
 }
 
@@ -53,7 +52,7 @@ export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
   type: CommentType = "default",
-  prValidationSource?: PrValidationSource,
+  prValidationRunType?: PrValidationRunType,
 ): string {
   let message: string;
   if (type === "review_and_security") {
@@ -68,7 +67,7 @@ export function createCommentBody(
 
 ${jobRunLink}${branchLink}`;
 
-  return prValidationSource
-    ? appendPrValidationMarker(body, prValidationSource)
+  return prValidationRunType
+    ? appendPrValidationMarker(body, prValidationRunType)
     : body;
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -1,7 +1,11 @@
 import { GITHUB_SERVER_URL } from "../../api/config";
 import { sanitizeContent } from "../../utils/sanitizer";
 
-export const DROID_PR_REVIEW_MARKER = "<!-- factory-pr-review -->";
+export type PrValidationSource = "review";
+
+export function createPrValidationMarker(source: PrValidationSource): string {
+  return `<!-- factory-pr-validation: source=${source} -->`;
+}
 
 export function createJobRunLink(
   owner: string,
@@ -28,28 +32,36 @@ export type CommentType =
   | "security_scan"
   | "review_and_security";
 
-function isReviewCommentType(type: CommentType): boolean {
-  return (
-    type === "review" || type === "security" || type === "review_and_security"
-  );
+function getPrValidationSource(
+  type: CommentType,
+): PrValidationSource | undefined {
+  return type === "review" ||
+    type === "security" ||
+    type === "review_and_security"
+    ? "review"
+    : undefined;
 }
 
-export function appendPrReviewMarker(content: string): string {
-  if (content.includes(DROID_PR_REVIEW_MARKER)) {
+export function appendPrValidationMarker(
+  content: string,
+  source: PrValidationSource,
+): string {
+  const marker = createPrValidationMarker(source);
+  if (content.includes(marker)) {
     return content;
   }
   const trimmedContent = content.trimEnd();
-  return trimmedContent
-    ? `${trimmedContent}\n\n${DROID_PR_REVIEW_MARKER}`
-    : DROID_PR_REVIEW_MARKER;
+  return trimmedContent ? `${trimmedContent}\n\n${marker}` : marker;
 }
 
 export function prepareDroidCommentBody(
   content: string,
-  includePrReviewMarker: boolean,
+  prValidationSource?: PrValidationSource,
 ): string {
   const sanitized = sanitizeContent(content);
-  return includePrReviewMarker ? appendPrReviewMarker(sanitized) : sanitized;
+  return prValidationSource
+    ? appendPrValidationMarker(sanitized, prValidationSource)
+    : sanitized;
 }
 
 export function createCommentBody(
@@ -70,5 +82,6 @@ export function createCommentBody(
 
 ${jobRunLink}${branchLink}`;
 
-  return isReviewCommentType(type) ? appendPrReviewMarker(body) : body;
+  const source = getPrValidationSource(type);
+  return source ? appendPrValidationMarker(body, source) : body;
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -25,22 +25,7 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
-export type CommentType =
-  | "default"
-  | "review"
-  | "security"
-  | "security_scan"
-  | "review_and_security";
-
-function getPrValidationSource(
-  type: CommentType,
-): PrValidationSource | undefined {
-  return type === "review" ||
-    type === "security" ||
-    type === "review_and_security"
-    ? "review"
-    : undefined;
-}
+export type CommentType = "default" | "security" | "review_and_security";
 
 export function appendPrValidationMarker(
   content: string,
@@ -68,11 +53,12 @@ export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
   type: CommentType = "default",
+  prValidationSource?: PrValidationSource,
 ): string {
   let message: string;
   if (type === "review_and_security") {
     message = "Droid is reviewing code and running a security check…";
-  } else if (type === "security" || type === "security_scan") {
+  } else if (type === "security") {
     message = "Droid is running a security check…";
   } else {
     message = "Droid is working…";
@@ -82,6 +68,7 @@ export function createCommentBody(
 
 ${jobRunLink}${branchLink}`;
 
-  const source = getPrValidationSource(type);
-  return source ? appendPrValidationMarker(body, source) : body;
+  return prValidationSource
+    ? appendPrValidationMarker(body, prValidationSource)
+    : body;
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -2,8 +2,21 @@ import { GITHUB_SERVER_URL } from "../../api/config";
 import { sanitizeContent } from "../../utils/sanitizer";
 import type { PrValidationRunType } from "../../../run-type";
 
-export function createPrValidationMarker(runType: PrValidationRunType): string {
-  return `<!-- factory-pr-validation: run-type=${runType} -->`;
+export type PrCommentKind = "issue-comment" | "inline-comment";
+
+export function parsePrCommentKind(
+  value: string | undefined,
+): PrCommentKind | undefined {
+  return value === "issue-comment" || value === "inline-comment"
+    ? value
+    : undefined;
+}
+
+export function createPrCommentMarker(
+  kind: PrCommentKind,
+  runType: PrValidationRunType,
+): string {
+  return `<!-- factory-pr-${kind}: run-type=${runType} -->`;
 }
 
 export function createJobRunLink(
@@ -26,11 +39,12 @@ export function createBranchLink(
 
 export type CommentType = "default" | "security" | "review_and_security";
 
-export function appendPrValidationMarker(
+export function appendPrCommentMarker(
   content: string,
+  kind: PrCommentKind,
   runType: PrValidationRunType,
 ): string {
-  const marker = createPrValidationMarker(runType);
+  const marker = createPrCommentMarker(kind, runType);
   if (content.includes(marker)) {
     return content;
   }
@@ -41,10 +55,11 @@ export function appendPrValidationMarker(
 export function prepareDroidCommentBody(
   content: string,
   prValidationRunType?: PrValidationRunType,
+  kind: PrCommentKind = "issue-comment",
 ): string {
   const sanitized = sanitizeContent(content);
   return prValidationRunType
-    ? appendPrValidationMarker(sanitized, prValidationRunType)
+    ? appendPrCommentMarker(sanitized, kind, prValidationRunType)
     : sanitized;
 }
 
@@ -53,6 +68,7 @@ export function createCommentBody(
   branchLink: string = "",
   type: CommentType = "default",
   prValidationRunType?: PrValidationRunType,
+  kind: PrCommentKind = "issue-comment",
 ): string {
   let message: string;
   if (type === "review_and_security") {
@@ -68,6 +84,6 @@ export function createCommentBody(
 ${jobRunLink}${branchLink}`;
 
   return prValidationRunType
-    ? appendPrValidationMarker(body, prValidationRunType)
+    ? appendPrCommentMarker(body, kind, prValidationRunType)
     : body;
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -1,8 +1,52 @@
 import { GITHUB_SERVER_URL } from "../../api/config";
 import { sanitizeContent } from "../../utils/sanitizer";
-import type { PrValidationRunType } from "../../../run-type";
+import {
+  DroidRunType,
+  parsePrValidationRunType,
+  type PrValidationRunType,
+} from "../../../run-type";
 
 export type PrCommentKind = "issue-comment" | "inline-comment";
+
+// A shared tracking comment can cover more than one execution.
+export const COMBINED_REVIEW_COMMENT_RUN_TYPE = "droid-review-and-security";
+export type PrCommentRunType =
+  | PrValidationRunType
+  | typeof COMBINED_REVIEW_COMMENT_RUN_TYPE;
+
+export function mergePrCommentRunTypes(
+  existing: PrCommentRunType | undefined,
+  current: PrCommentRunType | undefined,
+): PrCommentRunType | undefined {
+  if (
+    existing === COMBINED_REVIEW_COMMENT_RUN_TYPE ||
+    current === COMBINED_REVIEW_COMMENT_RUN_TYPE
+  ) {
+    return COMBINED_REVIEW_COMMENT_RUN_TYPE;
+  }
+  const isCodeReview = (value: PrCommentRunType | undefined) =>
+    value === DroidRunType.Review || value === DroidRunType.Default;
+  if (
+    (isCodeReview(existing) && current === DroidRunType.SecurityReview) ||
+    (existing === DroidRunType.SecurityReview && isCodeReview(current))
+  ) {
+    return COMBINED_REVIEW_COMMENT_RUN_TYPE;
+  }
+  return current ?? existing;
+}
+
+export function readPrCommentRunType(
+  body: string,
+  kind: PrCommentKind,
+): PrCommentRunType | undefined {
+  const match = body.match(
+    new RegExp(`(?:^|\\n)<!-- factory-pr-${kind}: run-type=([a-z-]+) -->\\s*$`),
+  );
+  const value = match?.[1];
+  return value === COMBINED_REVIEW_COMMENT_RUN_TYPE
+    ? value
+    : parsePrValidationRunType(value);
+}
 
 export function parsePrCommentKind(
   value: string | undefined,
@@ -14,7 +58,7 @@ export function parsePrCommentKind(
 
 export function createPrCommentMarker(
   kind: PrCommentKind,
-  runType: PrValidationRunType,
+  runType: PrCommentRunType,
 ): string {
   return `<!-- factory-pr-${kind}: run-type=${runType} -->`;
 }
@@ -42,7 +86,7 @@ export type CommentType = "default" | "security" | "review_and_security";
 export function appendPrCommentMarker(
   content: string,
   kind: PrCommentKind,
-  runType: PrValidationRunType,
+  runType: PrCommentRunType,
 ): string {
   const marker = createPrCommentMarker(kind, runType);
   if (content.includes(marker)) {
@@ -54,13 +98,28 @@ export function appendPrCommentMarker(
 
 export function prepareDroidCommentBody(
   content: string,
-  prValidationRunType?: PrValidationRunType,
+  prValidationRunType?: PrCommentRunType,
   kind: PrCommentKind = "issue-comment",
 ): string {
   const sanitized = sanitizeContent(content);
   return prValidationRunType
     ? appendPrCommentMarker(sanitized, kind, prValidationRunType)
     : sanitized;
+}
+
+export function prepareDroidTrackingCommentBody(
+  content: string,
+  currentBody: string,
+  runType?: PrCommentRunType,
+  kind: PrCommentKind = "issue-comment",
+): string {
+  // Only the stored tracking comment contributes prior classification, never
+  // markers in the model-provided replacement body.
+  const mergedRunType = mergePrCommentRunTypes(
+    readPrCommentRunType(currentBody, kind),
+    runType,
+  );
+  return prepareDroidCommentBody(content, mergedRunType, kind);
 }
 
 export function createCommentBody(
@@ -84,6 +143,12 @@ export function createCommentBody(
 ${jobRunLink}${branchLink}`;
 
   return prValidationRunType
-    ? appendPrCommentMarker(body, kind, prValidationRunType)
+    ? appendPrCommentMarker(
+        body,
+        kind,
+        type === "review_and_security"
+          ? COMBINED_REVIEW_COMMENT_RUN_TYPE
+          : prValidationRunType,
+      )
     : body;
 }

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -17,10 +17,7 @@ import {
   type ParsedGitHubContext,
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
-import {
-  prValidationSourceForRunType,
-  type DroidRunType,
-} from "../../../run-type";
+import { getPrValidationRunType, type DroidRunType } from "../../../run-type";
 
 const DROID_APP_BOT_ID = 209825114;
 
@@ -37,7 +34,7 @@ export async function createInitialComment(
     jobRunLink,
     "",
     commentType,
-    prValidationSourceForRunType(runType),
+    getPrValidationRunType(runType),
   );
 
   try {

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -25,7 +25,7 @@ export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
   commentType: CommentType = "default",
-  runType?: DroidRunType,
+  runType?: DroidRunType | null,
 ) {
   const { owner, repo } = context.repository;
 

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -17,6 +17,10 @@ import {
   type ParsedGitHubContext,
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
+import {
+  prValidationSourceForRunType,
+  type DroidRunType,
+} from "../../../run-type";
 
 const DROID_APP_BOT_ID = 209825114;
 
@@ -24,11 +28,17 @@ export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
   commentType: CommentType = "default",
+  runType?: DroidRunType,
 ) {
   const { owner, repo } = context.repository;
 
   const jobRunLink = createJobRunLink(owner, repo, context.runId);
-  const initialBody = createCommentBody(jobRunLink, "", commentType);
+  const initialBody = createCommentBody(
+    jobRunLink,
+    "",
+    commentType,
+    prValidationSourceForRunType(runType),
+  );
 
   try {
     let response;

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -10,6 +10,7 @@ import {
   createJobRunLink,
   createCommentBody,
   type CommentType,
+  type PrCommentKind,
 } from "./common";
 import {
   isPullRequestReviewCommentEvent,
@@ -18,6 +19,7 @@ import {
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
 import { getPrValidationRunType, type DroidRunType } from "../../../run-type";
+import * as core from "@actions/core";
 
 const DROID_APP_BOT_ID = 209825114;
 
@@ -30,15 +32,14 @@ export async function createInitialComment(
   const { owner, repo } = context.repository;
 
   const jobRunLink = createJobRunLink(owner, repo, context.runId);
-  const initialBody = createCommentBody(
-    jobRunLink,
-    "",
-    commentType,
-    getPrValidationRunType(runType),
-  );
+  const prValidationRunType = getPrValidationRunType(runType);
+  const createInitialBody = (kind: PrCommentKind) =>
+    createCommentBody(jobRunLink, "", commentType, prValidationRunType, kind);
+  const issueCommentBody = createInitialBody("issue-comment");
 
   try {
     let response;
+    let createdCommentKind: PrCommentKind = "issue-comment";
 
     if (
       context.inputs.useStickyComment &&
@@ -55,7 +56,7 @@ export async function createInitialComment(
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("droid");
-        const bodyMatch = comment.body === initialBody;
+        const bodyMatch = comment.body === issueCommentBody;
 
         return idMatch || botNameMatch || bodyMatch;
       });
@@ -64,7 +65,7 @@ export async function createInitialComment(
           owner,
           repo,
           comment_id: existingComment.id,
-          body: initialBody,
+          body: issueCommentBody,
         });
       } else {
         // Create new comment if no existing one found
@@ -72,7 +73,7 @@ export async function createInitialComment(
           owner,
           repo,
           issue_number: context.entityNumber,
-          body: initialBody,
+          body: issueCommentBody,
         });
       }
     } else if (isPullRequestReviewCommentEvent(context)) {
@@ -82,21 +83,23 @@ export async function createInitialComment(
         repo,
         pull_number: context.entityNumber,
         comment_id: context.payload.comment.id,
-        body: initialBody,
+        body: createInitialBody("inline-comment"),
       });
+      createdCommentKind = "inline-comment";
     } else {
       // For all other cases (issues, issue comments, or missing comment_id)
       response = await octokit.rest.issues.createComment({
         owner,
         repo,
         issue_number: context.entityNumber,
-        body: initialBody,
+        body: issueCommentBody,
       });
     }
 
     // Output the comment ID for downstream steps using GITHUB_OUTPUT
     const githubOutput = process.env.GITHUB_OUTPUT!;
     appendFileSync(githubOutput, `droid_comment_id=${response.data.id}\n`);
+    core.exportVariable("DROID_PR_COMMENT_KIND", createdCommentKind);
     console.log(`✅ Created initial comment with ID: ${response.data.id}`);
     return response.data;
   } catch (error) {
@@ -108,11 +111,12 @@ export async function createInitialComment(
         owner,
         repo,
         issue_number: context.entityNumber,
-        body: initialBody,
+        body: issueCommentBody,
       });
 
       const githubOutput = process.env.GITHUB_OUTPUT!;
       appendFileSync(githubOutput, `droid_comment_id=${response.data.id}\n`);
+      core.exportVariable("DROID_PR_COMMENT_KIND", "issue-comment");
       console.log(`✅ Created fallback comment with ID: ${response.data.id}`);
       return response.data;
     } catch (fallbackError) {

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -9,6 +9,8 @@ import { appendFileSync } from "fs";
 import {
   createJobRunLink,
   createCommentBody,
+  prepareDroidTrackingCommentBody,
+  readPrCommentRunType,
   type CommentType,
   type PrCommentKind,
 } from "./common";
@@ -35,7 +37,7 @@ export async function createInitialComment(
   const prValidationRunType = getPrValidationRunType(runType);
   const createInitialBody = (kind: PrCommentKind) =>
     createCommentBody(jobRunLink, "", commentType, prValidationRunType, kind);
-  const issueCommentBody = createInitialBody("issue-comment");
+  let issueCommentBody = createInitialBody("issue-comment");
 
   try {
     let response;
@@ -61,6 +63,11 @@ export async function createInitialComment(
         return idMatch || botNameMatch || bodyMatch;
       });
       if (existingComment) {
+        issueCommentBody = prepareDroidTrackingCommentBody(
+          issueCommentBody,
+          existingComment.body ?? "",
+          readPrCommentRunType(issueCommentBody, "issue-comment"),
+        );
         response = await octokit.rest.issues.updateComment({
           owner,
           repo,

--- a/src/github/operations/comments/update-tracking-comment.ts
+++ b/src/github/operations/comments/update-tracking-comment.ts
@@ -1,0 +1,35 @@
+import type { Octokits } from "../../api/client";
+import { fetchDroidComment } from "./fetch-droid-comment";
+import {
+  prepareDroidTrackingCommentBody,
+  type PrCommentRunType,
+} from "./common";
+import {
+  updateDroidComment,
+  type UpdateDroidCommentParams,
+} from "./update-droid-comment";
+
+export async function updateDroidTrackingComment(
+  octokit: Octokits,
+  params: UpdateDroidCommentParams & { runType?: PrCommentRunType },
+) {
+  // A failed read must not fall through to a write that could erase the
+  // shared comment's existing classification.
+  const { comment, isPRReviewComment } = await fetchDroidComment(octokit, {
+    owner: params.owner,
+    repo: params.repo,
+    commentId: params.commentId,
+    isPullRequestReviewCommentEvent: params.isPullRequestReviewComment,
+  });
+  const kind = isPRReviewComment ? "inline-comment" : "issue-comment";
+  return updateDroidComment(octokit.rest, {
+    ...params,
+    body: prepareDroidTrackingCommentBody(
+      params.body,
+      comment.body ?? "",
+      params.runType,
+      kind,
+    ),
+    isPullRequestReviewComment: isPRReviewComment,
+  });
+}

--- a/src/github/operations/reviews.ts
+++ b/src/github/operations/reviews.ts
@@ -1,3 +1,6 @@
+import { prepareDroidCommentBody } from "./comments/common";
+import type { PrValidationRunType } from "../../run-type";
+
 export type GitHubReviewCommentPayload = {
   path: string;
   body: string;
@@ -32,8 +35,16 @@ export async function createGitHubCommentReview(options: {
   body?: string;
   comments?: GitHubReviewCommentPayload[];
   commitId?: string | null;
+  runType?: PrValidationRunType;
 }): Promise<number | undefined> {
-  const { client, owner, repo, prNumber, body, comments, commitId } = options;
+  const { client, owner, repo, prNumber, body, comments, commitId, runType } =
+    options;
+  const preparedComments = runType
+    ? comments?.map((comment) => ({
+        ...comment,
+        body: prepareDroidCommentBody(comment.body, runType, "inline-comment"),
+      }))
+    : comments;
   const response = await client.rest.pulls.createReview({
     owner,
     repo,
@@ -41,7 +52,9 @@ export async function createGitHubCommentReview(options: {
     event: "COMMENT",
     ...(commitId ? { commit_id: commitId } : {}),
     ...(body ? { body } : {}),
-    ...(comments && comments.length > 0 ? { comments } : {}),
+    ...(preparedComments && preparedComments.length > 0
+      ? { comments: preparedComments }
+      : {}),
   });
   return response.data.id;
 }

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { prepareDroidCommentBody } from "../github/operations/comments/common";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -55,7 +55,10 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      let sanitizedBody = sanitizeContent(body);
+      let sanitizedBody = prepareDroidCommentBody(
+        body,
+        process.env.DROID_PR_REVIEW_MARKER === "true",
+      );
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.
       // Droid replaces the whole body, so carry the marker forward or every

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,7 +6,10 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
-import { prepareDroidCommentBody } from "../github/operations/comments/common";
+import {
+  prepareDroidCommentBody,
+  type PrValidationSource,
+} from "../github/operations/comments/common";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -55,10 +58,11 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      let sanitizedBody = prepareDroidCommentBody(
-        body,
-        process.env.DROID_PR_REVIEW_MARKER === "true",
-      );
+      const prValidationSource: PrValidationSource | undefined =
+        process.env.DROID_PR_VALIDATION_SOURCE === "review"
+          ? "review"
+          : undefined;
+      let sanitizedBody = prepareDroidCommentBody(body, prValidationSource);
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.
       // Droid replaces the whole body, so carry the marker forward or every

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -7,7 +7,7 @@ import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
 import { prepareDroidCommentBody } from "../github/operations/comments/common";
-import { parseDroidRunType, prValidationSourceForRunType } from "../run-type";
+import { getPrValidationRunType, parseDroidRunType } from "../run-type";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -59,7 +59,7 @@ server.tool(
       const runType = parseDroidRunType(process.env.DROID_EXEC_RUN_TYPE);
       let sanitizedBody = prepareDroidCommentBody(
         body,
-        prValidationSourceForRunType(runType),
+        getPrValidationRunType(runType),
       );
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,10 +6,8 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
-import {
-  prepareDroidCommentBody,
-  type PrValidationSource,
-} from "../github/operations/comments/common";
+import { prepareDroidCommentBody } from "../github/operations/comments/common";
+import { parseDroidRunType, prValidationSourceForRunType } from "../run-type";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -58,11 +56,11 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      const prValidationSource: PrValidationSource | undefined =
-        process.env.DROID_PR_VALIDATION_SOURCE === "review"
-          ? "review"
-          : undefined;
-      let sanitizedBody = prepareDroidCommentBody(body, prValidationSource);
+      const runType = parseDroidRunType(process.env.DROID_EXEC_RUN_TYPE);
+      let sanitizedBody = prepareDroidCommentBody(
+        body,
+        prValidationSourceForRunType(runType),
+      );
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.
       // Droid replaces the whole body, so carry the marker forward or every

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,8 +6,11 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
-import { prepareDroidCommentBody } from "../github/operations/comments/common";
-import { getPrValidationRunType, parseDroidRunType } from "../run-type";
+import {
+  parsePrCommentKind,
+  prepareDroidCommentBody,
+} from "../github/operations/comments/common";
+import { parsePrValidationRunType } from "../run-type";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -56,11 +59,11 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      const runType = parseDroidRunType(process.env.DROID_EXEC_RUN_TYPE);
-      let sanitizedBody = prepareDroidCommentBody(
-        body,
-        getPrValidationRunType(runType),
-      );
+      const runType = parsePrValidationRunType(process.env.DROID_EXEC_RUN_TYPE);
+      const commentKind =
+        parsePrCommentKind(process.env.DROID_PR_COMMENT_KIND) ??
+        (isPullRequestReviewComment ? "inline-comment" : "issue-comment");
+      let sanitizedBody = prepareDroidCommentBody(body, runType, commentKind);
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.
       // Droid replaces the whole body, so carry the marker forward or every

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -3,14 +3,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { GITHUB_API_URL } from "../github/api/config";
-import { Octokit } from "@octokit/rest";
+import { createOctokit } from "../github/api/client";
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
+import { updateDroidTrackingComment } from "../github/operations/comments/update-tracking-comment";
 import {
   parsePrCommentKind,
   prepareDroidCommentBody,
 } from "../github/operations/comments/common";
-import { parsePrValidationRunType } from "../run-type";
+import { DroidRunType, parsePrValidationRunType } from "../run-type";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -51,10 +51,7 @@ server.tool(
       const repo = REPO_NAME;
       const commentId = parseInt(droidCommentId, 10);
 
-      const octokit = new Octokit({
-        auth: githubToken,
-        baseUrl: GITHUB_API_URL,
-      });
+      const octokit = createOctokit(githubToken);
 
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
@@ -63,7 +60,9 @@ server.tool(
       const commentKind =
         parsePrCommentKind(process.env.DROID_PR_COMMENT_KIND) ??
         (isPullRequestReviewComment ? "inline-comment" : "issue-comment");
-      let sanitizedBody = prepareDroidCommentBody(body, runType, commentKind);
+      const isSteward =
+        process.env.DROID_EXEC_RUN_TYPE === DroidRunType.CiSteward;
+      let sanitizedBody = isSteward ? prepareDroidCommentBody(body) : body;
 
       // CI Steward keeps its lifetime run budget in a marker on this comment.
       // Droid replaces the whole body, so carry the marker forward or every
@@ -84,13 +83,16 @@ server.tool(
         sanitizedBody = `${sanitizedBody}\n\n<!-- ci-steward:run=${stewardRunId} count=${stewardRunCount} sha=${stewardRunSha} -->`;
       }
 
-      const result = await updateDroidComment(octokit, {
+      const params = {
         owner,
         repo,
         commentId,
         body: sanitizedBody,
-        isPullRequestReviewComment,
-      });
+        isPullRequestReviewComment: commentKind === "inline-comment",
+      };
+      const result = isSteward
+        ? await updateDroidComment(octokit.rest, params)
+        : await updateDroidTrackingComment(octokit, { ...params, runType });
 
       return {
         content: [

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -3,7 +3,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { createOctokit } from "../github/api/client";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { prepareDroidCommentBody } from "../github/operations/comments/common";
+import { parsePrValidationRunType } from "../run-type";
 
 // Get repository and PR information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -84,8 +85,12 @@ server.tool(
 
       const octokit = createOctokit(githubToken).rest;
 
-      // Sanitize the comment body to remove any potential GitHub tokens
-      const sanitizedBody = sanitizeContent(body);
+      const runType = parsePrValidationRunType(process.env.DROID_EXEC_RUN_TYPE);
+      const sanitizedBody = prepareDroidCommentBody(
+        body,
+        runType,
+        "inline-comment",
+      );
 
       // Validate that either line or both startLine and line are provided
       if (!line && !startLine) {

--- a/src/mcp/github-pr-server.ts
+++ b/src/mcp/github-pr-server.ts
@@ -9,6 +9,10 @@ import {
   createGitHubCommentReview,
   type GitHubReviewCommentPayload,
 } from "../github/operations/reviews";
+import {
+  parsePrValidationRunType,
+  type PrValidationRunType,
+} from "../run-type";
 
 const PLACEHOLDER_REGEX = /@droid\s+fill(?:\s+description)?/gi;
 const PLACEHOLDER_LINE_REGEX =
@@ -322,6 +326,7 @@ export async function handleSubmitReview({
   prNumber,
   body,
   comments,
+  runType,
   octokit,
   guard,
 }: {
@@ -330,6 +335,7 @@ export async function handleSubmitReview({
   prNumber: number;
   body?: string;
   comments?: ReviewComment[];
+  runType?: PrValidationRunType;
   octokit: OctokitLike;
   guard: SubmitReviewGuard;
 }): Promise<SubmitReviewOutcome> {
@@ -358,6 +364,7 @@ export async function handleSubmitReview({
       prNumber,
       body,
       comments,
+      runType,
       octokit,
     });
   } catch (error) {
@@ -380,6 +387,7 @@ export async function submitReviewWithComments({
   prNumber,
   body,
   comments,
+  runType,
   octokit,
 }: {
   owner: string;
@@ -387,6 +395,7 @@ export async function submitReviewWithComments({
   prNumber: number;
   body?: string;
   comments?: ReviewComment[];
+  runType?: PrValidationRunType;
   octokit: OctokitLike;
 }): Promise<number | undefined> {
   return createGitHubCommentReview({
@@ -396,6 +405,7 @@ export async function submitReviewWithComments({
     prNumber,
     body,
     comments,
+    runType,
   });
 }
 
@@ -846,12 +856,16 @@ export function createGitHubPRServer({
     },
     async ({ pr_number, body, comments }) => {
       try {
+        const runType = parsePrValidationRunType(
+          process.env.DROID_EXEC_RUN_TYPE,
+        );
         const outcome = await handleSubmitReview({
           owner,
           repo,
           prNumber: pr_number,
           body,
           comments,
+          runType,
           octokit,
           guard: submitReviewGuard,
         });

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { GitHubContext } from "../github/context";
 import { isEntityContext } from "../github/context";
+import type { PrValidationSource } from "../github/operations/comments/common";
 import { Octokit } from "@octokit/rest";
 
 type PrepareConfigParams = {
@@ -11,7 +12,7 @@ type PrepareConfigParams = {
   owner: string;
   repo: string;
   droidCommentId?: string;
-  includePrReviewMarker?: boolean;
+  prValidationSource?: PrValidationSource;
   allowedTools: string[];
   mode: "tag";
   context: GitHubContext;
@@ -57,7 +58,7 @@ export async function prepareMcpTools(
     owner,
     repo,
     droidCommentId,
-    includePrReviewMarker,
+    prValidationSource,
     allowedTools,
     context,
     mode: _mode,
@@ -110,8 +111,8 @@ export async function prepareMcpTools(
         REPO_OWNER: owner,
         REPO_NAME: repo,
         ...(droidCommentId && { DROID_COMMENT_ID: droidCommentId }),
-        ...(includePrReviewMarker && {
-          DROID_PR_REVIEW_MARKER: "true",
+        ...(prValidationSource && {
+          DROID_PR_VALIDATION_SOURCE: prValidationSource,
         }),
         ...(stewardPrNumber && { STEWARD_PR_NUMBER: stewardPrNumber }),
         ...(process.env.STEWARD_RUN_ID && {

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -11,6 +11,7 @@ type PrepareConfigParams = {
   owner: string;
   repo: string;
   droidCommentId?: string;
+  includePrReviewMarker?: boolean;
   allowedTools: string[];
   mode: "tag";
   context: GitHubContext;
@@ -56,6 +57,7 @@ export async function prepareMcpTools(
     owner,
     repo,
     droidCommentId,
+    includePrReviewMarker,
     allowedTools,
     context,
     mode: _mode,
@@ -108,6 +110,9 @@ export async function prepareMcpTools(
         REPO_OWNER: owner,
         REPO_NAME: repo,
         ...(droidCommentId && { DROID_COMMENT_ID: droidCommentId }),
+        ...(includePrReviewMarker && {
+          DROID_PR_REVIEW_MARKER: "true",
+        }),
         ...(stewardPrNumber && { STEWARD_PR_NUMBER: stewardPrNumber }),
         ...(process.env.STEWARD_RUN_ID && {
           STEWARD_RUN_ID: process.env.STEWARD_RUN_ID,

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { GitHubContext } from "../github/context";
 import { isEntityContext } from "../github/context";
-import type { PrValidationSource } from "../github/operations/comments/common";
+import type { DroidRunType } from "../run-type";
 import { Octokit } from "@octokit/rest";
 
 type PrepareConfigParams = {
@@ -12,7 +12,7 @@ type PrepareConfigParams = {
   owner: string;
   repo: string;
   droidCommentId?: string;
-  prValidationSource?: PrValidationSource;
+  runType: DroidRunType;
   allowedTools: string[];
   mode: "tag";
   context: GitHubContext;
@@ -58,7 +58,7 @@ export async function prepareMcpTools(
     owner,
     repo,
     droidCommentId,
-    prValidationSource,
+    runType,
     allowedTools,
     context,
     mode: _mode,
@@ -111,9 +111,7 @@ export async function prepareMcpTools(
         REPO_OWNER: owner,
         REPO_NAME: repo,
         ...(droidCommentId && { DROID_COMMENT_ID: droidCommentId }),
-        ...(prValidationSource && {
-          DROID_PR_VALIDATION_SOURCE: prValidationSource,
-        }),
+        DROID_EXEC_RUN_TYPE: runType,
         ...(stewardPrNumber && { STEWARD_PR_NUMBER: stewardPrNumber }),
         ...(process.env.STEWARD_RUN_ID && {
           STEWARD_RUN_ID: process.env.STEWARD_RUN_ID,

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -12,7 +12,7 @@ type PrepareConfigParams = {
   owner: string;
   repo: string;
   droidCommentId?: string;
-  runType: DroidRunType;
+  runType: DroidRunType | null;
   allowedTools: string[];
   mode: "tag";
   context: GitHubContext;
@@ -111,7 +111,7 @@ export async function prepareMcpTools(
         REPO_OWNER: owner,
         REPO_NAME: repo,
         ...(droidCommentId && { DROID_COMMENT_ID: droidCommentId }),
-        DROID_EXEC_RUN_TYPE: runType,
+        ...(runType && { DROID_EXEC_RUN_TYPE: runType }),
         ...(stewardPrNumber && { STEWARD_PR_NUMBER: stewardPrNumber }),
         ...(process.env.STEWARD_RUN_ID && {
           STEWARD_RUN_ID: process.env.STEWARD_RUN_ID,

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -5,6 +5,7 @@ import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { GitHubContext } from "../github/context";
 import { isEntityContext } from "../github/context";
 import type { DroidRunType } from "../run-type";
+import { parsePrCommentKind } from "../github/operations/comments/common";
 import { Octokit } from "@octokit/rest";
 
 type PrepareConfigParams = {
@@ -98,6 +99,7 @@ export async function prepareMcpTools(
         : undefined) ||
       stewardPrNumber ||
       "";
+    const prCommentKind = parsePrCommentKind(process.env.DROID_PR_COMMENT_KIND);
 
     const baseMcpTools: { mcpServers: Record<string, unknown> } = {
       mcpServers: {},
@@ -112,6 +114,7 @@ export async function prepareMcpTools(
         REPO_NAME: repo,
         ...(droidCommentId && { DROID_COMMENT_ID: droidCommentId }),
         ...(runType && { DROID_EXEC_RUN_TYPE: runType }),
+        ...(prCommentKind && { DROID_PR_COMMENT_KIND: prCommentKind }),
         ...(stewardPrNumber && { STEWARD_PR_NUMBER: stewardPrNumber }),
         ...(process.env.STEWARD_RUN_ID && {
           STEWARD_RUN_ID: process.env.STEWARD_RUN_ID,
@@ -137,6 +140,7 @@ export async function prepareMcpTools(
           REPO_OWNER: owner,
           REPO_NAME: repo,
           PR_NUMBER: pullRequestNumber,
+          ...(runType && { DROID_EXEC_RUN_TYPE: runType }),
           GITHUB_API_URL: GITHUB_API_URL,
         },
       };
@@ -183,6 +187,7 @@ export async function prepareMcpTools(
           REPO_OWNER: owner,
           REPO_NAME: repo,
           PR_NUMBER: context.entityNumber?.toString() || "",
+          ...(runType && { DROID_EXEC_RUN_TYPE: runType }),
         },
       };
     }

--- a/src/run-type.ts
+++ b/src/run-type.ts
@@ -1,6 +1,5 @@
 import * as core from "@actions/core";
 import type { DroidCommand } from "./core/review/triggers/parse-command";
-import type { PrValidationSource } from "./github/operations/comments/common";
 
 export enum DroidRunType {
   Review = "droid-review",
@@ -9,6 +8,11 @@ export enum DroidRunType {
   SecurityScan = "droid-security-scan",
   CiSteward = "ci-steward",
 }
+
+export type PrValidationRunType =
+  | DroidRunType.Review
+  | DroidRunType.SecurityReview
+  | DroidRunType.SecurityScan;
 
 export function setDroidRunType(runType: DroidRunType): void {
   core.exportVariable("DROID_EXEC_RUN_TYPE", runType);
@@ -31,12 +35,13 @@ export function parseDroidRunType(
     : undefined;
 }
 
-export function prValidationSourceForRunType(
+export function getPrValidationRunType(
   runType: DroidRunType | undefined,
-): PrValidationSource | undefined {
+): PrValidationRunType | undefined {
   return runType === DroidRunType.Review ||
-    runType === DroidRunType.SecurityReview
-    ? "review"
+    runType === DroidRunType.SecurityReview ||
+    runType === DroidRunType.SecurityScan
+    ? runType
     : undefined;
 }
 

--- a/src/run-type.ts
+++ b/src/run-type.ts
@@ -1,0 +1,71 @@
+import * as core from "@actions/core";
+import type { DroidCommand } from "./core/review/triggers/parse-command";
+import type { PrValidationSource } from "./github/operations/comments/common";
+
+export enum DroidRunType {
+  Review = "droid-review",
+  SecurityReview = "droid-security-review",
+  Fill = "droid-fill",
+  SecurityScan = "droid-security-scan",
+  CiSteward = "ci-steward",
+}
+
+export function setDroidRunType(runType: DroidRunType): void {
+  core.exportVariable("DROID_EXEC_RUN_TYPE", runType);
+}
+
+export function assertDroidRunType(
+  runType: DroidRunType,
+  expected: DroidRunType,
+): void {
+  if (runType !== expected) {
+    throw new Error(`Expected run type ${expected}, received ${runType}`);
+  }
+}
+
+export function parseDroidRunType(
+  value: string | undefined,
+): DroidRunType | undefined {
+  return Object.values(DroidRunType).includes(value as DroidRunType)
+    ? (value as DroidRunType)
+    : undefined;
+}
+
+export function prValidationSourceForRunType(
+  runType: DroidRunType | undefined,
+): PrValidationSource | undefined {
+  return runType === DroidRunType.Review ||
+    runType === DroidRunType.SecurityReview
+    ? "review"
+    : undefined;
+}
+
+export function resolveTagRunType({
+  automaticReview,
+  automaticSecurityReview,
+  command,
+}: {
+  automaticReview: boolean;
+  automaticSecurityReview: boolean;
+  command: DroidCommand | null;
+}): DroidRunType {
+  if (automaticReview) {
+    return DroidRunType.Review;
+  }
+  if (automaticSecurityReview) {
+    return DroidRunType.SecurityReview;
+  }
+
+  switch (command) {
+    case "fill":
+      return DroidRunType.Fill;
+    case "security":
+      return DroidRunType.SecurityReview;
+    case "security-full":
+      return DroidRunType.SecurityScan;
+    case "review":
+    case "default":
+    case null:
+      return DroidRunType.Review;
+  }
+}

--- a/src/run-type.ts
+++ b/src/run-type.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import type { DroidCommand } from "./core/review/triggers/parse-command";
 
 export enum DroidRunType {
+  Default = "droid-default",
   Review = "droid-review",
   SecurityReview = "droid-security-review",
   Fill = "droid-fill",
@@ -10,6 +11,7 @@ export enum DroidRunType {
 }
 
 export type PrValidationRunType =
+  | DroidRunType.Default
   | DroidRunType.Review
   | DroidRunType.SecurityReview
   | DroidRunType.SecurityScan;
@@ -19,11 +21,14 @@ export function setDroidRunType(runType: DroidRunType): void {
 }
 
 export function assertDroidRunType(
-  runType: DroidRunType,
-  expected: DroidRunType,
+  runType: DroidRunType | null,
+  expected: DroidRunType | null | readonly (DroidRunType | null)[],
 ): void {
-  if (runType !== expected) {
-    throw new Error(`Expected run type ${expected}, received ${runType}`);
+  const expectedRunTypes = Array.isArray(expected) ? expected : [expected];
+  if (!expectedRunTypes.includes(runType)) {
+    throw new Error(
+      `Expected run type ${expectedRunTypes.join(" or ")}, received ${runType}`,
+    );
   }
 }
 
@@ -36,9 +41,10 @@ export function parseDroidRunType(
 }
 
 export function getPrValidationRunType(
-  runType: DroidRunType | undefined,
+  runType: DroidRunType | null | undefined,
 ): PrValidationRunType | undefined {
-  return runType === DroidRunType.Review ||
+  return runType === DroidRunType.Default ||
+    runType === DroidRunType.Review ||
     runType === DroidRunType.SecurityReview ||
     runType === DroidRunType.SecurityScan
     ? runType
@@ -53,7 +59,7 @@ export function resolveTagRunType({
   automaticReview: boolean;
   automaticSecurityReview: boolean;
   command: DroidCommand | null;
-}): DroidRunType {
+}): DroidRunType | null {
   if (automaticReview) {
     return DroidRunType.Review;
   }
@@ -69,8 +75,10 @@ export function resolveTagRunType({
     case "security-full":
       return DroidRunType.SecurityScan;
     case "review":
-    case "default":
-    case null:
       return DroidRunType.Review;
+    case "default":
+      return DroidRunType.Default;
+    case null:
+      return null;
   }
 }

--- a/src/run-type.ts
+++ b/src/run-type.ts
@@ -51,6 +51,12 @@ export function getPrValidationRunType(
     : undefined;
 }
 
+export function parsePrValidationRunType(
+  value: string | undefined,
+): PrValidationRunType | undefined {
+  return getPrValidationRunType(parseDroidRunType(value));
+}
+
 export function resolveTagRunType({
   automaticReview,
   automaticSecurityReview,

--- a/src/steward/index.ts
+++ b/src/steward/index.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import { mkdir, writeFile } from "fs/promises";
 import type { WorkflowRunEvent } from "@octokit/webhooks-types";
 import type { AutomationContext } from "../github/context";
+import { DroidRunType } from "../run-type";
 import type { Octokits } from "../github/api/client";
 import { prepareMcpTools } from "../mcp/install-mcp-server";
 import {
@@ -161,6 +162,7 @@ export async function prepareStewardMode(
   context: AutomationContext,
   octokit: Octokits,
   githubToken: string,
+  runType: DroidRunType.CiSteward = DroidRunType.CiSteward,
 ): Promise<PrepareResult> {
   if (context.eventName !== "workflow_run") {
     throw new Error("CI Steward requires a workflow_run event");
@@ -361,7 +363,6 @@ export async function prepareStewardMode(
   core.setOutput("steward_pr_number", pr.number.toString());
   core.setOutput("run_code_review", "false");
   core.exportVariable("STEWARD_PR_NUMBER", pr.number.toString());
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "ci-steward");
   // The comment server rebuilds the marker from these instead of re-reading
   // the comment, so a transient read failure can no longer drop it and reset
   // the pull request's lifetime count. They are passed as two digit-only
@@ -421,6 +422,7 @@ ${config.instructions || "(none)"}`;
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: comment.data.id.toString(),
+    runType,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/fill.ts
+++ b/src/tag/commands/fill.ts
@@ -17,7 +17,7 @@ type FillCommandOptions = {
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
-  runType?: DroidRunType;
+  runType?: DroidRunType | null;
 };
 
 export async function prepareFillMode({

--- a/src/tag/commands/fill.ts
+++ b/src/tag/commands/fill.ts
@@ -10,12 +10,14 @@ import { isEntityContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
+import { assertDroidRunType, DroidRunType } from "../../run-type";
 
 type FillCommandOptions = {
   context: GitHubContext;
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
+  runType?: DroidRunType;
 };
 
 export async function prepareFillMode({
@@ -23,6 +25,7 @@ export async function prepareFillMode({
   octokit,
   githubToken,
   trackingCommentId,
+  runType = DroidRunType.Fill,
 }: FillCommandOptions): Promise<PrepareResult> {
   if (!isEntityContext(context)) {
     throw new Error("Fill command requires an entity event context");
@@ -31,9 +34,11 @@ export async function prepareFillMode({
   if (!context.isPR) {
     throw new Error("Fill command is only supported on pull requests");
   }
+  assertDroidRunType(runType, DroidRunType.Fill);
 
   const commentId =
-    trackingCommentId ?? (await createInitialComment(octokit.rest, context)).id;
+    trackingCommentId ??
+    (await createInitialComment(octokit.rest, context, "default", runType)).id;
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -58,8 +63,6 @@ export async function prepareFillMode({
     },
     generatePrompt: generateFillPrompt,
   });
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-fill");
-
   const rawUserArgs = process.env.DROID_ARGS || "";
   const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
   const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
@@ -85,6 +88,7 @@ export async function prepareFillMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
+    runType,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -13,17 +13,25 @@ import type { PrepareResult } from "../../prepare/types";
 import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
 import { resolveReviewConfig } from "../../utils/review-depth";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
+import { assertDroidRunType, DroidRunType } from "../../run-type";
 
 export async function prepareReviewValidatorMode(options: {
   context: GitHubContext;
   octokit: Octokits;
   githubToken: string;
   trackingCommentId: number;
+  runType?: DroidRunType;
 }): Promise<PrepareResult> {
-  const { context, octokit, trackingCommentId } = options;
+  const {
+    context,
+    octokit,
+    trackingCommentId,
+    runType = DroidRunType.Review,
+  } = options;
   if (!isEntityContext(context) || !context.isPR) {
     throw new Error("review validator mode requires pull request context");
   }
+  assertDroidRunType(runType, DroidRunType.Review);
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -60,8 +68,6 @@ export async function prepareReviewValidatorMode(options: {
     reviewArtifacts,
     includeSuggestions,
   });
-
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
 
   const rawUserArgs = process.env.DROID_ARGS || "";
   const normalizedUserArgs = stripToolSelectionArgs(

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -31,7 +31,11 @@ export async function prepareReviewValidatorMode(options: {
   if (!isEntityContext(context) || !context.isPR) {
     throw new Error("review validator mode requires pull request context");
   }
-  assertDroidRunType(runType, DroidRunType.Review);
+  assertDroidRunType(runType, [
+    DroidRunType.Default,
+    DroidRunType.Review,
+    DroidRunType.SecurityReview,
+  ]);
 
   const prData = await fetchPRBranchData({
     octokits: octokit,

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -14,12 +14,14 @@ import type { PrepareResult } from "../../prepare/types";
 import { resolveReviewConfig } from "../../utils/review-depth";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
 import { retryWithBackoff } from "../../utils/retry";
+import { assertDroidRunType, DroidRunType } from "../../run-type";
 
 type ReviewCommandOptions = {
   context: GitHubContext;
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
+  runType?: DroidRunType;
 };
 
 export async function prepareReviewMode({
@@ -27,6 +29,7 @@ export async function prepareReviewMode({
   octokit,
   githubToken,
   trackingCommentId,
+  runType = DroidRunType.Review,
 }: ReviewCommandOptions): Promise<PrepareResult> {
   if (!isEntityContext(context)) {
     throw new Error("Review command requires an entity event context");
@@ -35,10 +38,11 @@ export async function prepareReviewMode({
   if (!context.isPR) {
     throw new Error("Review command is only supported on pull requests");
   }
+  assertDroidRunType(runType, DroidRunType.Review);
 
   const commentId =
     trackingCommentId ??
-    (await createInitialComment(octokit.rest, context, "review")).id;
+    (await createInitialComment(octokit.rest, context, "default", runType)).id;
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -109,8 +113,6 @@ export async function prepareReviewMode({
     reviewArtifacts,
     includeSuggestions,
   });
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
-
   const rawUserArgs = process.env.DROID_ARGS || "";
   const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
   const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
@@ -154,7 +156,7 @@ export async function prepareReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
-    prValidationSource: "review",
+    runType,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -37,7 +37,8 @@ export async function prepareReviewMode({
   }
 
   const commentId =
-    trackingCommentId ?? (await createInitialComment(octokit.rest, context)).id;
+    trackingCommentId ??
+    (await createInitialComment(octokit.rest, context, "review")).id;
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -153,6 +154,7 @@ export async function prepareReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
+    includePrReviewMarker: true,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -154,7 +154,7 @@ export async function prepareReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
-    includePrReviewMarker: true,
+    prValidationSource: "review",
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/review.ts
+++ b/src/tag/commands/review.ts
@@ -21,7 +21,7 @@ type ReviewCommandOptions = {
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
-  runType?: DroidRunType;
+  runType?: DroidRunType | null;
 };
 
 export async function prepareReviewMode({
@@ -38,7 +38,11 @@ export async function prepareReviewMode({
   if (!context.isPR) {
     throw new Error("Review command is only supported on pull requests");
   }
-  assertDroidRunType(runType, DroidRunType.Review);
+  assertDroidRunType(runType, [
+    DroidRunType.Default,
+    DroidRunType.Review,
+    null,
+  ]);
 
   const commentId =
     trackingCommentId ??

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -38,7 +38,8 @@ export async function prepareSecurityReviewMode({
   }
 
   const commentId =
-    trackingCommentId ?? (await createInitialComment(octokit.rest, context)).id;
+    trackingCommentId ??
+    (await createInitialComment(octokit.rest, context, "security")).id;
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -143,6 +144,7 @@ export async function prepareSecurityReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
+    includePrReviewMarker: true,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -13,12 +13,14 @@ import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
 import { resolveReviewConfig } from "../../utils/review-depth";
+import { assertDroidRunType, DroidRunType } from "../../run-type";
 
 type SecurityReviewCommandOptions = {
   context: GitHubContext;
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
+  runType?: DroidRunType;
 };
 
 export async function prepareSecurityReviewMode({
@@ -26,6 +28,7 @@ export async function prepareSecurityReviewMode({
   octokit,
   githubToken,
   trackingCommentId,
+  runType = DroidRunType.SecurityReview,
 }: SecurityReviewCommandOptions): Promise<PrepareResult> {
   if (!isEntityContext(context)) {
     throw new Error("Security review command requires an entity event context");
@@ -36,10 +39,11 @@ export async function prepareSecurityReviewMode({
       "Security review command is only supported on pull requests",
     );
   }
+  assertDroidRunType(runType, DroidRunType.SecurityReview);
 
   const commentId =
     trackingCommentId ??
-    (await createInitialComment(octokit.rest, context, "security")).id;
+    (await createInitialComment(octokit.rest, context, "security", runType)).id;
 
   const prData = await fetchPRBranchData({
     octokits: octokit,
@@ -100,8 +104,6 @@ export async function prepareSecurityReviewMode({
     generatePrompt: generateSecurityCandidatesPrompt,
     reviewArtifacts,
   });
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-security-review");
-
   core.setOutput("install_security_skills", "true");
 
   const rawUserArgs = process.env.DROID_ARGS || "";
@@ -144,7 +146,7 @@ export async function prepareSecurityReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
-    prValidationSource: "review",
+    runType,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -144,7 +144,7 @@ export async function prepareSecurityReviewMode({
     owner: context.repository.owner,
     repo: context.repository.repo,
     droidCommentId: commentId.toString(),
-    includePrReviewMarker: true,
+    prValidationSource: "review",
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -20,7 +20,7 @@ type SecurityReviewCommandOptions = {
   octokit: Octokits;
   githubToken: string;
   trackingCommentId?: number;
-  runType?: DroidRunType;
+  runType?: DroidRunType | null;
 };
 
 export async function prepareSecurityReviewMode({

--- a/src/tag/commands/security-scan.ts
+++ b/src/tag/commands/security-scan.ts
@@ -9,6 +9,7 @@ import { generateSecurityReportPrompt } from "../../create-prompt/templates/secu
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
+import { assertDroidRunType, DroidRunType } from "../../run-type";
 
 export type ScanScope = { type: "full" } | { type: "scheduled"; days: number };
 
@@ -17,6 +18,7 @@ type SecurityScanCommandOptions = {
   octokit: Octokits;
   githubToken: string;
   scanScope: ScanScope;
+  runType?: DroidRunType;
 };
 
 export async function prepareSecurityScanMode({
@@ -24,10 +26,12 @@ export async function prepareSecurityScanMode({
   octokit,
   githubToken,
   scanScope,
+  runType = DroidRunType.SecurityScan,
 }: SecurityScanCommandOptions): Promise<PrepareResult> {
   if (!isEntityContext(context)) {
     throw new Error("Security scan command requires an entity event context");
   }
+  assertDroidRunType(runType, DroidRunType.SecurityScan);
 
   // Fetch the repository's default branch (could be main, master, develop, etc.)
   const defaultBranch = await fetchRepoDefaultBranch({
@@ -51,8 +55,6 @@ export async function prepareSecurityScanMode({
     generatePrompt: (ctx) =>
       generateSecurityReportPrompt(ctx, scanScope, branchName),
   });
-  core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-security-scan");
-
   // Signal that security skills should be installed
   core.setOutput("install_security_skills", "true");
 
@@ -79,6 +81,7 @@ export async function prepareSecurityScanMode({
     githubToken,
     owner: context.repository.owner,
     repo: context.repository.repo,
+    runType,
     allowedTools,
     mode: "tag",
     context,

--- a/src/tag/commands/security-scan.ts
+++ b/src/tag/commands/security-scan.ts
@@ -18,7 +18,7 @@ type SecurityScanCommandOptions = {
   octokit: Octokits;
   githubToken: string;
   scanScope: ScanScope;
-  runType?: DroidRunType;
+  runType?: DroidRunType | null;
 };
 
 export async function prepareSecurityScanMode({

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -109,12 +109,21 @@ export async function prepareTagExecution({
     (context.inputs.automaticSecurityReview ||
       commandContext?.command === "security" ||
       commandContext?.command === "security-full");
+  const isCodeReview =
+    context.inputs.automaticReview ||
+    commandContext?.command === "review" ||
+    commandContext?.command === "default" ||
+    !commandContext;
 
   const commentType = isDualReview
     ? "review_and_security"
     : isSecurityOnly
-      ? "security"
-      : "default";
+      ? commandContext?.command === "security-full"
+        ? "security_scan"
+        : "security"
+      : isCodeReview
+        ? "review"
+        : "default";
 
   const commentData = await createInitialComment(
     octokit.rest,

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -13,6 +13,7 @@ import type { PrepareResult } from "../prepare/types";
 import type { Octokits } from "../github/api/client";
 import { isAutomationContext } from "../github/context";
 import { prepareStewardMode } from "../steward";
+import { DroidRunType, resolveTagRunType, setDroidRunType } from "../run-type";
 
 const DROID_APP_BOT_ID = 209825114;
 const SECURITY_REVIEW_MARKER = "## Security Review Summary";
@@ -81,7 +82,9 @@ export async function prepareTagExecution({
   githubToken,
 }: PrepareTagOptions): Promise<PrepareResult> {
   if (isAutomationContext(context)) {
-    return prepareStewardMode(context, octokit, githubToken);
+    const runType = DroidRunType.CiSteward;
+    setDroidRunType(runType);
+    return prepareStewardMode(context, octokit, githubToken, runType);
   }
   if (!isEntityContext(context)) {
     throw new Error("Tag execution requires entity context");
@@ -100,6 +103,12 @@ export async function prepareTagExecution({
   }
 
   const commandContext = extractCommandFromContext(context);
+  const runType = resolveTagRunType({
+    automaticReview: context.inputs.automaticReview,
+    automaticSecurityReview: context.inputs.automaticSecurityReview,
+    command: commandContext?.command ?? null,
+  });
+  setDroidRunType(runType);
 
   // Determine comment type based on what's being run
   const isDualReview =
@@ -109,26 +118,18 @@ export async function prepareTagExecution({
     (context.inputs.automaticSecurityReview ||
       commandContext?.command === "security" ||
       commandContext?.command === "security-full");
-  const isCodeReview =
-    context.inputs.automaticReview ||
-    commandContext?.command === "review" ||
-    commandContext?.command === "default" ||
-    !commandContext;
 
   const commentType = isDualReview
     ? "review_and_security"
     : isSecurityOnly
-      ? commandContext?.command === "security-full"
-        ? "security_scan"
-        : "security"
-      : isCodeReview
-        ? "review"
-        : "default";
+      ? "security"
+      : "default";
 
   const commentData = await createInitialComment(
     octokit.rest,
     context,
     commentType,
+    runType,
   );
   const commentId = commentData.id;
 
@@ -163,6 +164,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 
@@ -174,6 +176,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 
@@ -203,6 +206,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 
@@ -212,6 +216,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 
@@ -224,6 +229,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 
@@ -233,6 +239,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       scanScope: { type: "full" },
+      runType,
     });
   }
 
@@ -249,6 +256,7 @@ export async function prepareTagExecution({
       octokit,
       githubToken,
       trackingCommentId: commentId,
+      runType,
     });
   }
 

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -110,12 +110,37 @@ export async function prepareTagExecution({
   });
   setDroidRunType(runType);
 
+  let runAutomaticSecurityReview = context.inputs.automaticSecurityReview;
+  if (runAutomaticSecurityReview) {
+    const hasExisting = await hasExistingSecurityReview(octokit, context);
+    if (hasExisting) {
+      console.log(
+        "Security review already exists on this PR, skipping security",
+      );
+      runAutomaticSecurityReview = false;
+
+      if (!context.inputs.automaticReview) {
+        core.setOutput("run_code_review", "false");
+        core.setOutput("run_security_review", "false");
+        return {
+          skipped: true,
+          reason: "security_review_exists",
+          branchInfo: {
+            baseBranch: "",
+            currentBranch: "",
+          },
+          mcpTools: "",
+        };
+      }
+    }
+  }
+
   // Determine comment type based on what's being run
   const isDualReview =
-    context.inputs.automaticReview && context.inputs.automaticSecurityReview;
+    context.inputs.automaticReview && runAutomaticSecurityReview;
   const isSecurityOnly =
-    !isDualReview &&
-    (context.inputs.automaticSecurityReview ||
+    !context.inputs.automaticReview &&
+    (runAutomaticSecurityReview ||
       commandContext?.command === "security" ||
       commandContext?.command === "security-full");
 
@@ -138,25 +163,17 @@ export async function prepareTagExecution({
     context.inputs.automaticReview &&
     context.inputs.automaticSecurityReview
   ) {
-    let runSecurityReview = true;
-
-    // Check if security review already exists on this PR (run once behavior)
-    const hasExisting = await hasExistingSecurityReview(octokit, context);
-    if (hasExisting) {
-      console.log(
-        "Security review already exists on this PR, skipping security",
-      );
-      runSecurityReview = false;
-    }
-
-    if (runSecurityReview) {
+    if (runAutomaticSecurityReview) {
       // Signal to the code review prompt to spawn a security-reviewer subagent
       core.exportVariable("SECURITY_REVIEW_ENABLED", "true");
       core.setOutput("install_security_skills", "true");
     }
 
     core.setOutput("run_code_review", "true");
-    core.setOutput("run_security_review", runSecurityReview.toString());
+    core.setOutput(
+      "run_security_review",
+      runAutomaticSecurityReview.toString(),
+    );
 
     // Prepare the code review (security review runs as a subagent within pass 1)
     return prepareReviewMode({
@@ -181,23 +198,6 @@ export async function prepareTagExecution({
   }
 
   if (context.inputs.automaticSecurityReview) {
-    // Check if security review already exists on this PR (run once behavior)
-    const hasExisting = await hasExistingSecurityReview(octokit, context);
-    if (hasExisting) {
-      console.log("Security review already exists on this PR, skipping");
-      core.setOutput("run_code_review", "false");
-      core.setOutput("run_security_review", "false");
-      return {
-        skipped: true,
-        reason: "security_review_exists",
-        branchInfo: {
-          baseBranch: "",
-          currentBranch: "",
-        },
-        mcpTools: "",
-      };
-    }
-
     // Standalone security review uses the two-pass pipeline (candidates + validator)
     core.setOutput("run_code_review", "true");
     core.setOutput("run_security_review", "true");

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -108,7 +108,9 @@ export async function prepareTagExecution({
     automaticSecurityReview: context.inputs.automaticSecurityReview,
     command: commandContext?.command ?? null,
   });
-  setDroidRunType(runType);
+  if (runType) {
+    setDroidRunType(runType);
+  }
 
   let runAutomaticSecurityReview = context.inputs.automaticSecurityReview;
   if (runAutomaticSecurityReview) {

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -3,7 +3,10 @@ import {
   updateCommentBody,
   type CommentUpdateInput,
 } from "../src/github/operations/comment-logic";
-import { createPrCommentMarker } from "../src/github/operations/comments/common";
+import {
+  COMBINED_REVIEW_COMMENT_RUN_TYPE,
+  createPrCommentMarker,
+} from "../src/github/operations/comments/common";
 import { DroidRunType } from "../src/run-type";
 
 describe("updateCommentBody", () => {
@@ -16,6 +19,81 @@ describe("updateCommentBody", () => {
     triggerUsername: undefined,
   };
 
+  it.each([
+    DroidRunType.Review,
+    DroidRunType.SecurityReview,
+    COMBINED_REVIEW_COMMENT_RUN_TYPE,
+  ] as const)(
+    "preserves the %s marker through deterministic summaries",
+    (runType) => {
+      const marker = createPrCommentMarker("issue-comment", runType);
+      const result = updateCommentBody({
+        ...baseInput,
+        currentBody: `Droid is working…\n\n${marker}`,
+        review: { summaryBody: "Final review summary", posted: 2 },
+      });
+      expect(result).toContain("Final review summary");
+      expect(result).toContain("2 inline comments posted");
+      expect(result).toEndWith(marker);
+      expect(result.match(/<!-- factory-pr-issue-comment:/g)).toHaveLength(1);
+    },
+  );
+
+  it("keeps the combined marker when either review finalizes the shared comment", () => {
+    const marker = createPrCommentMarker(
+      "issue-comment",
+      COMBINED_REVIEW_COMMENT_RUN_TYPE,
+    );
+    let currentBody = marker;
+    for (const runType of [
+      DroidRunType.SecurityReview,
+      DroidRunType.Review,
+    ] as const) {
+      currentBody = updateCommentBody({
+        ...baseInput,
+        currentBody,
+        prCommentRunType: runType,
+        review: {
+          posted: 0,
+          summaryBody: `Summary\n\n${createPrCommentMarker("issue-comment", runType)}`,
+        },
+      });
+      expect(currentBody).toEndWith(marker);
+      expect(currentBody.match(/<!-- factory-pr-issue-comment:/g)).toHaveLength(
+        1,
+      );
+    }
+  });
+
+  it("restores the marker from trusted run metadata if the old body has none", () => {
+    const result = updateCommentBody({
+      ...baseInput,
+      prCommentRunType: DroidRunType.SecurityReview,
+      review: { summaryBody: "Security summary", posted: 0 },
+    });
+    expect(result).toEndWith(
+      createPrCommentMarker("issue-comment", DroidRunType.SecurityReview),
+    );
+  });
+
+  it("preserves inline tracking markers through failures and final summaries", () => {
+    const marker = createPrCommentMarker(
+      "inline-comment",
+      COMBINED_REVIEW_COMMENT_RUN_TYPE,
+    );
+    const result = updateCommentBody({
+      ...baseInput,
+      currentBody: marker,
+      prCommentKind: "inline-comment",
+      prCommentRunType: DroidRunType.SecurityReview,
+      actionFailed: true,
+      errorDetails: "Posting failed",
+      review: { summaryBody: "Partial results", failed: 1 },
+    });
+    expect(result).toContain("Posting failed");
+    expect(result).toEndWith(marker);
+    expect(result).not.toContain("factory-pr-issue-comment");
+  });
   it("renders the deterministic review summary and posting counts", () => {
     const result = updateCommentBody({
       ...baseInput,

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -3,6 +3,7 @@ import {
   updateCommentBody,
   type CommentUpdateInput,
 } from "../src/github/operations/comment-logic";
+import { DROID_PR_REVIEW_MARKER } from "../src/github/operations/comments/common";
 
 describe("updateCommentBody", () => {
   const baseInput = {
@@ -105,6 +106,16 @@ describe("updateCommentBody", () => {
 
       const result = updateCommentBody(input);
       expect(result).not.toContain("running a security check");
+    });
+
+    it("preserves the hidden PR review marker in the final summary", () => {
+      const input = {
+        ...baseInput,
+        currentBody: `Droid is reviewing code…\n\n${DROID_PR_REVIEW_MARKER}`,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain(DROID_PR_REVIEW_MARKER);
     });
 
     it("includes error details when provided", () => {

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -4,6 +4,7 @@ import {
   type CommentUpdateInput,
 } from "../src/github/operations/comment-logic";
 import { createPrValidationMarker } from "../src/github/operations/comments/common";
+import { DroidRunType } from "../src/run-type";
 
 describe("updateCommentBody", () => {
   const baseInput = {
@@ -109,7 +110,7 @@ describe("updateCommentBody", () => {
     });
 
     it("preserves the hidden PR validation marker in the final summary", () => {
-      const marker = createPrValidationMarker("review");
+      const marker = createPrValidationMarker(DroidRunType.Review);
       const input = {
         ...baseInput,
         currentBody: `Droid is reviewing code…\n\n${marker}`,

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -3,7 +3,7 @@ import {
   updateCommentBody,
   type CommentUpdateInput,
 } from "../src/github/operations/comment-logic";
-import { createPrValidationMarker } from "../src/github/operations/comments/common";
+import { createPrCommentMarker } from "../src/github/operations/comments/common";
 import { DroidRunType } from "../src/run-type";
 
 describe("updateCommentBody", () => {
@@ -110,7 +110,10 @@ describe("updateCommentBody", () => {
     });
 
     it("preserves the hidden PR validation marker in the final summary", () => {
-      const marker = createPrValidationMarker(DroidRunType.Review);
+      const marker = createPrCommentMarker(
+        "issue-comment",
+        DroidRunType.Review,
+      );
       const input = {
         ...baseInput,
         currentBody: `Droid is reviewing code…\n\n${marker}`,

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -3,7 +3,7 @@ import {
   updateCommentBody,
   type CommentUpdateInput,
 } from "../src/github/operations/comment-logic";
-import { DROID_PR_REVIEW_MARKER } from "../src/github/operations/comments/common";
+import { createPrValidationMarker } from "../src/github/operations/comments/common";
 
 describe("updateCommentBody", () => {
   const baseInput = {
@@ -108,14 +108,15 @@ describe("updateCommentBody", () => {
       expect(result).not.toContain("running a security check");
     });
 
-    it("preserves the hidden PR review marker in the final summary", () => {
+    it("preserves the hidden PR validation marker in the final summary", () => {
+      const marker = createPrValidationMarker("review");
       const input = {
         ...baseInput,
-        currentBody: `Droid is reviewing code…\n\n${DROID_PR_REVIEW_MARKER}`,
+        currentBody: `Droid is reviewing code…\n\n${marker}`,
       };
 
       const result = updateCommentBody(input);
-      expect(result).toContain(DROID_PR_REVIEW_MARKER);
+      expect(result).toContain(marker);
     });
 
     it("includes error details when provided", () => {

--- a/test/entrypoints/github-post-review.test.ts
+++ b/test/entrypoints/github-post-review.test.ts
@@ -14,6 +14,7 @@ import {
 import { buildUnifiedDiffIndex } from "../../src/core/review/validated/diff";
 import type { ValidatedReviewComment } from "../../src/core/review/validated/parse";
 import { createMockContext } from "../mockContext";
+import { DroidRunType } from "../../src/run-type";
 
 const DIFF = `diff --git a/src/x.ts b/src/x.ts
 --- a/src/x.ts
@@ -152,6 +153,29 @@ describe("postGitHubReview", () => {
     expect(createReview).toHaveBeenCalledTimes(1);
     expect((createReview.mock.calls[0]![0] as any).commit_id).toBe(
       "0123456789abcdef0123456789abcdef01234567",
+    );
+  });
+
+  it("tags inline comments with the review run type", async () => {
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 125 },
+    }));
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [comment({ body: "[P1] [security] Finding" })],
+      diff: DIFF,
+      runType: DroidRunType.SecurityReview,
+    });
+
+    expect((createReview.mock.calls[0]![0] as any).comments[0].body).toEndWith(
+      "<!-- factory-pr-inline-comment: run-type=droid-security-review -->",
     );
   });
 

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
-  DROID_PR_REVIEW_MARKER,
-  appendPrReviewMarker,
+  appendPrValidationMarker,
   createBranchLink,
   createCommentBody,
   createJobRunLink,
+  createPrValidationMarker,
   prepareDroidCommentBody,
 } from "../../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../../src/github/api/config";
@@ -48,26 +48,25 @@ describe("comments common helpers", () => {
 
   it("adds the hidden marker to PR review tracking comments", () => {
     const jobLink = createJobRunLink("factory", "droid", "run-102");
+    const marker = createPrValidationMarker("review");
 
-    expect(createCommentBody(jobLink, "", "review")).toEndWith(
-      DROID_PR_REVIEW_MARKER,
-    );
-    expect(createCommentBody(jobLink, "", "security")).toEndWith(
-      DROID_PR_REVIEW_MARKER,
-    );
+    expect(marker).toBe("<!-- factory-pr-validation: source=review -->");
+    expect(createCommentBody(jobLink, "", "review")).toEndWith(marker);
+    expect(createCommentBody(jobLink, "", "security")).toEndWith(marker);
     expect(createCommentBody(jobLink, "", "security_scan")).not.toContain(
-      DROID_PR_REVIEW_MARKER,
+      marker,
     );
-    expect(createCommentBody(jobLink)).not.toContain(DROID_PR_REVIEW_MARKER);
+    expect(createCommentBody(jobLink)).not.toContain(marker);
   });
 
-  it("restores the PR review marker after sanitizing comment updates", () => {
+  it("restores the PR validation marker after sanitizing comment updates", () => {
+    const marker = createPrValidationMarker("review");
     const body = prepareDroidCommentBody(
-      `Review complete\n\n${DROID_PR_REVIEW_MARKER}`,
-      true,
+      `Review complete\n\n${marker}`,
+      "review",
     );
 
-    expect(body).toBe(`Review complete\n\n${DROID_PR_REVIEW_MARKER}`);
-    expect(appendPrReviewMarker(body)).toBe(body);
+    expect(body).toBe(`Review complete\n\n${marker}`);
+    expect(appendPrValidationMarker(body, "review")).toBe(body);
   });
 });

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -49,6 +49,7 @@ describe("comments common helpers", () => {
 
   it("adds the run type marker to PR validation tracking comments", () => {
     const jobLink = createJobRunLink("factory", "droid", "run-102");
+    const defaultMarker = createPrValidationMarker(DroidRunType.Default);
     const reviewMarker = createPrValidationMarker(DroidRunType.Review);
     const securityReviewMarker = createPrValidationMarker(
       DroidRunType.SecurityReview,
@@ -57,6 +58,9 @@ describe("comments common helpers", () => {
       DroidRunType.SecurityScan,
     );
 
+    expect(defaultMarker).toBe(
+      "<!-- factory-pr-validation: run-type=droid-default -->",
+    );
     expect(reviewMarker).toBe(
       "<!-- factory-pr-validation: run-type=droid-review -->",
     );
@@ -66,6 +70,9 @@ describe("comments common helpers", () => {
     expect(securityScanMarker).toBe(
       "<!-- factory-pr-validation: run-type=droid-security-scan -->",
     );
+    expect(
+      createCommentBody(jobLink, "", "default", DroidRunType.Default),
+    ).toEndWith(defaultMarker);
     expect(
       createCommentBody(jobLink, "", "default", DroidRunType.Review),
     ).toEndWith(reviewMarker);

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -8,6 +8,7 @@ import {
   prepareDroidCommentBody,
 } from "../../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../../src/github/api/config";
+import { DroidRunType } from "../../src/run-type";
 
 describe("comments common helpers", () => {
   it("creates a job run link using the configured GitHub server", () => {
@@ -46,29 +47,47 @@ describe("comments common helpers", () => {
     expect(body).not.toContain("View branch");
   });
 
-  it("adds the hidden marker to PR review tracking comments", () => {
+  it("adds the run type marker to PR validation tracking comments", () => {
     const jobLink = createJobRunLink("factory", "droid", "run-102");
-    const marker = createPrValidationMarker("review");
+    const reviewMarker = createPrValidationMarker(DroidRunType.Review);
+    const securityReviewMarker = createPrValidationMarker(
+      DroidRunType.SecurityReview,
+    );
+    const securityScanMarker = createPrValidationMarker(
+      DroidRunType.SecurityScan,
+    );
 
-    expect(marker).toBe("<!-- factory-pr-validation: source=review -->");
-    expect(createCommentBody(jobLink, "", "default", "review")).toEndWith(
-      marker,
+    expect(reviewMarker).toBe(
+      "<!-- factory-pr-validation: run-type=droid-review -->",
     );
-    expect(createCommentBody(jobLink, "", "security", "review")).toEndWith(
-      marker,
+    expect(securityReviewMarker).toBe(
+      "<!-- factory-pr-validation: run-type=droid-security-review -->",
     );
-    expect(createCommentBody(jobLink, "", "security")).not.toContain(marker);
-    expect(createCommentBody(jobLink)).not.toContain(marker);
+    expect(securityScanMarker).toBe(
+      "<!-- factory-pr-validation: run-type=droid-security-scan -->",
+    );
+    expect(
+      createCommentBody(jobLink, "", "default", DroidRunType.Review),
+    ).toEndWith(reviewMarker);
+    expect(
+      createCommentBody(jobLink, "", "security", DroidRunType.SecurityReview),
+    ).toEndWith(securityReviewMarker);
+    expect(
+      createCommentBody(jobLink, "", "security", DroidRunType.SecurityScan),
+    ).toEndWith(securityScanMarker);
+    expect(createCommentBody(jobLink)).not.toContain("factory-pr-validation");
   });
 
   it("restores the PR validation marker after sanitizing comment updates", () => {
-    const marker = createPrValidationMarker("review");
+    const marker = createPrValidationMarker(DroidRunType.SecurityReview);
     const body = prepareDroidCommentBody(
       `Review complete\n\n${marker}`,
-      "review",
+      DroidRunType.SecurityReview,
     );
 
     expect(body).toBe(`Review complete\n\n${marker}`);
-    expect(appendPrValidationMarker(body, "review")).toBe(body);
+    expect(appendPrValidationMarker(body, DroidRunType.SecurityReview)).toBe(
+      body,
+    );
   });
 });

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+  DROID_PR_REVIEW_MARKER,
+  appendPrReviewMarker,
   createBranchLink,
   createCommentBody,
   createJobRunLink,
+  prepareDroidCommentBody,
 } from "../../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../../src/github/api/config";
 
@@ -41,5 +44,30 @@ describe("comments common helpers", () => {
 
     expect(body).toContain(jobLink);
     expect(body).not.toContain("View branch");
+  });
+
+  it("adds the hidden marker to PR review tracking comments", () => {
+    const jobLink = createJobRunLink("factory", "droid", "run-102");
+
+    expect(createCommentBody(jobLink, "", "review")).toEndWith(
+      DROID_PR_REVIEW_MARKER,
+    );
+    expect(createCommentBody(jobLink, "", "security")).toEndWith(
+      DROID_PR_REVIEW_MARKER,
+    );
+    expect(createCommentBody(jobLink, "", "security_scan")).not.toContain(
+      DROID_PR_REVIEW_MARKER,
+    );
+    expect(createCommentBody(jobLink)).not.toContain(DROID_PR_REVIEW_MARKER);
+  });
+
+  it("restores the PR review marker after sanitizing comment updates", () => {
+    const body = prepareDroidCommentBody(
+      `Review complete\n\n${DROID_PR_REVIEW_MARKER}`,
+      true,
+    );
+
+    expect(body).toBe(`Review complete\n\n${DROID_PR_REVIEW_MARKER}`);
+    expect(appendPrReviewMarker(body)).toBe(body);
   });
 });

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -51,11 +51,13 @@ describe("comments common helpers", () => {
     const marker = createPrValidationMarker("review");
 
     expect(marker).toBe("<!-- factory-pr-validation: source=review -->");
-    expect(createCommentBody(jobLink, "", "review")).toEndWith(marker);
-    expect(createCommentBody(jobLink, "", "security")).toEndWith(marker);
-    expect(createCommentBody(jobLink, "", "security_scan")).not.toContain(
+    expect(createCommentBody(jobLink, "", "default", "review")).toEndWith(
       marker,
     );
+    expect(createCommentBody(jobLink, "", "security", "review")).toEndWith(
+      marker,
+    );
+    expect(createCommentBody(jobLink, "", "security")).not.toContain(marker);
     expect(createCommentBody(jobLink)).not.toContain(marker);
   });
 

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
-  appendPrValidationMarker,
+  appendPrCommentMarker,
   createBranchLink,
   createCommentBody,
   createJobRunLink,
-  createPrValidationMarker,
+  createPrCommentMarker,
+  parsePrCommentKind,
   prepareDroidCommentBody,
 } from "../../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../../src/github/api/config";
@@ -49,26 +50,34 @@ describe("comments common helpers", () => {
 
   it("adds the run type marker to PR validation tracking comments", () => {
     const jobLink = createJobRunLink("factory", "droid", "run-102");
-    const defaultMarker = createPrValidationMarker(DroidRunType.Default);
-    const reviewMarker = createPrValidationMarker(DroidRunType.Review);
-    const securityReviewMarker = createPrValidationMarker(
+    const defaultMarker = createPrCommentMarker(
+      "issue-comment",
+      DroidRunType.Default,
+    );
+    const reviewMarker = createPrCommentMarker(
+      "issue-comment",
+      DroidRunType.Review,
+    );
+    const securityReviewMarker = createPrCommentMarker(
+      "issue-comment",
       DroidRunType.SecurityReview,
     );
-    const securityScanMarker = createPrValidationMarker(
+    const securityScanMarker = createPrCommentMarker(
+      "issue-comment",
       DroidRunType.SecurityScan,
     );
 
     expect(defaultMarker).toBe(
-      "<!-- factory-pr-validation: run-type=droid-default -->",
+      "<!-- factory-pr-issue-comment: run-type=droid-default -->",
     );
     expect(reviewMarker).toBe(
-      "<!-- factory-pr-validation: run-type=droid-review -->",
+      "<!-- factory-pr-issue-comment: run-type=droid-review -->",
     );
     expect(securityReviewMarker).toBe(
-      "<!-- factory-pr-validation: run-type=droid-security-review -->",
+      "<!-- factory-pr-issue-comment: run-type=droid-security-review -->",
     );
     expect(securityScanMarker).toBe(
-      "<!-- factory-pr-validation: run-type=droid-security-scan -->",
+      "<!-- factory-pr-issue-comment: run-type=droid-security-scan -->",
     );
     expect(
       createCommentBody(jobLink, "", "default", DroidRunType.Default),
@@ -82,19 +91,46 @@ describe("comments common helpers", () => {
     expect(
       createCommentBody(jobLink, "", "security", DroidRunType.SecurityScan),
     ).toEndWith(securityScanMarker);
-    expect(createCommentBody(jobLink)).not.toContain("factory-pr-validation");
+    expect(createCommentBody(jobLink)).not.toContain("factory-pr-");
   });
 
   it("restores the PR validation marker after sanitizing comment updates", () => {
-    const marker = createPrValidationMarker(DroidRunType.SecurityReview);
+    const marker = createPrCommentMarker(
+      "issue-comment",
+      DroidRunType.SecurityReview,
+    );
     const body = prepareDroidCommentBody(
       `Review complete\n\n${marker}`,
       DroidRunType.SecurityReview,
     );
 
     expect(body).toBe(`Review complete\n\n${marker}`);
-    expect(appendPrValidationMarker(body, DroidRunType.SecurityReview)).toBe(
-      body,
+    expect(
+      appendPrCommentMarker(body, "issue-comment", DroidRunType.SecurityReview),
+    ).toBe(body);
+  });
+
+  it("creates a distinct marker for inline review comments", () => {
+    const marker = createPrCommentMarker(
+      "inline-comment",
+      DroidRunType.SecurityReview,
     );
+
+    expect(marker).toBe(
+      "<!-- factory-pr-inline-comment: run-type=droid-security-review -->",
+    );
+    expect(
+      prepareDroidCommentBody(
+        `[P1] [security] Finding\n\nDetails\n\n${marker}`,
+        DroidRunType.SecurityReview,
+        "inline-comment",
+      ),
+    ).toBe(`[P1] [security] Finding\n\nDetails\n\n${marker}`);
+  });
+
+  it("parses only known PR comment kinds", () => {
+    expect(parsePrCommentKind("issue-comment")).toBe("issue-comment");
+    expect(parsePrCommentKind("inline-comment")).toBe("inline-comment");
+    expect(parsePrCommentKind("review")).toBeUndefined();
   });
 });

--- a/test/github/comments-common.test.ts
+++ b/test/github/comments-common.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import {
   appendPrCommentMarker,
+  COMBINED_REVIEW_COMMENT_RUN_TYPE,
   createBranchLink,
   createCommentBody,
   createJobRunLink,
   createPrCommentMarker,
   parsePrCommentKind,
   prepareDroidCommentBody,
+  prepareDroidTrackingCommentBody,
+  readPrCommentRunType,
 } from "../../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../../src/github/api/config";
 import { DroidRunType } from "../../src/run-type";
@@ -132,5 +135,88 @@ describe("comments common helpers", () => {
     expect(parsePrCommentKind("issue-comment")).toBe("issue-comment");
     expect(parsePrCommentKind("inline-comment")).toBe("inline-comment");
     expect(parsePrCommentKind("review")).toBeUndefined();
+  });
+
+  it("marks a combined tracking comment without changing execution identity", () => {
+    const body = createCommentBody(
+      "job",
+      "",
+      "review_and_security",
+      DroidRunType.Review,
+    );
+    expect(body).toEndWith(
+      "<!-- factory-pr-issue-comment: run-type=droid-review-and-security -->",
+    );
+  });
+
+  it.each([
+    [DroidRunType.Review, DroidRunType.SecurityReview],
+    [DroidRunType.SecurityReview, DroidRunType.Review],
+    [DroidRunType.Default, DroidRunType.SecurityReview],
+    [DroidRunType.SecurityReview, DroidRunType.Default],
+    [COMBINED_REVIEW_COMMENT_RUN_TYPE, DroidRunType.Review],
+    [COMBINED_REVIEW_COMMENT_RUN_TYPE, DroidRunType.SecurityReview],
+  ] as const)("merges stored %s with current %s", (previous, current) => {
+    const body = prepareDroidTrackingCommentBody(
+      "New progress",
+      createPrCommentMarker("issue-comment", previous),
+      current,
+    );
+    expect(body).toBe(
+      "New progress\n\n<!-- factory-pr-issue-comment: run-type=droid-review-and-security -->",
+    );
+  });
+
+  it("ignores classification supplied in replacement content", () => {
+    const body = prepareDroidTrackingCommentBody(
+      `Model output\n\n${createPrCommentMarker("issue-comment", COMBINED_REVIEW_COMMENT_RUN_TYPE)}`,
+      createPrCommentMarker("issue-comment", DroidRunType.Review),
+      DroidRunType.Review,
+    );
+    expect(body).toBe(
+      "Model output\n\n<!-- factory-pr-issue-comment: run-type=droid-review -->",
+    );
+  });
+
+  it("reads only supported markers for the requested comment surface", () => {
+    expect(
+      readPrCommentRunType(
+        "<!-- factory-pr-issue-comment: run-type=unknown -->",
+        "issue-comment",
+      ),
+    ).toBeUndefined();
+    expect(
+      readPrCommentRunType(
+        createPrCommentMarker("inline-comment", DroidRunType.SecurityReview),
+        "issue-comment",
+      ),
+    ).toBeUndefined();
+    expect(
+      readPrCommentRunType(
+        [
+          createPrCommentMarker("issue-comment", DroidRunType.SecurityReview),
+          createPrCommentMarker("issue-comment", DroidRunType.Review),
+        ].join("\n"),
+        "issue-comment",
+      ),
+    ).toBe(DroidRunType.Review);
+    expect(
+      readPrCommentRunType(
+        `\`\`\`html\n${createPrCommentMarker("issue-comment", DroidRunType.SecurityReview)}\n\`\`\``,
+        "issue-comment",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not combine inline findings using model-provided markers", () => {
+    expect(
+      prepareDroidCommentBody(
+        `Finding\n\n${createPrCommentMarker("inline-comment", DroidRunType.SecurityReview)}`,
+        DroidRunType.Review,
+        "inline-comment",
+      ),
+    ).toBe(
+      "Finding\n\n<!-- factory-pr-inline-comment: run-type=droid-review -->",
+    );
   });
 });

--- a/test/github/create-initial-comment.test.ts
+++ b/test/github/create-initial-comment.test.ts
@@ -1,0 +1,103 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import * as core from "@actions/core";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createInitialComment } from "../../src/github/operations/comments/create-initial";
+import { DroidRunType } from "../../src/run-type";
+import { mockPullRequestReviewCommentContext } from "../mockContext";
+
+describe("createInitialComment", () => {
+  const originalGitHubOutput = process.env.GITHUB_OUTPUT;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "droid-initial-comment-"));
+    process.env.GITHUB_OUTPUT = join(tempDir, "github-output");
+    spyOn(core, "exportVariable").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mock.restore();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalGitHubOutput === undefined) {
+      delete process.env.GITHUB_OUTPUT;
+    } else {
+      process.env.GITHUB_OUTPUT = originalGitHubOutput;
+    }
+  });
+
+  it("records an inline tracking comment when the reply succeeds", async () => {
+    const replyBodies: string[] = [];
+    const octokit = {
+      rest: {
+        pulls: {
+          createReplyForReviewComment: async ({ body }: { body: string }) => {
+            replyBodies.push(body);
+            return { data: { id: 123 } };
+          },
+        },
+        issues: {
+          createComment: async () => ({ data: { id: 456 } }),
+        },
+      },
+    };
+
+    await createInitialComment(
+      octokit as any,
+      mockPullRequestReviewCommentContext,
+      "security",
+      DroidRunType.SecurityReview,
+    );
+
+    expect(replyBodies[0]).toContain(
+      "<!-- factory-pr-inline-comment: run-type=droid-security-review -->",
+    );
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      "DROID_PR_COMMENT_KIND",
+      "inline-comment",
+    );
+  });
+
+  it("records an issue tracking comment when the inline reply falls back", async () => {
+    const issueBodies: string[] = [];
+    const octokit = {
+      rest: {
+        pulls: {
+          createReplyForReviewComment: async () => {
+            throw new Error("reply failed");
+          },
+        },
+        issues: {
+          createComment: async ({ body }: { body: string }) => {
+            issueBodies.push(body);
+            return { data: { id: 456 } };
+          },
+        },
+      },
+    };
+
+    await createInitialComment(
+      octokit as any,
+      mockPullRequestReviewCommentContext,
+      "security",
+      DroidRunType.SecurityReview,
+    );
+
+    expect(issueBodies[0]).toContain(
+      "<!-- factory-pr-issue-comment: run-type=droid-security-review -->",
+    );
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      "DROID_PR_COMMENT_KIND",
+      "issue-comment",
+    );
+  });
+});

--- a/test/github/create-initial-comment.test.ts
+++ b/test/github/create-initial-comment.test.ts
@@ -13,7 +13,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { createInitialComment } from "../../src/github/operations/comments/create-initial";
 import { DroidRunType } from "../../src/run-type";
-import { mockPullRequestReviewCommentContext } from "../mockContext";
+import {
+  createMockContext,
+  mockPullRequestReviewCommentContext,
+} from "../mockContext";
+import {
+  COMBINED_REVIEW_COMMENT_RUN_TYPE,
+  createPrCommentMarker,
+} from "../../src/github/operations/comments/common";
 
 describe("createInitialComment", () => {
   const originalGitHubOutput = process.env.GITHUB_OUTPUT;
@@ -98,6 +105,76 @@ describe("createInitialComment", () => {
     expect(core.exportVariable).toHaveBeenCalledWith(
       "DROID_PR_COMMENT_KIND",
       "issue-comment",
+    );
+  });
+
+  it.each([
+    [DroidRunType.Review, DroidRunType.SecurityReview],
+    [DroidRunType.SecurityReview, DroidRunType.Review],
+    [COMBINED_REVIEW_COMMENT_RUN_TYPE, DroidRunType.SecurityReview],
+    [COMBINED_REVIEW_COMMENT_RUN_TYPE, DroidRunType.Review],
+  ] as const)(
+    "preserves both reviews when sticky %s is reused by %s",
+    async (previous, current) => {
+      const updateComment = mock(async (_params: unknown) => ({
+        data: { id: 123 },
+      }));
+      const createComment = mock(async () => ({ data: { id: 456 } }));
+      const octokit = {
+        rest: {
+          issues: {
+            listComments: async () => ({
+              data: [
+                {
+                  id: 123,
+                  user: { id: 209825114 },
+                  body: createPrCommentMarker("issue-comment", previous),
+                },
+              ],
+            }),
+            updateComment,
+            createComment,
+          },
+        },
+      };
+      await createInitialComment(
+        octokit as any,
+        createMockContext({
+          eventName: "pull_request",
+          isPR: true,
+          inputs: { useStickyComment: true },
+        }),
+        current === DroidRunType.SecurityReview ? "security" : "default",
+        current,
+      );
+      expect(updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          comment_id: 123,
+          body: expect.stringContaining(
+            "<!-- factory-pr-issue-comment: run-type=droid-review-and-security -->",
+          ),
+        }),
+      );
+      expect(createComment).not.toHaveBeenCalled();
+    },
+  );
+
+  it("creates a combined marker before either review updates the comment", async () => {
+    const createComment = mock(async (_params: unknown) => ({
+      data: { id: 123 },
+    }));
+    await createInitialComment(
+      { rest: { issues: { createComment } } } as any,
+      createMockContext({ eventName: "pull_request", isPR: true }),
+      "review_and_security",
+      DroidRunType.Review,
+    );
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "<!-- factory-pr-issue-comment: run-type=droid-review-and-security -->",
+        ),
+      }),
     );
   });
 });

--- a/test/github/update-tracking-comment.test.ts
+++ b/test/github/update-tracking-comment.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, mock } from "bun:test";
+import { updateDroidTrackingComment } from "../../src/github/operations/comments/update-tracking-comment";
+import {
+  COMBINED_REVIEW_COMMENT_RUN_TYPE,
+  createPrCommentMarker,
+  type PrCommentKind,
+} from "../../src/github/operations/comments/common";
+import { DroidRunType } from "../../src/run-type";
+
+const combinedMarker = createPrCommentMarker(
+  "issue-comment",
+  COMBINED_REVIEW_COMMENT_RUN_TYPE,
+);
+const params = {
+  owner: "o",
+  repo: "r",
+  commentId: 123,
+  isPullRequestReviewComment: false,
+};
+
+function storedComment(body: string, kind: PrCommentKind = "issue-comment") {
+  let currentBody = body;
+  const read = mock(async () => ({ data: { body: currentBody } }));
+  const missing = mock(async () => {
+    throw Object.assign(new Error("Not found"), { status: 404 });
+  });
+  const write = mock(async (input: { body: string; comment_id: number }) => {
+    expect(input.comment_id).toBe(123);
+    currentBody = input.body;
+    return {
+      data: {
+        id: 123,
+        html_url: "https://github.com/o/r/pull/1",
+        updated_at: "",
+      },
+    };
+  });
+  const issues = {
+    getComment: kind === "issue-comment" ? read : missing,
+    updateComment: write,
+  };
+  const pulls = {
+    getReviewComment: kind === "inline-comment" ? read : missing,
+    updateReviewComment: write,
+  };
+  return {
+    client: { rest: { issues, pulls, rest: { issues, pulls } } } as any,
+    read,
+    write,
+    body: () => currentBody,
+  };
+}
+
+describe("updateDroidTrackingComment", () => {
+  it.each([
+    [DroidRunType.Review, DroidRunType.SecurityReview],
+    [DroidRunType.SecurityReview, DroidRunType.Review],
+  ] as const)(
+    "combines %s and %s updates on the same comment",
+    async (first, second) => {
+      const stored = storedComment(
+        createPrCommentMarker("issue-comment", first),
+      );
+      for (const runType of [second, first, second]) {
+        await updateDroidTrackingComment(stored.client, {
+          ...params,
+          body: `Progress from ${runType}`,
+          runType,
+        });
+        expect(stored.body()).toEndWith(combinedMarker);
+        expect(
+          stored.body().match(/<!-- factory-pr-issue-comment:/g),
+        ).toHaveLength(1);
+      }
+      expect(stored.read).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("keeps the planned combined scope for concurrent review updates", async () => {
+    const stored = storedComment(combinedMarker);
+    await Promise.all(
+      ([DroidRunType.Review, DroidRunType.SecurityReview] as const).map(
+        (runType) =>
+          updateDroidTrackingComment(stored.client, {
+            ...params,
+            body: "Progress",
+            runType,
+          }),
+      ),
+    );
+    expect(stored.write).toHaveBeenCalledTimes(2);
+    for (const [payload] of stored.write.mock.calls) {
+      expect(payload.body).toEndWith(combinedMarker);
+    }
+  });
+
+  it("preserves stored classification when the run type is unresolved", async () => {
+    const stored = storedComment(combinedMarker);
+    await updateDroidTrackingComment(stored.client, {
+      ...params,
+      body: "Progress",
+    });
+    expect(stored.body()).toEndWith(combinedMarker);
+  });
+
+  it("does not accept a combined marker supplied by the model", async () => {
+    const marker = createPrCommentMarker("issue-comment", DroidRunType.Review);
+    const stored = storedComment(marker);
+    await updateDroidTrackingComment(stored.client, {
+      ...params,
+      body: `Progress\n\n${combinedMarker}`,
+      runType: DroidRunType.Review,
+    });
+    expect(stored.body()).toBe(`Progress\n\n${marker}`);
+  });
+
+  it("uses the actual issue surface when inline tracking fell back", async () => {
+    const stored = storedComment(combinedMarker);
+    await updateDroidTrackingComment(stored.client, {
+      ...params,
+      isPullRequestReviewComment: true,
+      body: "Progress",
+      runType: DroidRunType.SecurityReview,
+    });
+    expect(stored.body()).toEndWith(combinedMarker);
+    expect(stored.body()).not.toContain("factory-pr-inline-comment");
+  });
+
+  it("preserves the actual inline surface for tracking replies", async () => {
+    const marker = createPrCommentMarker(
+      "inline-comment",
+      COMBINED_REVIEW_COMMENT_RUN_TYPE,
+    );
+    const stored = storedComment(marker, "inline-comment");
+    await updateDroidTrackingComment(stored.client, {
+      ...params,
+      isPullRequestReviewComment: true,
+      body: "Progress",
+      runType: DroidRunType.Review,
+    });
+    expect(stored.body()).toEndWith(marker);
+    expect(stored.body()).not.toContain("factory-pr-issue-comment");
+  });
+
+  it("does not write if the existing tracking comment cannot be read", async () => {
+    const write = mock(async () => ({ data: { id: 123 } }));
+    const fail = async () => {
+      throw new Error("Read failed");
+    };
+    const client = {
+      rest: {
+        issues: { getComment: fail },
+        pulls: { getReviewComment: fail },
+        rest: { issues: { updateComment: write } },
+      },
+    } as any;
+    await expect(
+      updateDroidTrackingComment(client, {
+        ...params,
+        body: "Progress",
+        runType: DroidRunType.SecurityReview,
+      }),
+    ).rejects.toThrow("Read failed");
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -243,6 +243,91 @@ describe("review command integration", () => {
     expect(runSecurityReviewCall?.[1]).toBe("false");
   });
 
+  it("uses the default run type for a bare @droid command", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 888,
+          body: "@droid",
+          user: { login: "human-reviewer" },
+          created_at: "2024-02-02T00:00:00Z",
+        },
+        issue: {
+          number: 7,
+          pull_request: {},
+        },
+      } as any,
+    });
+    const octokit = createAutomaticReviewOctokit(false);
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBeFalsy();
+    expect(exportVarSpy).toHaveBeenCalledWith(
+      "DROID_EXEC_RUN_TYPE",
+      DroidRunType.Default,
+    );
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "default",
+      DroidRunType.Default,
+    );
+    expect(mcpSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runType: DroidRunType.Default }),
+    );
+  });
+
+  it("keeps the run type null when no command is parsed", async () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      inputs: {
+        triggerPhrase: "/droid",
+      },
+      payload: {
+        comment: {
+          id: 888,
+          body: "/droid",
+          user: { login: "human-reviewer" },
+          created_at: "2024-02-02T00:00:00Z",
+        },
+        issue: {
+          number: 7,
+          pull_request: {},
+        },
+      } as any,
+    });
+    const octokit = createAutomaticReviewOctokit(false);
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBeFalsy();
+    expect(exportVarSpy).not.toHaveBeenCalledWith(
+      "DROID_EXEC_RUN_TYPE",
+      expect.anything(),
+    );
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "default",
+      null,
+    );
+    expect(mcpSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runType: null }),
+    );
+  });
+
   it("sets security flag only for @droid security", async () => {
     const context = createMockContext({
       eventName: "issue_comment",

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -27,6 +27,70 @@ describe("review command integration", () => {
   let computeArtifactsSpy: ReturnType<typeof spyOn>;
   let execSyncSpy: ReturnType<typeof spyOn>;
 
+  function createAutomaticReviewContext(automaticReview: boolean) {
+    return createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      inputs: {
+        automaticReview,
+        automaticSecurityReview: true,
+      },
+      payload: {
+        comment: {
+          id: 888,
+          body: "",
+          user: { login: "human-reviewer" },
+          created_at: "2024-02-02T00:00:00Z",
+        },
+        issue: {
+          number: 7,
+          pull_request: {},
+        },
+      } as any,
+    });
+  }
+
+  function createAutomaticReviewOctokit(hasExistingSecurityReview: boolean) {
+    const octokit = {
+      rest: {
+        issues: {
+          listComments: () =>
+            Promise.resolve({
+              data: hasExistingSecurityReview
+                ? [
+                    {
+                      user: { id: 209825114, login: "factory-droid[bot]" },
+                      body: "## Security Review Summary",
+                    },
+                  ]
+                : [],
+            }),
+        },
+      },
+      graphql: () =>
+        Promise.resolve({
+          repository: {
+            pullRequest: {
+              baseRefName: "main",
+              headRefName: "feature/review",
+              headRefOid: "def456",
+            },
+          },
+        }),
+    } as any;
+
+    graphqlSpy = spyOn(octokit, "graphql").mockResolvedValue({
+      repository: {
+        pullRequest: {
+          baseRefName: "main",
+          headRefName: "feature/review",
+          headRefOid: "def456",
+        },
+      },
+    });
+    return octokit;
+  }
+
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "review-int-"));
     process.env.RUNNER_TEMP = tmpDir;
@@ -259,5 +323,79 @@ describe("review command integration", () => {
     // Standalone security now uses two-pass pipeline (candidates + validator)
     expect(runCodeReviewCall?.[1]).toBe("true");
     expect(runSecurityReviewCall?.[1]).toBe("true");
+  });
+
+  it("does not create a comment when automatic security review is skipped", async () => {
+    const context = createAutomaticReviewContext(false);
+    const octokit = createAutomaticReviewOctokit(true);
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result).toEqual({
+      skipped: true,
+      reason: "security_review_exists",
+      branchInfo: {
+        baseBranch: "",
+        currentBranch: "",
+      },
+      mcpTools: "",
+    });
+    expect(createCommentSpy).not.toHaveBeenCalled();
+    expect(setOutputSpy).toHaveBeenCalledWith("run_code_review", "false");
+    expect(setOutputSpy).toHaveBeenCalledWith("run_security_review", "false");
+  });
+
+  it("creates a review-only comment when automatic security is skipped", async () => {
+    const context = createAutomaticReviewContext(true);
+    const octokit = createAutomaticReviewOctokit(true);
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBeFalsy();
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "default",
+      DroidRunType.Review,
+    );
+    expect(setOutputSpy).toHaveBeenCalledWith("run_code_review", "true");
+    expect(setOutputSpy).toHaveBeenCalledWith("run_security_review", "false");
+    expect(exportVarSpy).not.toHaveBeenCalledWith(
+      "SECURITY_REVIEW_ENABLED",
+      "true",
+    );
+  });
+
+  it("creates a combined comment when both automatic reviews will run", async () => {
+    const context = createAutomaticReviewContext(true);
+    const octokit = createAutomaticReviewOctokit(false);
+
+    const result = await prepareTagExecution({
+      context,
+      octokit,
+      githubToken: "token",
+    });
+
+    expect(result.skipped).toBeFalsy();
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "review_and_security",
+      DroidRunType.Review,
+    );
+    expect(setOutputSpy).toHaveBeenCalledWith("run_code_review", "true");
+    expect(setOutputSpy).toHaveBeenCalledWith("run_security_review", "true");
+    expect(exportVarSpy).toHaveBeenCalledWith(
+      "SECURITY_REVIEW_ENABLED",
+      "true",
+    );
   });
 });

--- a/test/integration/review-flow.test.ts
+++ b/test/integration/review-flow.test.ts
@@ -11,6 +11,7 @@ import * as promptModule from "../../src/create-prompt";
 import * as reviewArtifactsModule from "../../src/github/data/review-artifacts";
 import * as core from "@actions/core";
 import * as childProcess from "node:child_process";
+import { DroidRunType } from "../../src/run-type";
 
 describe("review command integration", () => {
   const originalRunnerTemp = process.env.RUNNER_TEMP;
@@ -155,6 +156,16 @@ describe("review command integration", () => {
     expect(result.branchInfo.baseBranch).toBe("main");
     expect(result.branchInfo.currentBranch).toBe("feature/review");
     expect(promptSpy).toHaveBeenCalled();
+    expect(exportVarSpy).toHaveBeenCalledWith(
+      "DROID_EXEC_RUN_TYPE",
+      DroidRunType.Review,
+    );
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "default",
+      DroidRunType.Review,
+    );
 
     // Verify output flags were set correctly for code review only
     const runCodeReviewCall = setOutputSpy.mock.calls.find(
@@ -227,6 +238,16 @@ describe("review command integration", () => {
     expect(result.branchInfo.baseBranch).toBe("main");
     expect(result.branchInfo.currentBranch).toBe("feature/security");
     expect(promptSpy).toHaveBeenCalled();
+    expect(exportVarSpy).toHaveBeenCalledWith(
+      "DROID_EXEC_RUN_TYPE",
+      DroidRunType.SecurityReview,
+    );
+    expect(createCommentSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "security",
+      DroidRunType.SecurityReview,
+    );
 
     const runCodeReviewCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "run_code_review",

--- a/test/mcp/github-pr-server.test.ts
+++ b/test/mcp/github-pr-server.test.ts
@@ -13,6 +13,7 @@ import {
   type OctokitLike,
   type ReviewComment,
 } from "../../src/mcp/github-pr-server";
+import { DroidRunType } from "../../src/run-type";
 
 function createOctokitStub() {
   const calls = {
@@ -172,6 +173,35 @@ describe("github-pr-server helpers", () => {
       comments: [{ path: "file.ts", position: 3, body: "issue" }],
     });
     expect(reviewId).toBe(9001);
+  });
+
+  it("adds the run type marker to batched inline comments", async () => {
+    const { client, calls } = createOctokitStub();
+
+    await submitReviewWithComments({
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [
+        {
+          path: "file.ts",
+          position: 3,
+          body: "[P1] [security] issue",
+        },
+      ],
+      runType: DroidRunType.SecurityReview,
+      octokit: client,
+    });
+
+    expect(calls.createReview[0][0].comments).toEqual([
+      {
+        path: "file.ts",
+        position: 3,
+        body:
+          "[P1] [security] issue\n\n" +
+          "<!-- factory-pr-inline-comment: run-type=droid-security-review -->",
+      },
+    ]);
   });
 
   it("deletes issue and review comments", async () => {

--- a/test/mcp/install-mcp-server.test.ts
+++ b/test/mcp/install-mcp-server.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { prepareMcpTools } from "../../src/mcp/install-mcp-server";
+import { createMockContext } from "../mockContext";
+
+describe("prepareMcpTools", () => {
+  it("passes the PR review marker flag to the comment server", async () => {
+    const config = JSON.parse(
+      await prepareMcpTools({
+        githubToken: "token",
+        owner: "factory",
+        repo: "droid",
+        droidCommentId: "123",
+        includePrReviewMarker: true,
+        allowedTools: ["github_comment___update_droid_comment"],
+        mode: "tag",
+        context: createMockContext({ isPR: true }),
+      }),
+    );
+
+    expect(config.mcpServers.github_comment.env.DROID_PR_REVIEW_MARKER).toBe(
+      "true",
+    );
+  });
+});

--- a/test/mcp/install-mcp-server.test.ts
+++ b/test/mcp/install-mcp-server.test.ts
@@ -1,24 +1,25 @@
 import { describe, expect, it } from "bun:test";
 import { prepareMcpTools } from "../../src/mcp/install-mcp-server";
 import { createMockContext } from "../mockContext";
+import { DroidRunType } from "../../src/run-type";
 
 describe("prepareMcpTools", () => {
-  it("passes the PR validation source to the comment server", async () => {
+  it("passes the run type to the comment server", async () => {
     const config = JSON.parse(
       await prepareMcpTools({
         githubToken: "token",
         owner: "factory",
         repo: "droid",
         droidCommentId: "123",
-        prValidationSource: "review",
+        runType: DroidRunType.Review,
         allowedTools: ["github_comment___update_droid_comment"],
         mode: "tag",
         context: createMockContext({ isPR: true }),
       }),
     );
 
-    expect(
-      config.mcpServers.github_comment.env.DROID_PR_VALIDATION_SOURCE,
-    ).toBe("review");
+    expect(config.mcpServers.github_comment.env.DROID_EXEC_RUN_TYPE).toBe(
+      DroidRunType.Review,
+    );
   });
 });

--- a/test/mcp/install-mcp-server.test.ts
+++ b/test/mcp/install-mcp-server.test.ts
@@ -3,22 +3,22 @@ import { prepareMcpTools } from "../../src/mcp/install-mcp-server";
 import { createMockContext } from "../mockContext";
 
 describe("prepareMcpTools", () => {
-  it("passes the PR review marker flag to the comment server", async () => {
+  it("passes the PR validation source to the comment server", async () => {
     const config = JSON.parse(
       await prepareMcpTools({
         githubToken: "token",
         owner: "factory",
         repo: "droid",
         droidCommentId: "123",
-        includePrReviewMarker: true,
+        prValidationSource: "review",
         allowedTools: ["github_comment___update_droid_comment"],
         mode: "tag",
         context: createMockContext({ isPR: true }),
       }),
     );
 
-    expect(config.mcpServers.github_comment.env.DROID_PR_REVIEW_MARKER).toBe(
-      "true",
-    );
+    expect(
+      config.mcpServers.github_comment.env.DROID_PR_VALIDATION_SOURCE,
+    ).toBe("review");
   });
 });

--- a/test/mcp/install-mcp-server.test.ts
+++ b/test/mcp/install-mcp-server.test.ts
@@ -22,4 +22,23 @@ describe("prepareMcpTools", () => {
       DroidRunType.Review,
     );
   });
+
+  it("omits the run type from the comment server when unresolved", async () => {
+    const config = JSON.parse(
+      await prepareMcpTools({
+        githubToken: "token",
+        owner: "factory",
+        repo: "droid",
+        droidCommentId: "123",
+        runType: null,
+        allowedTools: ["github_comment___update_droid_comment"],
+        mode: "tag",
+        context: createMockContext({ isPR: true }),
+      }),
+    );
+
+    expect(config.mcpServers.github_comment.env).not.toHaveProperty(
+      "DROID_EXEC_RUN_TYPE",
+    );
+  });
 });

--- a/test/mcp/install-mcp-server.test.ts
+++ b/test/mcp/install-mcp-server.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { prepareMcpTools } from "../../src/mcp/install-mcp-server";
 import { createMockContext } from "../mockContext";
 import { DroidRunType } from "../../src/run-type";
 
 describe("prepareMcpTools", () => {
+  const originalPrCommentKind = process.env.DROID_PR_COMMENT_KIND;
+
+  afterEach(() => {
+    if (originalPrCommentKind === undefined) {
+      delete process.env.DROID_PR_COMMENT_KIND;
+    } else {
+      process.env.DROID_PR_COMMENT_KIND = originalPrCommentKind;
+    }
+  });
+
   it("passes the run type to the comment server", async () => {
     const config = JSON.parse(
       await prepareMcpTools({
@@ -20,6 +30,55 @@ describe("prepareMcpTools", () => {
 
     expect(config.mcpServers.github_comment.env.DROID_EXEC_RUN_TYPE).toBe(
       DroidRunType.Review,
+    );
+  });
+
+  it("passes the run type to inline comment servers", async () => {
+    const config = JSON.parse(
+      await prepareMcpTools({
+        githubToken: "token",
+        owner: "factory",
+        repo: "droid",
+        droidCommentId: "123",
+        runType: DroidRunType.SecurityReview,
+        allowedTools: [
+          "github_inline_comment___create_inline_comment",
+          "github_pr___submit_review",
+        ],
+        mode: "tag",
+        context: createMockContext({ isPR: true }),
+      }),
+    );
+
+    expect(
+      config.mcpServers.github_inline_comment.env.DROID_EXEC_RUN_TYPE,
+    ).toBe(DroidRunType.SecurityReview);
+    expect(config.mcpServers.github_pr.env.DROID_EXEC_RUN_TYPE).toBe(
+      DroidRunType.SecurityReview,
+    );
+  });
+
+  it("passes the actual tracking comment kind to the comment server", async () => {
+    process.env.DROID_PR_COMMENT_KIND = "issue-comment";
+
+    const config = JSON.parse(
+      await prepareMcpTools({
+        githubToken: "token",
+        owner: "factory",
+        repo: "droid",
+        droidCommentId: "123",
+        runType: DroidRunType.SecurityReview,
+        allowedTools: ["github_comment___update_droid_comment"],
+        mode: "tag",
+        context: createMockContext({
+          isPR: true,
+          eventName: "pull_request_review_comment",
+        }),
+      }),
+    );
+
+    expect(config.mcpServers.github_comment.env.DROID_PR_COMMENT_KIND).toBe(
+      "issue-comment",
     );
   });
 

--- a/test/modes/tag/fill-command.test.ts
+++ b/test/modes/tag/fill-command.test.ts
@@ -5,6 +5,7 @@ import { createMockContext } from "../../mockContext";
 import * as prFetcher from "../../../src/github/data/pr-fetcher";
 import * as promptModule from "../../../src/create-prompt";
 import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
+import { DroidRunType } from "../../../src/run-type";
 
 const MOCK_PR_DATA = {
   title: "Test PR",
@@ -98,6 +99,7 @@ describe("prepareFillMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        runType: DroidRunType.Fill,
         allowedTools: expect.arrayContaining([
           "github_pr___update_pr_description",
         ]),
@@ -112,10 +114,6 @@ describe("prepareFillMode", () => {
     ) as [string, string] | undefined;
     expect(droidArgsCall?.[1]).toContain("github_pr___update_pr_description");
     expect(droidArgsCall?.[1]).toContain("Execute");
-    expect(exportVariableSpy).toHaveBeenCalledWith(
-      "DROID_EXEC_RUN_TYPE",
-      "droid-fill",
-    );
   });
 
   it("throws when invoked on non-PR context", async () => {

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -156,6 +156,7 @@ describe("prepareReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        includePrReviewMarker: true,
         allowedTools: expect.arrayContaining([
           "Execute",
           "github_comment___update_droid_comment",
@@ -243,7 +244,11 @@ describe("prepareReviewMode", () => {
       githubToken: "token",
     });
 
-    expect(createInitialSpy).toHaveBeenCalled();
+    expect(createInitialSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "review",
+    );
     expect(result.commentId).toBe(777);
   });
 

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -156,7 +156,7 @@ describe("prepareReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        includePrReviewMarker: true,
+        prValidationSource: "review",
         allowedTools: expect.arrayContaining([
           "Execute",
           "github_comment___update_droid_comment",

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -8,6 +8,7 @@ import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
 import * as comments from "../../../src/github/operations/comments/create-initial";
 import * as childProcess from "child_process";
 import * as fsPromises from "fs/promises";
+import { DroidRunType } from "../../../src/run-type";
 
 const MOCK_PR_DATA = {
   title: "PR for review",
@@ -156,7 +157,7 @@ describe("prepareReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        prValidationSource: "review",
+        runType: DroidRunType.Review,
         allowedTools: expect.arrayContaining([
           "Execute",
           "github_comment___update_droid_comment",
@@ -184,10 +185,6 @@ describe("prepareReviewMode", () => {
       "github_inline_comment___create_inline_comment",
     );
     expect(droidArgsCall?.[1]).not.toContain("github_pr___submit_review");
-    expect(exportVariableSpy).toHaveBeenCalledWith(
-      "DROID_EXEC_RUN_TYPE",
-      "droid-review",
-    );
   });
 
   it("creates tracking comment when not provided", async () => {
@@ -247,7 +244,8 @@ describe("prepareReviewMode", () => {
     expect(createInitialSpy).toHaveBeenCalledWith(
       octokit.rest,
       context,
-      "review",
+      "default",
+      DroidRunType.Review,
     );
     expect(result.commentId).toBe(777);
   });

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -16,6 +16,7 @@ import * as reviewArtifacts from "../../../src/github/data/review-artifacts";
 import * as promptModule from "../../../src/create-prompt";
 import * as mcpInstaller from "../../../src/mcp/install-mcp-server";
 import * as comments from "../../../src/github/operations/comments/create-initial";
+import { DroidRunType } from "../../../src/run-type";
 
 const MOCK_PR_DATA = {
   baseRefName: "main",
@@ -147,7 +148,7 @@ describe("prepareSecurityReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        prValidationSource: "review",
+        runType: DroidRunType.SecurityReview,
         allowedTools: expect.arrayContaining([
           "Execute",
           "Task",
@@ -169,11 +170,6 @@ describe("prepareSecurityReviewMode", () => {
     expect(result.branchInfo.baseBranch).toBe("main");
     expect(result.branchInfo.currentBranch).toBe("feature/security-review");
     expect(result.branchInfo.droidBranch).toBeUndefined();
-
-    expect(exportVariableSpy).toHaveBeenCalledWith(
-      "DROID_EXEC_RUN_TYPE",
-      "droid-security-review",
-    );
   });
 
   it("creates tracking comment when not provided", async () => {
@@ -201,6 +197,7 @@ describe("prepareSecurityReviewMode", () => {
       octokit.rest,
       context,
       "security",
+      DroidRunType.SecurityReview,
     );
     expect(result.commentId).toBe(777);
   });

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -147,7 +147,7 @@ describe("prepareSecurityReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        includePrReviewMarker: true,
+        prValidationSource: "review",
         allowedTools: expect.arrayContaining([
           "Execute",
           "Task",

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -147,6 +147,7 @@ describe("prepareSecurityReviewMode", () => {
     expect(promptSpy).toHaveBeenCalled();
     expect(mcpSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        includePrReviewMarker: true,
         allowedTools: expect.arrayContaining([
           "Execute",
           "Task",
@@ -196,7 +197,11 @@ describe("prepareSecurityReviewMode", () => {
       githubToken: "token",
     });
 
-    expect(createInitialSpy).toHaveBeenCalled();
+    expect(createInitialSpy).toHaveBeenCalledWith(
+      octokit.rest,
+      context,
+      "security",
+    );
     expect(result.commentId).toBe(777);
   });
 

--- a/test/run-type.test.ts
+++ b/test/run-type.test.ts
@@ -13,8 +13,8 @@ describe("DroidRunType", () => {
     [true, false, null, DroidRunType.Review],
     [false, true, null, DroidRunType.SecurityReview],
     [false, false, "review", DroidRunType.Review],
-    [false, false, "default", DroidRunType.Review],
-    [false, false, null, DroidRunType.Review],
+    [false, false, "default", DroidRunType.Default],
+    [false, false, null, null],
     [false, false, "security", DroidRunType.SecurityReview],
     [false, false, "security-full", DroidRunType.SecurityScan],
     [false, false, "fill", DroidRunType.Fill],
@@ -32,6 +32,7 @@ describe("DroidRunType", () => {
   );
 
   it("parses only known run types", () => {
+    expect(parseDroidRunType(DroidRunType.Default)).toBe(DroidRunType.Default);
     expect(parseDroidRunType(DroidRunType.Review)).toBe(DroidRunType.Review);
     expect(parseDroidRunType("unknown")).toBeUndefined();
   });
@@ -43,6 +44,9 @@ describe("DroidRunType", () => {
   });
 
   it("selects the run types that produce PR validation markers", () => {
+    expect(getPrValidationRunType(DroidRunType.Default)).toBe(
+      DroidRunType.Default,
+    );
     expect(getPrValidationRunType(DroidRunType.Review)).toBe(
       DroidRunType.Review,
     );

--- a/test/run-type.test.ts
+++ b/test/run-type.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   assertDroidRunType,
   DroidRunType,
+  getPrValidationRunType,
   parseDroidRunType,
-  prValidationSourceForRunType,
   resolveTagRunType,
 } from "../src/run-type";
 
@@ -42,17 +42,17 @@ describe("DroidRunType", () => {
     ).toThrow("Expected run type droid-review, received droid-fill");
   });
 
-  it("maps PR review run types to the review validation source", () => {
-    expect(prValidationSourceForRunType(DroidRunType.Review)).toBe("review");
-    expect(prValidationSourceForRunType(DroidRunType.SecurityReview)).toBe(
-      "review",
+  it("selects the run types that produce PR validation markers", () => {
+    expect(getPrValidationRunType(DroidRunType.Review)).toBe(
+      DroidRunType.Review,
     );
-    expect(prValidationSourceForRunType(DroidRunType.Fill)).toBeUndefined();
-    expect(
-      prValidationSourceForRunType(DroidRunType.SecurityScan),
-    ).toBeUndefined();
-    expect(
-      prValidationSourceForRunType(DroidRunType.CiSteward),
-    ).toBeUndefined();
+    expect(getPrValidationRunType(DroidRunType.SecurityReview)).toBe(
+      DroidRunType.SecurityReview,
+    );
+    expect(getPrValidationRunType(DroidRunType.SecurityScan)).toBe(
+      DroidRunType.SecurityScan,
+    );
+    expect(getPrValidationRunType(DroidRunType.Fill)).toBeUndefined();
+    expect(getPrValidationRunType(DroidRunType.CiSteward)).toBeUndefined();
   });
 });

--- a/test/run-type.test.ts
+++ b/test/run-type.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertDroidRunType,
+  DroidRunType,
+  parseDroidRunType,
+  prValidationSourceForRunType,
+  resolveTagRunType,
+} from "../src/run-type";
+
+describe("DroidRunType", () => {
+  it.each([
+    [true, true, null, DroidRunType.Review],
+    [true, false, null, DroidRunType.Review],
+    [false, true, null, DroidRunType.SecurityReview],
+    [false, false, "review", DroidRunType.Review],
+    [false, false, "default", DroidRunType.Review],
+    [false, false, null, DroidRunType.Review],
+    [false, false, "security", DroidRunType.SecurityReview],
+    [false, false, "security-full", DroidRunType.SecurityScan],
+    [false, false, "fill", DroidRunType.Fill],
+  ] as const)(
+    "resolves automaticReview=%s automaticSecurityReview=%s command=%s",
+    (automaticReview, automaticSecurityReview, command, expected) => {
+      expect(
+        resolveTagRunType({
+          automaticReview,
+          automaticSecurityReview,
+          command,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("parses only known run types", () => {
+    expect(parseDroidRunType(DroidRunType.Review)).toBe(DroidRunType.Review);
+    expect(parseDroidRunType("unknown")).toBeUndefined();
+  });
+
+  it("rejects a run type passed to the wrong mode", () => {
+    expect(() =>
+      assertDroidRunType(DroidRunType.Fill, DroidRunType.Review),
+    ).toThrow("Expected run type droid-review, received droid-fill");
+  });
+
+  it("maps PR review run types to the review validation source", () => {
+    expect(prValidationSourceForRunType(DroidRunType.Review)).toBe("review");
+    expect(prValidationSourceForRunType(DroidRunType.SecurityReview)).toBe(
+      "review",
+    );
+    expect(prValidationSourceForRunType(DroidRunType.Fill)).toBeUndefined();
+    expect(
+      prValidationSourceForRunType(DroidRunType.SecurityScan),
+    ).toBeUndefined();
+    expect(
+      prValidationSourceForRunType(DroidRunType.CiSteward),
+    ).toBeUndefined();
+  });
+});

--- a/test/run-type.test.ts
+++ b/test/run-type.test.ts
@@ -4,6 +4,7 @@ import {
   DroidRunType,
   getPrValidationRunType,
   parseDroidRunType,
+  parsePrValidationRunType,
   resolveTagRunType,
 } from "../src/run-type";
 
@@ -58,5 +59,16 @@ describe("DroidRunType", () => {
     );
     expect(getPrValidationRunType(DroidRunType.Fill)).toBeUndefined();
     expect(getPrValidationRunType(DroidRunType.CiSteward)).toBeUndefined();
+  });
+
+  it("parses and narrows PR validation run types", () => {
+    expect(parsePrValidationRunType(DroidRunType.Review)).toBe(
+      DroidRunType.Review,
+    );
+    expect(parsePrValidationRunType(DroidRunType.SecurityReview)).toBe(
+      DroidRunType.SecurityReview,
+    );
+    expect(parsePrValidationRunType(DroidRunType.Fill)).toBeUndefined();
+    expect(parsePrValidationRunType("unknown")).toBeUndefined();
   });
 });

--- a/test/steward.test.ts
+++ b/test/steward.test.ts
@@ -10,6 +10,7 @@ import {
   workflowsPassedOnCommit,
 } from "../src/steward/gate";
 import { prepareMcpTools } from "../src/mcp/install-mcp-server";
+import { DroidRunType } from "../src/run-type";
 import {
   STEWARD_ALLOWED_TOOLS,
   buildActionConfig,
@@ -112,6 +113,7 @@ describe("CI Steward MCP wiring", () => {
         owner: "owner",
         repo: "repo",
         droidCommentId: "1",
+        runType: DroidRunType.CiSteward,
         allowedTools: STEWARD_ALLOWED_TOOLS,
         mode: "tag",
         context: {
@@ -151,6 +153,7 @@ describe("CI Steward MCP wiring", () => {
         owner: "owner",
         repo: "repo",
         droidCommentId: "1",
+        runType: DroidRunType.CiSteward,
         allowedTools: STEWARD_ALLOWED_TOOLS,
         mode: "tag",
         context: {
@@ -177,6 +180,7 @@ describe("CI Steward MCP wiring", () => {
         owner: "owner",
         repo: "repo",
         droidCommentId: "1",
+        runType: DroidRunType.CiSteward,
         allowedTools: STEWARD_ALLOWED_TOOLS,
         mode: "tag",
         context: {


### PR DESCRIPTION
## Summary

- define a centralized `DroidRunType` enum for default, review, security review, fill, full security scan, and CI Steward runs
- resolve run identity before creating the initial tracking comment, export it when known, and pass it through each mode and comment-posting path
- distinguish a bare `@droid` command as `droid-default` and leave the run type `null` when no command or automatic mode identifies one
- use separate hidden markers for PR issue comments and inline review comments:
  - `<!-- factory-pr-issue-comment: run-type=droid-review -->`
  - `<!-- factory-pr-inline-comment: run-type=droid-security-review -->`
- tag inline comments posted individually, in batched reviews, and through the deterministic post-review step
- mark default, code review, security review, and full security scan comments while leaving fill and CI Steward outside PR-validation tagging
- preserve trusted markers when Droid sanitizes and rewrites comments
- preserve the actual review run type through validator execution, including standalone security reviews
- track the actual comment surface when an inline tracking reply falls back to a top-level issue comment
- check automatic-security run-once state before comment creation, avoiding no-op comments and downgrading dual-review messages when security is skipped
- cover run-type resolution, both marker formats, direct and batched inline posting, fallback behavior, MCP wiring, nullable runs, and automatic-security skip behavior with tests

## Why

GitHub comments do not retain structured metadata linking them to the workflow or validation that created them. The hidden markers let downstream consumers identify both the comment surface and the exact originating run type without coupling classification to presentation-oriented text such as `[security]`.

## Reviewer notes

The action derives markers from its trusted `DroidRunType` rather than accepting them from model output. Sanitization removes arbitrary HTML comments before the appropriate trusted marker is appended.

Issue-comment marker values include:

- `<!-- factory-pr-issue-comment: run-type=droid-default -->`
- `<!-- factory-pr-issue-comment: run-type=droid-review -->`
- `<!-- factory-pr-issue-comment: run-type=droid-security-review -->`
- `<!-- factory-pr-issue-comment: run-type=droid-security-scan -->`

Inline comments use the same run types with the `factory-pr-inline-comment` prefix. For example:

- `<!-- factory-pr-inline-comment: run-type=droid-review -->`
- `<!-- factory-pr-inline-comment: run-type=droid-security-review -->`

When no command is parsed and neither automatic mode applies, run-type resolution returns `null`; no run type is exported or added to a marker.

Automatic security reviews check the existing security summary before creating a tracking comment. A security-only no-op creates no comment, while a combined run that skips security creates a code-review-only comment.

## Testing

- `npx --yes bun@1.2.11 test` (657 passed)
- `npm run typecheck`
- `npm run format:check`
