### PR TITLE
feat(action): add fail-closed model policy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,13 +343,14 @@ To leave comments and approvals on your PRs, Droid needs a GitHub token. There a
 
 ### Review Configuration
 
-| Input              | Default | Purpose                                                                                              |
-| ------------------ | ------- | ---------------------------------------------------------------------------------------------------- |
-| `automatic_review` | `false` | Automatically run code review on PRs without requiring `@droid review`.                              |
-| `review_depth`     | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below. |
-| `review_model`     | `""`    | Override the model for code review. When empty, determined by `review_depth`.                        |
-| `reasoning_effort` | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                      |
-| `fill_model`       | `""`    | Override the model used for PR description fill.                                                     |
+| Input                   | Default                | Purpose                                                                                                               |
+| ----------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `automatic_review`      | `false`                | Automatically run code review on PRs without requiring `@droid review`.                                               |
+| `review_depth`          | `deep`                 | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below.                  |
+| `review_model`          | `""`                   | Override the model for code review. When empty, determined by `review_depth`.                                         |
+| `reasoning_effort`      | `""`                   | Override reasoning effort for review. When empty, determined by `review_depth`.                                       |
+| `model_policy_fallback` | `organization-default` | Set to `fail` to stop when a requested model is blocked or invalid instead of retrying with the organization default. |
+| `fill_model`            | `""`                   | Override the model used for PR description fill.                                                                      |
 
 ### Review Depth
 

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,10 @@ inputs:
     description: "Override reasoning effort for review flows (passed to Droid Exec as --reasoning-effort). If empty, determined by review_depth (shallow=default, deep=high)."
     required: false
     default: ""
+  model_policy_fallback:
+    description: "Behavior when the requested model is blocked or invalid: 'organization-default' retries without model arguments; 'fail' preserves the error and never falls back."
+    required: false
+    default: "organization-default"
   include_suggestions:
     description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
     required: false
@@ -239,6 +243,7 @@ runs:
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         FILL_MODEL: ${{ inputs.fill_model }}
@@ -327,6 +332,7 @@ runs:
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
@@ -362,6 +368,7 @@ runs:
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
 
     - name: Run Droid Exec (validator)
@@ -383,6 +390,7 @@ runs:
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -366,7 +366,7 @@ runs:
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         DROID_COMMENT_ID: ${{ steps.prepare.outputs.droid_comment_id }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
-        REVIEW_MODEL: ${{ inputs.review_model }}
+        REVIEW_MODEL: ${{ steps.prepare.outputs.run_security_review == 'true' && inputs.security_model || inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
@@ -436,7 +436,7 @@ runs:
       if: always() && steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.steward_skipped != 'true'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: droid-review-debug-${{ github.run_id }}
+        name: droid-review-debug-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}-${{ github.action }}
         path: |
           ${{ runner.temp }}/.factory/**
           ${{ runner.temp }}/droid-prompts/**

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Additional arguments to pass directly to Droid CLI (e.g., '--auto', '--enabled-tools read,edit')"
     required: false
     default: ""
+  model_policy_fallback:
+    description: "Behavior when model arguments are blocked or invalid: 'organization-default' retries without them; 'fail' preserves the error."
+    required: false
+    default: "organization-default"
 
   # Authentication settings
   factory_api_key:
@@ -119,6 +123,7 @@ runs:
         INPUT_SETTINGS: ${{ inputs.settings }}
         INPUT_DROID_ARGS: ${{ inputs.droid_args }}
         INPUT_REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -31,6 +31,7 @@ async function run() {
       appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,
       pathToDroidExecutable: process.env.INPUT_PATH_TO_DROID_EXECUTABLE,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      modelPolicyFallback: process.env.INPUT_MODEL_POLICY_FALLBACK,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -8,6 +8,8 @@ import {
   condenseInvalidModelError,
   isInvalidModelError,
   isModelPolicyError,
+  parseModelPolicyFallbackMode,
+  shouldStripModelArgs,
   stripModelArgs,
 } from "./utils/model-policy-error";
 
@@ -89,6 +91,7 @@ export type DroidOptions = {
   systemPrompt?: string;
   appendSystemPrompt?: string;
   showFullOutput?: string;
+  modelPolicyFallback?: string;
 };
 
 type PreparedConfig = {
@@ -133,6 +136,9 @@ export function prepareRunConfig(
 }
 
 export async function runDroid(promptPath: string, options: DroidOptions) {
+  const modelPolicyFallback = parseModelPolicyFallbackMode(
+    options.modelPolicyFallback,
+  );
   // If MCP tools config is provided, register servers via `droid mcp add` before running exec
   if (options.mcpTools && options.mcpTools.trim()) {
     try {
@@ -392,11 +398,15 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
             isModelPolicyError(resultEvent.result);
           const invalidModel = isInvalidModelError(getStderrTail());
           if (
-            !modelArgsStripped &&
-            (policyBlocked || invalidModel) &&
-            currentDroidArgs.some(
-              (arg) => arg === "--model" || arg.startsWith("--model="),
-            )
+            shouldStripModelArgs({
+              mode: modelPolicyFallback,
+              modelArgsStripped,
+              policyBlocked,
+              invalidModel,
+              hasModelArg: currentDroidArgs.some(
+                (arg) => arg === "--model" || arg.startsWith("--model="),
+              ),
+            })
           ) {
             modelArgsStripped = true;
             currentDroidArgs = stripModelArgs(currentDroidArgs);

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -9,11 +9,14 @@ import {
   isInvalidModelError,
   isModelPolicyError,
   parseModelPolicyFallbackMode,
+  shouldRetryModelFailure,
   shouldStripModelArgs,
   stripModelArgs,
 } from "./utils/model-policy-error";
 
 const execAsync = promisify(exec);
+
+class NonRetryableModelError extends Error {}
 
 /** Redact inline `--env KEY=value` secrets before logging a command string. */
 function redactEnvSecrets(text: string): string {
@@ -268,6 +271,7 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
   // retryWithBackoff so backoff timing lives in one place (3 total attempts,
   // 5s then 10s delays).
   let lastExitCode = 1;
+  let attemptCount = 0;
   let currentDroidArgs = config.droidArgs;
   let modelArgsStripped = false;
   type ResultEvent = { is_error?: boolean; result?: string };
@@ -385,6 +389,7 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
   try {
     await retryWithBackoff(
       async () => {
+        attemptCount += 1;
         lastExitCode = await runDroidOnce();
         if (lastExitCode !== 0) {
           console.log(`Droid Exec exited with code ${lastExitCode}`);
@@ -424,17 +429,35 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
                 "by your organization to control which model is used.",
             );
           }
+          if (
+            !shouldRetryModelFailure({
+              mode: modelPolicyFallback,
+              policyBlocked,
+              invalidModel,
+            })
+          ) {
+            throw new NonRetryableModelError(
+              `Droid Exec exited with code ${lastExitCode}`,
+            );
+          }
           throw new Error(`Droid Exec exited with code ${lastExitCode}`);
         }
       },
-      { maxAttempts: 3, initialDelayMs: 5000, maxDelayMs: 20000 },
+      {
+        maxAttempts: 3,
+        initialDelayMs: 5000,
+        maxDelayMs: 20000,
+        shouldRetry: (error) => !(error instanceof NonRetryableModelError),
+      },
     );
     core.setOutput("conclusion", "success");
     return;
   } catch (_) {
     // All retry attempts exhausted
     console.error(
-      `Droid Exec failed after 3 total attempts (exit code: ${lastExitCode})`,
+      `Droid Exec failed after ${attemptCount} total ${
+        attemptCount === 1 ? "attempt" : "attempts"
+      } (exit code: ${lastExitCode})`,
     );
     const finalResultEvent = getLastResultEvent();
     let finalStderrTail = getStderrTail().trim();

--- a/base-action/src/utils/model-policy-error.ts
+++ b/base-action/src/utils/model-policy-error.ts
@@ -115,3 +115,15 @@ export function shouldStripModelArgs({
     hasModelArg
   );
 }
+
+export function shouldRetryModelFailure({
+  mode,
+  policyBlocked,
+  invalidModel,
+}: {
+  mode: ModelPolicyFallbackMode;
+  policyBlocked: boolean;
+  invalidModel: boolean;
+}): boolean {
+  return mode !== "fail" || (!policyBlocked && !invalidModel);
+}

--- a/base-action/src/utils/model-policy-error.ts
+++ b/base-action/src/utils/model-policy-error.ts
@@ -9,6 +9,25 @@ const MODEL_POLICY_ERROR_PATTERNS = [
   /requires explicit organization opt-in/i,
 ];
 
+export const MODEL_POLICY_FALLBACK_MODES = [
+  "organization-default",
+  "fail",
+] as const;
+export type ModelPolicyFallbackMode =
+  (typeof MODEL_POLICY_FALLBACK_MODES)[number];
+
+export function parseModelPolicyFallbackMode(
+  value: string | undefined,
+): ModelPolicyFallbackMode {
+  const mode = value?.trim() || "organization-default";
+  if (!MODEL_POLICY_FALLBACK_MODES.includes(mode as ModelPolicyFallbackMode)) {
+    throw new Error(
+      `model_policy_fallback must be one of: ${MODEL_POLICY_FALLBACK_MODES.join(", ")}`,
+    );
+  }
+  return mode as ModelPolicyFallbackMode;
+}
+
 export function isModelPolicyError(text: string | undefined | null): boolean {
   if (!text) {
     return false;
@@ -74,4 +93,25 @@ export function stripModelArgs(args: string[]): string[] {
   }
 
   return stripped;
+}
+
+export function shouldStripModelArgs({
+  mode,
+  modelArgsStripped,
+  policyBlocked,
+  invalidModel,
+  hasModelArg,
+}: {
+  mode: ModelPolicyFallbackMode;
+  modelArgsStripped: boolean;
+  policyBlocked: boolean;
+  invalidModel: boolean;
+  hasModelArg: boolean;
+}): boolean {
+  return (
+    mode === "organization-default" &&
+    !modelArgsStripped &&
+    (policyBlocked || invalidModel) &&
+    hasModelArg
+  );
 }

--- a/base-action/src/utils/retry.ts
+++ b/base-action/src/utils/retry.ts
@@ -3,6 +3,7 @@ export type RetryOptions = {
   initialDelayMs?: number;
   maxDelayMs?: number;
   backoffFactor?: number;
+  shouldRetry?: (error: Error) => boolean;
 };
 
 /**
@@ -22,6 +23,7 @@ export async function retryWithBackoff<T>(
     initialDelayMs = 5000,
     maxDelayMs = 20000,
     backoffFactor = 2,
+    shouldRetry = () => true,
   } = options;
 
   let delayMs = initialDelayMs;
@@ -34,6 +36,11 @@ export async function retryWithBackoff<T>(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       console.error(`Attempt ${attempt} failed:`, lastError.message);
+
+      if (!shouldRetry(lastError)) {
+        console.log("Failure is not retryable; stopping.");
+        throw lastError;
+      }
 
       if (attempt < maxAttempts) {
         console.log(`Retrying in ${delayMs / 1000} seconds...`);

--- a/base-action/test/model-policy-error.test.ts
+++ b/base-action/test/model-policy-error.test.ts
@@ -3,8 +3,31 @@ import {
   condenseInvalidModelError,
   isInvalidModelError,
   isModelPolicyError,
+  parseModelPolicyFallbackMode,
+  shouldStripModelArgs,
   stripModelArgs,
 } from "../src/utils/model-policy-error";
+
+describe("parseModelPolicyFallbackMode", () => {
+  it("defaults to the organization default fallback", () => {
+    expect(parseModelPolicyFallbackMode(undefined)).toBe(
+      "organization-default",
+    );
+    expect(parseModelPolicyFallbackMode("")).toBe("organization-default");
+    expect(parseModelPolicyFallbackMode("   ")).toBe("organization-default");
+  });
+
+  it("accepts fail-closed mode", () => {
+    expect(parseModelPolicyFallbackMode("fail")).toBe("fail");
+    expect(parseModelPolicyFallbackMode(" fail ")).toBe("fail");
+  });
+
+  it("rejects unsupported modes", () => {
+    expect(() => parseModelPolicyFallbackMode("best-effort")).toThrow(
+      "model_policy_fallback must be one of: organization-default, fail",
+    );
+  });
+});
 
 describe("isModelPolicyError", () => {
   it("matches the model policy 403 message", () => {
@@ -116,5 +139,73 @@ describe("stripModelArgs", () => {
   it("returns args unchanged when no model flags are present", () => {
     const args = ["exec", "--output-format", "stream-json", "-f", "p.txt"];
     expect(stripModelArgs(args)).toEqual(args);
+  });
+});
+
+describe("shouldStripModelArgs", () => {
+  const fallbackCandidate = {
+    modelArgsStripped: false,
+    policyBlocked: false,
+    invalidModel: false,
+    hasModelArg: true,
+  };
+
+  it("uses the organization default for policy and invalid-model failures by default", () => {
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "organization-default",
+        policyBlocked: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "organization-default",
+        invalidModel: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves model arguments in fail-closed mode", () => {
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "fail",
+        policyBlocked: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "fail",
+        invalidModel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry without model arguments when fallback is inapplicable", () => {
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "organization-default",
+      }),
+    ).toBe(false);
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "organization-default",
+        policyBlocked: true,
+        hasModelArg: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldStripModelArgs({
+        ...fallbackCandidate,
+        mode: "organization-default",
+        policyBlocked: true,
+        modelArgsStripped: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/base-action/test/model-policy-error.test.ts
+++ b/base-action/test/model-policy-error.test.ts
@@ -4,6 +4,7 @@ import {
   isInvalidModelError,
   isModelPolicyError,
   parseModelPolicyFallbackMode,
+  shouldRetryModelFailure,
   shouldStripModelArgs,
   stripModelArgs,
 } from "../src/utils/model-policy-error";
@@ -207,5 +208,41 @@ describe("shouldStripModelArgs", () => {
         modelArgsStripped: true,
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldRetryModelFailure", () => {
+  it("stops deterministic model failures in fail-closed mode", () => {
+    expect(
+      shouldRetryModelFailure({
+        mode: "fail",
+        policyBlocked: true,
+        invalidModel: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryModelFailure({
+        mode: "fail",
+        policyBlocked: false,
+        invalidModel: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("retains transient retries and organization-default fallback", () => {
+    expect(
+      shouldRetryModelFailure({
+        mode: "fail",
+        policyBlocked: false,
+        invalidModel: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryModelFailure({
+        mode: "organization-default",
+        policyBlocked: true,
+        invalidModel: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/base-action/test/retry.test.ts
+++ b/base-action/test/retry.test.ts
@@ -69,4 +69,21 @@ describe("retryWithBackoff", () => {
       | undefined;
     expect(firstCall?.[1]).toBe(5);
   });
+
+  it("stops immediately when the failure is not retryable", async () => {
+    let attempts = 0;
+
+    await expect(
+      retryWithBackoff(
+        async () => {
+          attempts += 1;
+          throw new Error("invalid model");
+        },
+        { maxAttempts: 3, shouldRetry: () => false },
+      ),
+    ).rejects.toThrow("invalid model");
+
+    expect(attempts).toBe(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
 });

--- a/review/action.yml
+++ b/review/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Override reasoning effort for review. If empty, determined by review_depth (shallow=default, deep=high)."
     required: false
     default: ""
+  model_policy_fallback:
+    description: "Behavior when the requested review model is blocked or invalid: 'organization-default' retries with the org default; 'fail' preserves the error."
+    required: false
+    default: "organization-default"
   output_file:
     description: "Path to write review results JSON"
     required: false
@@ -92,6 +96,7 @@ runs:
         REVIEW_TYPE: "code"
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
 
@@ -116,6 +121,7 @@ runs:
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
     - name: Prepare Validator
       id: prepare_validator
@@ -130,6 +136,7 @@ runs:
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
 
@@ -144,6 +151,7 @@ runs:
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
     - name: Update tracking comment
       if: always() && inputs.tracking_comment_id

--- a/security/action.yml
+++ b/security/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Model to use for security review"
     required: false
     default: ""
+  model_policy_fallback:
+    description: "Behavior when the requested security model is blocked or invalid: 'organization-default' retries with the org default; 'fail' preserves the error."
+    required: false
+    default: "organization-default"
   security_severity_threshold:
     description: "Minimum severity to report"
     required: false
@@ -120,8 +124,10 @@ runs:
         bun run ${{ github.action_path }}/../src/entrypoints/generate-review-prompt.ts
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
         SECURITY_MODEL: ${{ inputs.security_model }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         SECURITY_SEVERITY_THRESHOLD: ${{ inputs.security_severity_threshold }}
         SECURITY_BLOCK_ON_CRITICAL: ${{ inputs.security_block_on_critical }}
         SECURITY_BLOCK_ON_HIGH: ${{ inputs.security_block_on_high }}
@@ -142,6 +148,7 @@ runs:
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
     - name: Prepare Validator
       id: prepare_validator
@@ -150,11 +157,13 @@ runs:
         bun run ${{ github.action_path }}/../src/entrypoints/prepare-validator.ts
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         REVIEW_MODEL: ${{ inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
+        MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}
         DROID_COMMENT_ID: ${{ inputs.tracking_comment_id }}
 
@@ -169,6 +178,7 @@ runs:
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        INPUT_MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
 
     - name: Update tracking comment
       if: always() && inputs.tracking_comment_id

--- a/security/action.yml
+++ b/security/action.yml
@@ -161,7 +161,7 @@ runs:
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
-        REVIEW_MODEL: ${{ inputs.review_model }}
+        REVIEW_MODEL: ${{ inputs.security_model || inputs.review_model }}
         REASONING_EFFORT: ${{ inputs.reasoning_effort }}
         MODEL_POLICY_FALLBACK: ${{ inputs.model_policy_fallback }}
         INCLUDE_SUGGESTIONS: ${{ inputs.include_suggestions }}

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -34,6 +34,7 @@ export function collectActionInputsPresence(): void {
     security_notify_team: "",
     security_scan_schedule: "false",
     security_scan_days: "7",
+    model_policy_fallback: "organization-default",
   };
 
   const allInputsJson = process.env.ALL_INPUTS;

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -12,6 +12,7 @@ import { generateSecurityCandidatesPrompt } from "../../create-prompt/templates/
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
+import { resolveReviewConfig } from "../../utils/review-depth";
 
 type SecurityReviewCommandOptions = {
   context: GitHubContext;
@@ -156,11 +157,12 @@ export async function prepareSecurityReviewMode({
     reasoningEffort,
     fallbackNote,
   } = await applyModelPolicyFallback(
-    {
-      model:
+    resolveReviewConfig({
+      reviewModel:
         process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim(),
       reasoningEffort: process.env.REASONING_EFFORT?.trim(),
-    },
+      reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+    }),
     { flowLabel: "security review", modelInputName: "security_model" },
   );
   if (securityModel) {

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -151,15 +151,23 @@ export async function prepareSecurityReviewMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const { model: securityModel, fallbackNote } = await applyModelPolicyFallback(
+  const {
+    model: securityModel,
+    reasoningEffort,
+    fallbackNote,
+  } = await applyModelPolicyFallback(
     {
       model:
         process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim(),
+      reasoningEffort: process.env.REASONING_EFFORT?.trim(),
     },
     { flowLabel: "security review", modelInputName: "security_model" },
   );
   if (securityModel) {
     droidArgParts.push(`--model "${securityModel}"`);
+  }
+  if (reasoningEffort) {
+    droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
   }
   if (fallbackNote) {
     core.setOutput("model_fallback_note", fallbackNote);

--- a/src/utils/model-policy.ts
+++ b/src/utils/model-policy.ts
@@ -134,11 +134,21 @@ export type PolicyCheckedModelConfig = {
   fallbackNote?: string;
 };
 
+function shouldFailClosed(): boolean {
+  const mode =
+    process.env.MODEL_POLICY_FALLBACK?.trim() || "organization-default";
+  if (mode === "organization-default") return false;
+  if (mode === "fail") return true;
+  throw new Error(
+    "model_policy_fallback must be one of: organization-default, fail",
+  );
+}
+
 /**
  * Pre-flight check of a resolved model against the org's model policy.
- * When the model is disallowed, drops the model (and reasoning effort) so
- * `droid exec` falls back to the organization's default model, and returns
- * a note describing the fallback for surfacing in the tracking comment.
+ * When the model is disallowed, either rejects the run in fail-closed mode
+ * or drops the model (and reasoning effort) so `droid exec` falls back to the
+ * organization's default model.
  */
 export async function applyModelPolicyFallback(
   config: { model?: string; reasoningEffort?: string },
@@ -154,6 +164,11 @@ export async function applyModelPolicyFallback(
   const policy = await fetchModelPolicy(factoryApiKey);
   if (isModelAllowedByPolicy(model, policy)) {
     return { model, reasoningEffort };
+  }
+  if (shouldFailClosed()) {
+    throw new Error(
+      `The ${options.flowLabel} model "${model}" is not allowed by the organization's model policy`,
+    );
   }
 
   const fallbackNote =

--- a/src/utils/model-policy.ts
+++ b/src/utils/model-policy.ts
@@ -134,11 +134,14 @@ export type PolicyCheckedModelConfig = {
   fallbackNote?: string;
 };
 
-function shouldFailClosed(): boolean {
+type ModelPolicyFallbackMode = "organization-default" | "fail";
+
+function parseModelPolicyFallbackMode(): ModelPolicyFallbackMode {
   const mode =
     process.env.MODEL_POLICY_FALLBACK?.trim() || "organization-default";
-  if (mode === "organization-default") return false;
-  if (mode === "fail") return true;
+  if (mode === "organization-default" || mode === "fail") {
+    return mode;
+  }
   throw new Error(
     "model_policy_fallback must be one of: organization-default, fail",
   );
@@ -154,6 +157,7 @@ export async function applyModelPolicyFallback(
   config: { model?: string; reasoningEffort?: string },
   options: { flowLabel: string; modelInputName: string },
 ): Promise<PolicyCheckedModelConfig> {
+  const fallbackMode = parseModelPolicyFallbackMode();
   const { model, reasoningEffort } = config;
   const factoryApiKey = process.env.FACTORY_API_KEY;
 
@@ -165,7 +169,7 @@ export async function applyModelPolicyFallback(
   if (isModelAllowedByPolicy(model, policy)) {
     return { model, reasoningEffort };
   }
-  if (shouldFailClosed()) {
+  if (fallbackMode === "fail") {
     throw new Error(
       `The ${options.flowLabel} model "${model}" is not allowed by the organization's model policy`,
     );

--- a/test/model-policy-action-wiring.test.ts
+++ b/test/model-policy-action-wiring.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+
+type ActionStep = {
+  name?: string;
+  env?: Record<string, string>;
+};
+
+type ActionDefinition = {
+  inputs?: Record<string, { default?: string }>;
+  runs?: { steps?: ActionStep[] };
+};
+
+const repositoryRoot = join(import.meta.dir, "..");
+
+function readAction(path: string): ActionDefinition {
+  return parse(readFileSync(join(repositoryRoot, path), "utf8"));
+}
+
+function getStep(action: ActionDefinition, name: string): ActionStep {
+  const step = action.runs?.steps?.find((candidate) => candidate.name === name);
+  if (!step) {
+    throw new Error(`Action step not found: ${name}`);
+  }
+  return step;
+}
+
+describe("model policy fallback action wiring", () => {
+  const actionCases = [
+    {
+      path: "action.yml",
+      prepareSteps: ["Prepare action", "Prepare validator"],
+      executionSteps: ["Run Droid Exec", "Run Droid Exec (validator)"],
+    },
+    {
+      path: "review/action.yml",
+      prepareSteps: ["Generate Review Prompt", "Prepare Validator"],
+      executionSteps: ["Run Code Review", "Run Validator"],
+    },
+    {
+      path: "security/action.yml",
+      prepareSteps: ["Generate Security Prompt", "Prepare Validator"],
+      executionSteps: ["Run Security Review", "Run Validator"],
+    },
+  ];
+
+  for (const { path, prepareSteps, executionSteps } of actionCases) {
+    it(`forwards strict mode through every ${path} pass`, () => {
+      const action = readAction(path);
+
+      expect(action.inputs?.model_policy_fallback?.default).toBe(
+        "organization-default",
+      );
+      for (const stepName of prepareSteps) {
+        const env = getStep(action, stepName).env;
+        expect(env?.MODEL_POLICY_FALLBACK).toBe(
+          "${{ inputs.model_policy_fallback }}",
+        );
+        expect(env?.FACTORY_API_KEY).toBe("${{ inputs.factory_api_key }}");
+      }
+      for (const stepName of executionSteps) {
+        expect(getStep(action, stepName).env?.INPUT_MODEL_POLICY_FALLBACK).toBe(
+          "${{ inputs.model_policy_fallback }}",
+        );
+      }
+    });
+  }
+
+  it("forwards strict mode through the standalone base action", () => {
+    const action = readAction("base-action/action.yml");
+
+    expect(action.inputs?.model_policy_fallback?.default).toBe(
+      "organization-default",
+    );
+    expect(
+      getStep(action, "Run Droid Exec Action").env?.INPUT_MODEL_POLICY_FALLBACK,
+    ).toBe("${{ inputs.model_policy_fallback }}");
+  });
+});

--- a/test/model-policy-action-wiring.test.ts
+++ b/test/model-policy-action-wiring.test.ts
@@ -6,6 +6,7 @@ import { parse } from "yaml";
 type ActionStep = {
   name?: string;
   env?: Record<string, string>;
+  with?: Record<string, string>;
 };
 
 type ActionDefinition = {
@@ -77,5 +78,25 @@ describe("model policy fallback action wiring", () => {
     expect(
       getStep(action, "Run Droid Exec Action").env?.INPUT_MODEL_POLICY_FALLBACK,
     ).toBe("${{ inputs.model_policy_fallback }}");
+  });
+
+  it("selects the security model for security validators", () => {
+    const mainAction = readAction("action.yml");
+    const securityAction = readAction("security/action.yml");
+
+    expect(getStep(mainAction, "Prepare validator").env?.REVIEW_MODEL).toBe(
+      "${{ steps.prepare.outputs.run_security_review == 'true' && inputs.security_model || inputs.review_model }}",
+    );
+    expect(getStep(securityAction, "Prepare Validator").env?.REVIEW_MODEL).toBe(
+      "${{ inputs.security_model || inputs.review_model }}",
+    );
+  });
+
+  it("uses a unique debug artifact name for each action invocation", () => {
+    const action = readAction("action.yml");
+
+    expect(getStep(action, "Upload debug artifacts").with?.name).toBe(
+      "droid-review-debug-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index || 0 }}-${{ github.action }}",
+    );
   });
 });

--- a/test/model-policy.test.ts
+++ b/test/model-policy.test.ts
@@ -188,6 +188,23 @@ describe("applyModelPolicyFallback", () => {
     );
   });
 
+  it("rejects an invalid fallback mode before checking model policy", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    process.env.MODEL_POLICY_FALLBACK = "best-effort";
+    let fetchCalled = false;
+    mockFetch(() => {
+      fetchCalled = true;
+      return managedSettingsResponse({ allowedModelIds: ["gpt-5.2"] });
+    });
+
+    await expect(
+      applyModelPolicyFallback({ model: "gpt-5.2" }, options),
+    ).rejects.toThrow(
+      "model_policy_fallback must be one of: organization-default, fail",
+    );
+    expect(fetchCalled).toBe(false);
+  });
+
   it("keeps the model when the policy lookup fails", async () => {
     process.env.FACTORY_API_KEY = "fk-test";
     mockFetch(() => {

--- a/test/model-policy.test.ts
+++ b/test/model-policy.test.ts
@@ -8,6 +8,7 @@ import {
 
 const originalFetch = globalThis.fetch;
 const originalApiKey = process.env.FACTORY_API_KEY;
+const originalModelPolicyFallback = process.env.MODEL_POLICY_FALLBACK;
 
 function mockFetch(handler: () => Promise<Response> | Response) {
   globalThis.fetch = Object.assign(async () => handler(), {
@@ -28,6 +29,11 @@ afterEach(() => {
     delete process.env.FACTORY_API_KEY;
   } else {
     process.env.FACTORY_API_KEY = originalApiKey;
+  }
+  if (originalModelPolicyFallback === undefined) {
+    delete process.env.MODEL_POLICY_FALLBACK;
+  } else {
+    process.env.MODEL_POLICY_FALLBACK = originalModelPolicyFallback;
   }
 });
 
@@ -163,6 +169,23 @@ describe("applyModelPolicyFallback", () => {
     expect(result.reasoningEffort).toBeUndefined();
     expect(result.fallbackNote).toContain("`gpt-5.2`");
     expect(result.fallbackNote).toContain("`review_model`");
+  });
+
+  it("fails closed when strict model policy rejects the model", async () => {
+    process.env.FACTORY_API_KEY = "fk-test";
+    process.env.MODEL_POLICY_FALLBACK = "fail";
+    mockFetch(() =>
+      managedSettingsResponse({ allowedModelIds: ["claude-opus-5"] }),
+    );
+
+    await expect(
+      applyModelPolicyFallback(
+        { model: "gpt-5.2", reasoningEffort: "high" },
+        options,
+      ),
+    ).rejects.toThrow(
+      `code review model "gpt-5.2" is not allowed by the organization's model policy`,
+    );
   });
 
   it("keeps the model when the policy lookup fails", async () => {

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -33,6 +33,7 @@ describe("prepareSecurityReviewMode", () => {
   const originalArgs = process.env.DROID_ARGS;
   const originalReviewModel = process.env.REVIEW_MODEL;
   const originalSecurityModel = process.env.SECURITY_MODEL;
+  const originalReasoningEffort = process.env.REASONING_EFFORT;
   let fetchPRSpy: ReturnType<typeof spyOn>;
   let computeArtifactsSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
@@ -45,6 +46,7 @@ describe("prepareSecurityReviewMode", () => {
     process.env.DROID_ARGS = "";
     delete process.env.REVIEW_MODEL;
     delete process.env.SECURITY_MODEL;
+    delete process.env.REASONING_EFFORT;
 
     fetchPRSpy = spyOn(prFetcher, "fetchPRBranchData").mockResolvedValue({
       baseRefName: MOCK_PR_DATA.baseRefName,
@@ -100,6 +102,11 @@ describe("prepareSecurityReviewMode", () => {
       process.env.SECURITY_MODEL = originalSecurityModel;
     } else {
       delete process.env.SECURITY_MODEL;
+    }
+    if (originalReasoningEffort !== undefined) {
+      process.env.REASONING_EFFORT = originalReasoningEffort;
+    } else {
+      delete process.env.REASONING_EFFORT;
     }
   });
 
@@ -320,6 +327,36 @@ describe("prepareSecurityReviewMode", () => {
     ) as [string, string] | undefined;
     expect(droidArgsCall?.[1]).toContain('--model "gpt-5.1-codex"');
     expect(droidArgsCall?.[1]).not.toContain("claude-sonnet");
+  });
+
+  it("passes reasoning effort to the security candidate review", async () => {
+    process.env.SECURITY_MODEL = "gpt-5.4";
+    process.env.REASONING_EFFORT = "high";
+
+    const context = createMockContext({
+      eventName: "issue_comment",
+      isPR: true,
+      payload: {
+        comment: {
+          id: 107,
+          body: "@droid security-review",
+        },
+      } as any,
+      entityNumber: 30,
+    });
+
+    await prepareSecurityReviewMode({
+      context,
+      octokit: { rest: {}, graphql: () => {} } as any,
+      githubToken: "token",
+      trackingCommentId: 560,
+    });
+
+    const droidArgsCall = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    ) as [string, string] | undefined;
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.4"');
+    expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 
   it("falls back to REVIEW_MODEL when SECURITY_MODEL is not set", async () => {

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -239,7 +239,7 @@ describe("prepareSecurityReviewMode", () => {
     );
   });
 
-  it("does not add --model flag when REVIEW_MODEL is empty", async () => {
+  it("uses deep review defaults when REVIEW_MODEL is empty", async () => {
     process.env.REVIEW_MODEL = "";
 
     const context = createMockContext({
@@ -266,7 +266,8 @@ describe("prepareSecurityReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).not.toContain("--model");
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.2"');
+    expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 
   it("outputs install_security_skills flag", async () => {


### PR DESCRIPTION
## Summary

- add a backwards-compatible `model_policy_fallback` input to the main, review, security, and base actions
- support `fail` mode so policy-blocked or invalid requested models never retry with the organization's default model
- validate strict-mode configuration eagerly and stop deterministic model failures after one attempt while retaining transient retries
- forward strict policy through every review pass, including security model, reasoning, and validator selection
- make debug artifacts unique across retries, jobs, matrices, and repeated action invocations
- keep `organization-default` as the existing default behavior

## Motivation

This is the upstream prerequisite for the CLI-2122 Droid Review migration. Factory's review workflows need to pin review and security models without silently changing models when organization policy or the CLI rejects those pins.

## Testing

- `bun test` (595 passed)
- `bun run typecheck`
- `bun run format:check`
- `actionlint .github/workflows/*.yml`
