### PR TITLE
chore: update review model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,10 +355,10 @@ To leave comments and approvals on your PRs, Droid needs a GitHub token. There a
 
 The `review_depth` input controls which model and reasoning effort are used for code reviews. Two presets are available:
 
-| Depth       | Model       | Reasoning Effort | Best For                                                |
-| ----------- | ----------- | ---------------- | ------------------------------------------------------- |
-| **deep**    | `gpt-5.2`   | `high`           | Thorough reviews catching subtle bugs and design issues |
-| **shallow** | `kimi-k2.6` | default          | Fast, cost-effective reviews for straightforward PRs    |
+| Depth       | Model         | Reasoning Effort | Best For                                                |
+| ----------- | ------------- | ---------------- | ------------------------------------------------------- |
+| **deep**    | `gpt-5.6-sol` | `high`           | Thorough reviews catching subtle bugs and design issues |
+| **shallow** | `glm-5.2`     | default          | Fast, cost-effective reviews for straightforward PRs    |
 
 **Examples:**
 
@@ -387,14 +387,16 @@ The `review_depth` input controls which model and reasoning effort are used for 
 
 > **Tip:** Setting `review_model` or `reasoning_effort` explicitly always takes priority over the depth preset. You can mix and match -- for example, use `review_depth: shallow` but override just `reasoning_effort: high` to get the shallow model with higher reasoning.
 
-The default models (`gpt-5.2` for `deep`, `kimi-k2.6` for `shallow`) are managed by Factory and may change over time. To pin a specific model regardless of the depth preset, set `review_model` to any model ID supported by `droid exec --model`. A few common choices:
+The default models (`gpt-5.6-sol` for `deep`, `glm-5.2` for `shallow`) are managed by Factory and may change over time. To pin a specific model regardless of the depth preset, set `review_model` to any model ID supported by `droid exec --model`. A few common choices:
 
 - `claude-opus-4-7`
 - `claude-sonnet-4-6`
 - `claude-haiku-4-5`
+- `gpt-5.6-sol`
 - `gpt-5.5`
 - `gpt-5.5-pro`
 - `gpt-5.3-codex`
+- `glm-5.2`
 - `kimi-k2.6`
 
 See the [CLI reference](https://docs.factory.ai/reference/cli-reference#available-models) for the canonical, up-to-date list.

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ inputs:
     required: false
     default: "7"
   review_depth:
-    description: "Review depth preset: 'shallow' (fast, uses kimi-k2.6) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    description: "Review depth preset: 'shallow' (fast, uses glm-5.2) or 'deep' (thorough, uses gpt-5.6-sol with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
     required: false
     default: "deep"
   review_model:

--- a/review/action.yml
+++ b/review/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "ID of the tracking comment to update"
     required: true
   review_depth:
-    description: "Review depth preset: 'shallow' (fast, uses kimi-k2.6) or 'deep' (thorough, uses gpt-5.2 with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
+    description: "Review depth preset: 'shallow' (fast, uses glm-5.2) or 'deep' (thorough, uses gpt-5.6-sol with high reasoning). Defaults to deep. Setting review_model or reasoning_effort explicitly overrides the preset values."
     required: false
     default: "deep"
   review_model:

--- a/src/tag/commands/security-review.ts
+++ b/src/tag/commands/security-review.ts
@@ -12,6 +12,7 @@ import { generateSecurityCandidatesPrompt } from "../../create-prompt/templates/
 import type { Octokits } from "../../github/api/client";
 import type { PrepareResult } from "../../prepare/types";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
+import { resolveReviewConfig } from "../../utils/review-depth";
 
 type SecurityReviewCommandOptions = {
   context: GitHubContext;
@@ -151,15 +152,30 @@ export async function prepareSecurityReviewMode({
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);
   droidArgParts.push('--tag "code-review"');
 
-  const { model: securityModel, fallbackNote } = await applyModelPolicyFallback(
+  const securityModelOverride = process.env.SECURITY_MODEL?.trim();
+  const reviewConfig = resolveReviewConfig({
+    reviewModel: process.env.REVIEW_MODEL?.trim(),
+    reasoningEffort: process.env.REASONING_EFFORT?.trim(),
+    reviewDepth: process.env.REVIEW_DEPTH?.trim(),
+  });
+  const {
+    model: securityModel,
+    reasoningEffort,
+    fallbackNote,
+  } = await applyModelPolicyFallback(
     {
-      model:
-        process.env.SECURITY_MODEL?.trim() || process.env.REVIEW_MODEL?.trim(),
+      model: securityModelOverride || reviewConfig.model,
+      reasoningEffort: securityModelOverride
+        ? undefined
+        : reviewConfig.reasoningEffort,
     },
     { flowLabel: "security review", modelInputName: "security_model" },
   );
   if (securityModel) {
     droidArgParts.push(`--model "${securityModel}"`);
+  }
+  if (reasoningEffort) {
+    droidArgParts.push(`--reasoning-effort "${reasoningEffort}"`);
   }
   if (fallbackNote) {
     core.setOutput("model_fallback_note", fallbackNote);

--- a/src/utils/review-depth.ts
+++ b/src/utils/review-depth.ts
@@ -4,12 +4,12 @@ export enum ReviewDepth {
 }
 
 const SHALLOW_DEFAULTS = {
-  model: "kimi-k2.6",
+  model: "glm-5.2",
   reasoningEffort: undefined as string | undefined,
 };
 
 const DEEP_DEFAULTS = {
-  model: "gpt-5.2",
+  model: "gpt-5.6-sol",
   reasoningEffort: "high" as string | undefined,
 };
 

--- a/test/gitlab/review-config-resolution.test.ts
+++ b/test/gitlab/review-config-resolution.test.ts
@@ -4,14 +4,14 @@ import { resolveReviewConfig } from "../../src/utils/review-depth";
 describe("resolveReviewConfig (used by gitlab-prepare)", () => {
   it("uses deep preset by default", () => {
     expect(resolveReviewConfig()).toEqual({
-      model: "gpt-5.2",
+      model: "gpt-5.6-sol",
       reasoningEffort: "high",
     });
   });
 
   it("returns shallow preset for review_depth=shallow", () => {
     expect(resolveReviewConfig({ reviewDepth: "shallow" })).toEqual({
-      model: "kimi-k2.6",
+      model: "glm-5.2",
       reasoningEffort: undefined,
     });
   });
@@ -30,7 +30,7 @@ describe("resolveReviewConfig (used by gitlab-prepare)", () => {
       reasoningEffort: "medium",
     });
     expect(out.reasoningEffort).toBe("medium");
-    expect(out.model).toBe("gpt-5.2");
+    expect(out.model).toBe("gpt-5.6-sol");
   });
 
   it("both explicit overrides win simultaneously", () => {
@@ -47,6 +47,6 @@ describe("resolveReviewConfig (used by gitlab-prepare)", () => {
 
   it("unknown reviewDepth falls back to shallow preset", () => {
     const out = resolveReviewConfig({ reviewDepth: "neutron-star" });
-    expect(out.model).toBe("kimi-k2.6");
+    expect(out.model).toBe("glm-5.2");
   });
 });

--- a/test/modes/tag/review-command.test.ts
+++ b/test/modes/tag/review-command.test.ts
@@ -385,8 +385,8 @@ describe("prepareReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    // When REVIEW_MODEL is empty the deep depth preset kicks in (gpt-5.2, high reasoning).
-    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.2"');
+    // When REVIEW_MODEL is empty the deep depth preset kicks in (gpt-5.6-sol, high reasoning).
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.6-sol"');
     expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 

--- a/test/modes/tag/security-review-command.test.ts
+++ b/test/modes/tag/security-review-command.test.ts
@@ -33,6 +33,8 @@ describe("prepareSecurityReviewMode", () => {
   const originalArgs = process.env.DROID_ARGS;
   const originalReviewModel = process.env.REVIEW_MODEL;
   const originalSecurityModel = process.env.SECURITY_MODEL;
+  const originalReviewDepth = process.env.REVIEW_DEPTH;
+  const originalReasoningEffort = process.env.REASONING_EFFORT;
   let fetchPRSpy: ReturnType<typeof spyOn>;
   let computeArtifactsSpy: ReturnType<typeof spyOn>;
   let promptSpy: ReturnType<typeof spyOn>;
@@ -45,6 +47,8 @@ describe("prepareSecurityReviewMode", () => {
     process.env.DROID_ARGS = "";
     delete process.env.REVIEW_MODEL;
     delete process.env.SECURITY_MODEL;
+    delete process.env.REVIEW_DEPTH;
+    delete process.env.REASONING_EFFORT;
 
     fetchPRSpy = spyOn(prFetcher, "fetchPRBranchData").mockResolvedValue({
       baseRefName: MOCK_PR_DATA.baseRefName,
@@ -100,6 +104,16 @@ describe("prepareSecurityReviewMode", () => {
       process.env.SECURITY_MODEL = originalSecurityModel;
     } else {
       delete process.env.SECURITY_MODEL;
+    }
+    if (originalReviewDepth !== undefined) {
+      process.env.REVIEW_DEPTH = originalReviewDepth;
+    } else {
+      delete process.env.REVIEW_DEPTH;
+    }
+    if (originalReasoningEffort !== undefined) {
+      process.env.REASONING_EFFORT = originalReasoningEffort;
+    } else {
+      delete process.env.REASONING_EFFORT;
     }
   });
 
@@ -232,7 +246,7 @@ describe("prepareSecurityReviewMode", () => {
     );
   });
 
-  it("does not add --model flag when REVIEW_MODEL is empty", async () => {
+  it("uses the code review default when REVIEW_MODEL is empty", async () => {
     process.env.REVIEW_MODEL = "";
 
     const context = createMockContext({
@@ -259,7 +273,8 @@ describe("prepareSecurityReviewMode", () => {
     const droidArgsCall = setOutputSpy.mock.calls.find(
       (call: unknown[]) => call[0] === "droid_args",
     ) as [string, string] | undefined;
-    expect(droidArgsCall?.[1]).not.toContain("--model");
+    expect(droidArgsCall?.[1]).toContain('--model "gpt-5.6-sol"');
+    expect(droidArgsCall?.[1]).toContain('--reasoning-effort "high"');
   });
 
   it("outputs install_security_skills flag", async () => {


### PR DESCRIPTION
## Description

Update the review-depth presets to use `gpt-5.6-sol` for deep reviews and `glm-5.2` for shallow reviews. When `security_model` is unset, security reviews now use the same resolved code-review model and reasoning defaults. Keep the action metadata, README, and configuration tests aligned with the new behavior.

## Related Issue

Not applicable, maintenance change.

## Potential Risk & Impact

Low risk. Existing callers can still override `security_model`, `review_model`, and `reasoning_effort`. Security reviews without a security-specific model now follow the code-review preset instead of the organization/CLI default.

## How Has This Been Tested?

- `bun test test/modes/tag/security-review-command.test.ts test/gitlab/review-config-resolution.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `git diff --check`
