### PR TITLE
Merge dev into main: deterministic review posting

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -30,3 +30,4 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
+          allowed_bots: "dependabot,factory-droid"

--- a/README.md
+++ b/README.md
@@ -343,13 +343,15 @@ To leave comments and approvals on your PRs, Droid needs a GitHub token. There a
 
 ### Review Configuration
 
-| Input              | Default | Purpose                                                                                              |
-| ------------------ | ------- | ---------------------------------------------------------------------------------------------------- |
-| `automatic_review` | `false` | Automatically run code review on PRs without requiring `@droid review`.                              |
-| `review_depth`     | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below. |
-| `review_model`     | `""`    | Override the model for code review. When empty, determined by `review_depth`.                        |
-| `reasoning_effort` | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                      |
-| `fill_model`       | `""`    | Override the model used for PR description fill.                                                     |
+| Input                         | Default | Purpose                                                                                              |
+| ----------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `automatic_review`            | `false` | Automatically run code review on PRs without requiring `@droid review`.                              |
+| `review_depth`                | `deep`  | Review depth preset: `shallow` (fast) or `deep` (thorough). See [Review Depth](#review-depth) below. |
+| `review_model`                | `""`    | Override the model for code review. When empty, determined by `review_depth`.                        |
+| `reasoning_effort`            | `""`    | Override reasoning effort for review. When empty, determined by `review_depth`.                      |
+| `review_candidates_max_turns` | `100`   | Stop candidate generation after this many assistant turns.                                           |
+| `review_validator_max_turns`  | `40`    | Stop validation after this many assistant turns.                                                     |
+| `fill_model`                  | `""`    | Override the model used for PR description fill.                                                     |
 
 ### Review Depth
 

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,14 @@ inputs:
     description: "Path to write review validated JSON (pass 2 of the two-pass review)."
     required: false
     default: "${{ runner.temp }}/droid-prompts/review_validated.json"
+  review_candidates_max_turns:
+    description: "Maximum agent turns for review candidate generation (pass 1). Empty disables the cap."
+    required: false
+    default: "100"
+  review_validator_max_turns:
+    description: "Maximum agent turns for review validation (pass 2). Empty disables the cap."
+    required: false
+    default: "40"
   fill_model:
     description: "Override the model used for PR description fill (e.g., 'claude-sonnet-4-5-20250929', 'gpt-5.1-codex'). Only applies to fill flows."
     required: false
@@ -327,6 +335,7 @@ runs:
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_MAX_TURNS: ${{ steps.prepare.outputs.run_code_review == 'true' && inputs.review_candidates_max_turns || '' }}
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
@@ -383,12 +392,25 @@ runs:
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_MAX_TURNS: ${{ inputs.review_validator_max_turns }}
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
         NODE_VERSION: ${{ env.NODE_VERSION }}
         DETAILED_PERMISSION_MESSAGES: "1"
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
+
+    - name: Post review
+      id: post_review
+      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.steward_skipped != 'true' && steps.prepare.outputs.run_code_review == 'true' && steps.prepare_validator.outputs.validator_should_run != 'false' && steps.droid_validator.outputs.conclusion == 'success'
+      shell: bash
+      run: |
+        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/github-post-review.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.prepare.outputs.github_token }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
+        REVIEW_DIFF_PATH: ${{ runner.temp }}/droid-prompts/pr.diff
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json
 
     - name: Update comment with job link
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.steward_skipped != 'true' && steps.prepare.outputs.droid_comment_id && github.event_name != 'workflow_run' && always()
@@ -404,12 +426,14 @@ runs:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         IS_PR: ${{ github.event.issue.pull_request != null || github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review_comment' }}
-        DROID_SUCCESS: ${{ (steps.prepare.outputs.run_code_review == 'true' && ((steps.prepare_validator.outputs.validator_should_run == 'false' && steps.droid.outputs.conclusion == 'success') || (steps.prepare_validator.outputs.validator_should_run != 'false' && steps.droid_validator.outputs.conclusion == 'success'))) || (steps.prepare.outputs.run_code_review != 'true' && steps.droid.outputs.conclusion == 'success') }}
+        DROID_SUCCESS: ${{ (steps.prepare.outputs.run_code_review == 'true' && ((steps.prepare_validator.outputs.validator_should_run == 'false' && steps.droid.outputs.conclusion == 'success') || (steps.prepare_validator.outputs.validator_should_run != 'false' && steps.droid.outputs.conclusion == 'success' && steps.droid_validator.outputs.conclusion == 'success' && steps.post_review.outputs.conclusion == 'success'))) || (steps.prepare.outputs.run_code_review != 'true' && steps.droid.outputs.conclusion == 'success') }}
         TRIGGER_USERNAME: ${{ github.event.comment.user.login || github.event.issue.user.login || github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
         DROID_ERROR_MESSAGE: ${{ steps.droid.outputs.error_message || '' }}
         DROID_VALIDATOR_ERROR_MESSAGE: ${{ steps.droid_validator.outputs.error_message || '' }}
+        DROID_POST_ERROR_MESSAGE: ${{ steps.post_review.outputs.error_message || '' }}
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json
         MODEL_FALLBACK_NOTE: ${{ steps.prepare.outputs.model_fallback_note || steps.prepare_validator.outputs.model_fallback_note || steps.droid.outputs.model_fallback_note || steps.droid_validator.outputs.model_fallback_note || '' }}
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}

--- a/action.yml
+++ b/action.yml
@@ -394,8 +394,10 @@ runs:
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
         INPUT_MAX_TURNS: ${{ inputs.review_validator_max_turns }}
 
-        # Model configuration
-        GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        # No GITHUB_TOKEN here on purpose: the validator only reads files and
+        # writes review_validated.json, and it keeps `Execute`. Withholding the
+        # token means a prompt injection in the diff has no credential to
+        # reach the GitHub API with; the post_review step below does the write.
         NODE_VERSION: ${{ env.NODE_VERSION }}
         DETAILED_PERMISSION_MESSAGES: "1"
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: "Show full JSON output from Droid Exec. WARNING: This outputs ALL Droid messages including tool execution results which may contain secrets, API keys, or other sensitive information. These logs are publicly visible in GitHub Actions. Only enable for debugging in non-sensitive environments."
     required: false
     default: "false"
+  max_turns:
+    description: "Maximum assistant turns before Droid Exec is stopped. Empty disables the cap."
+    required: false
+    default: ""
 
 outputs:
   conclusion:
@@ -122,6 +126,7 @@ runs:
         INPUT_PATH_TO_DROID_EXECUTABLE: ${{ inputs.path_to_droid_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_MAX_TURNS: ${{ inputs.max_turns }}
 
         # Provider configuration
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}

--- a/base-action/src/run-droid.ts
+++ b/base-action/src/run-droid.ts
@@ -84,6 +84,11 @@ export type DroidOptions = {
   pathToDroidExecutable?: string;
   allowedTools?: string;
   disallowedTools?: string;
+  /**
+   * Upper bound on assistant turns before the run is aborted. Enforced here
+   * by watching the stream-json output, since `droid exec` has no turn limit
+   * of its own. Empty disables the cap.
+   */
   maxTurns?: string;
   mcpTools?: string;
   systemPrompt?: string;
@@ -96,6 +101,64 @@ type PreparedConfig = {
   promptPath: string;
   env: Record<string, string>;
 };
+
+export function parseMaxTurns(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      `max_turns must be a positive integer, got ${JSON.stringify(value)}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Counts assistant turns in `droid exec --output-format stream-json` output.
+ *
+ * One assistant turn fans out into several events (`reasoning`, `message`,
+ * `tool_call`) that share the assistant message id (`messageId` on
+ * tool_call, `id` on the others), so turns are counted as distinct ids.
+ * Subagents run as separate processes and never appear on this stream, so
+ * the count covers the root session only.
+ */
+export function createTurnCounter() {
+  const seen = new Set<string>();
+  return {
+    get count() {
+      return seen.size;
+    },
+    /** Returns the turn count after observing `event`. */
+    observe(event: unknown): number {
+      if (typeof event !== "object" || event === null) return seen.size;
+      const e = event as Record<string, unknown>;
+      let id: unknown;
+      if (e.type === "tool_call") {
+        id = e.messageId;
+      } else if (
+        (e.type === "message" && e.role === "assistant") ||
+        e.type === "reasoning"
+      ) {
+        id = e.id;
+      }
+      if (typeof id === "string" && id) {
+        seen.add(id);
+      }
+      return seen.size;
+    },
+  };
+}
+
+export class MaxTurnsExceededError extends Error {
+  constructor(public readonly maxTurns: number) {
+    super(
+      `Droid Exec exceeded the maximum of ${maxTurns} turns and was stopped. ` +
+        "This usually means the agent got stuck in a loop.",
+    );
+    this.name = "MaxTurnsExceededError";
+  }
+}
 
 export function prepareRunConfig(
   promptPath: string,
@@ -258,6 +321,11 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
     );
   }
 
+  const maxTurns = parseMaxTurns(options.maxTurns);
+  if (maxTurns !== null) {
+    console.log(`Turn limit: ${maxTurns}`);
+  }
+
   // Run Droid Exec with retry for transient failures. Uses the shared
   // retryWithBackoff so backoff timing lives in one place (3 total attempts,
   // 5s then 10s delays).
@@ -279,6 +347,8 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
 
   const runDroidOnce = (): Promise<number> => {
     stderrTail = "";
+    const turns = createTurnCounter();
+    let turnLimitHit = false;
     const droidProcess = spawn(droidExecutable, currentDroidArgs, {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
@@ -286,6 +356,22 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
         ...config.env,
       },
     });
+
+    const stopForTurnLimit = () => {
+      if (turnLimitHit) return;
+      turnLimitHit = true;
+      console.error(
+        `Droid Exec reached the turn limit (${maxTurns}); stopping the process`,
+      );
+      droidProcess.kill("SIGTERM");
+      // Give the CLI a moment to flush and exit cleanly before forcing it.
+      const forceKill = setTimeout(() => {
+        if (droidProcess.exitCode === null) {
+          droidProcess.kill("SIGKILL");
+        }
+      }, 5000);
+      forceKill.unref();
+    };
 
     droidProcess.stderr.on("data", (data) => {
       const text = data.toString();
@@ -304,58 +390,68 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
 
     // Capture output for parsing execution metrics
     let sessionId: string | undefined;
-    droidProcess.stdout.on("data", (data) => {
-      const text = data.toString();
+    let stdoutBuffer = "";
+    const handleStdoutLine = (line: string): void => {
+      if (line.trim() === "") return;
 
-      // Try to parse as JSON and handle based on verbose setting
-      const lines = text.split("\n");
-      lines.forEach((line: string, index: number) => {
-        if (line.trim() === "") return;
-
-        try {
-          // Check if this line is a JSON object
-          const parsed = JSON.parse(line);
-          if (!sessionId && typeof parsed === "object" && parsed !== null) {
-            const detectedSessionId = parsed.session_id;
-            if (
-              typeof detectedSessionId === "string" &&
-              detectedSessionId.trim()
-            ) {
-              sessionId = detectedSessionId;
-              console.log(`Detected Droid session: ${sessionId}`);
-            }
-          }
+      try {
+        const parsed = JSON.parse(line);
+        if (!sessionId && typeof parsed === "object" && parsed !== null) {
+          const detectedSessionId = parsed.session_id;
           if (
-            typeof parsed === "object" &&
-            parsed !== null &&
-            parsed.type === "result"
+            typeof detectedSessionId === "string" &&
+            detectedSessionId.trim()
           ) {
-            lastResultEvent = {
-              is_error: parsed.is_error === true,
-              result:
-                typeof parsed.result === "string" ? parsed.result : undefined,
-            };
+            sessionId = detectedSessionId;
+            console.log(`Detected Droid session: ${sessionId}`);
           }
-          const sanitizedOutput = sanitizeJsonOutput(parsed, showFullOutput);
-
-          if (sanitizedOutput) {
-            process.stdout.write(sanitizedOutput);
-            if (index < lines.length - 1 || text.endsWith("\n")) {
-              process.stdout.write("\n");
-            }
-          }
-        } catch (e) {
-          // Not a JSON object
-          if (showFullOutput) {
-            // In full output mode, print as is
-            process.stdout.write(line);
-            if (index < lines.length - 1 || text.endsWith("\n")) {
-              process.stdout.write("\n");
-            }
-          }
-          // In non-full-output mode, suppress non-JSON output
         }
-      });
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          parsed.type === "result"
+        ) {
+          lastResultEvent = {
+            is_error: parsed.is_error === true,
+            result:
+              typeof parsed.result === "string" ? parsed.result : undefined,
+          };
+        }
+        if (
+          maxTurns !== null &&
+          !turnLimitHit &&
+          turns.observe(parsed) > maxTurns
+        ) {
+          stopForTurnLimit();
+        }
+        const sanitizedOutput = sanitizeJsonOutput(parsed, showFullOutput);
+
+        if (sanitizedOutput) {
+          process.stdout.write(`${sanitizedOutput}\n`);
+        }
+      } catch {
+        // Not a JSON object
+        if (showFullOutput) {
+          process.stdout.write(`${line}\n`);
+        }
+        // In non-full-output mode, suppress non-JSON output
+      }
+    };
+
+    droidProcess.stdout.on("data", (data) => {
+      stdoutBuffer += data.toString();
+      const lines = stdoutBuffer.split("\n");
+      stdoutBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        handleStdoutLine(line);
+      }
+    });
+
+    droidProcess.stdout.on("end", () => {
+      if (stdoutBuffer) {
+        handleStdoutLine(stdoutBuffer);
+        stdoutBuffer = "";
+      }
     });
 
     // Handle stdout errors
@@ -364,8 +460,12 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
     });
 
     // Wait for Droid Exec to finish
-    return new Promise<number>((resolve) => {
+    return new Promise<number>((resolve, reject) => {
       droidProcess.on("close", (code) => {
+        if (turnLimitHit) {
+          reject(new MaxTurnsExceededError(maxTurns!));
+          return;
+        }
         resolve(code || 0);
       });
 
@@ -376,10 +476,21 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
     });
   };
 
+  let turnCapError: MaxTurnsExceededError | null = null;
+  const getTurnCapError = (): MaxTurnsExceededError | null => turnCapError;
+
   try {
     await retryWithBackoff(
       async () => {
-        lastExitCode = await runDroidOnce();
+        try {
+          lastExitCode = await runDroidOnce();
+        } catch (error) {
+          if (error instanceof MaxTurnsExceededError) {
+            turnCapError = error;
+            lastExitCode = 1;
+          }
+          throw error;
+        }
         if (lastExitCode !== 0) {
           console.log(`Droid Exec exited with code ${lastExitCode}`);
           // If the failure was caused by the requested model being rejected
@@ -417,22 +528,33 @@ export async function runDroid(promptPath: string, options: DroidOptions) {
           throw new Error(`Droid Exec exited with code ${lastExitCode}`);
         }
       },
-      { maxAttempts: 3, initialDelayMs: 5000, maxDelayMs: 20000 },
+      {
+        maxAttempts: 3,
+        initialDelayMs: 5000,
+        maxDelayMs: 20000,
+        // A runaway agent is not a transient failure; re-running it would
+        // only repeat the loop.
+        shouldRetry: (error) => !(error instanceof MaxTurnsExceededError),
+      },
     );
     core.setOutput("conclusion", "success");
     return;
   } catch (_) {
-    // All retry attempts exhausted
-    console.error(
-      `Droid Exec failed after 3 total attempts (exit code: ${lastExitCode})`,
-    );
+    const capError = getTurnCapError();
+    if (!capError) {
+      // All retry attempts exhausted
+      console.error(
+        `Droid Exec failed after 3 total attempts (exit code: ${lastExitCode})`,
+      );
+    }
     const finalResultEvent = getLastResultEvent();
     let finalStderrTail = getStderrTail().trim();
     if (isInvalidModelError(finalStderrTail)) {
       finalStderrTail = condenseInvalidModelError(finalStderrTail);
     }
-    const rawErrorMessage =
-      finalResultEvent?.is_error && finalResultEvent.result?.trim()
+    const rawErrorMessage = capError
+      ? capError.message
+      : finalResultEvent?.is_error && finalResultEvent.result?.trim()
         ? finalResultEvent.result.trim()
         : finalStderrTail
           ? `Droid Exec exited with code ${lastExitCode}:\n${finalStderrTail}`

--- a/base-action/src/utils/retry.ts
+++ b/base-action/src/utils/retry.ts
@@ -3,6 +3,12 @@ export type RetryOptions = {
   initialDelayMs?: number;
   maxDelayMs?: number;
   backoffFactor?: number;
+  /**
+   * Decides whether a failed attempt is worth retrying. Returning false
+   * rethrows the error immediately, skipping the backoff and any remaining
+   * attempts. Defaults to retrying every error.
+   */
+  shouldRetry?: (error: Error) => boolean;
 };
 
 /**
@@ -22,6 +28,7 @@ export async function retryWithBackoff<T>(
     initialDelayMs = 5000,
     maxDelayMs = 20000,
     backoffFactor = 2,
+    shouldRetry,
   } = options;
 
   let delayMs = initialDelayMs;
@@ -34,6 +41,11 @@ export async function retryWithBackoff<T>(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       console.error(`Attempt ${attempt} failed:`, lastError.message);
+
+      if (shouldRetry && !shouldRetry(lastError)) {
+        console.error("Error is not retryable; giving up");
+        throw lastError;
+      }
 
       if (attempt < maxAttempts) {
         console.log(`Retrying in ${delayMs / 1000} seconds...`);

--- a/base-action/test/retry.test.ts
+++ b/base-action/test/retry.test.ts
@@ -69,4 +69,25 @@ describe("retryWithBackoff", () => {
       | undefined;
     expect(firstCall?.[1]).toBe(5);
   });
+
+  it("rethrows immediately, without backoff, when shouldRetry returns false", async () => {
+    let attempts = 0;
+
+    await expect(
+      retryWithBackoff(
+        async () => {
+          attempts += 1;
+          throw new Error(attempts === 1 ? "fatal" : "transient");
+        },
+        {
+          maxAttempts: 3,
+          initialDelayMs: 5,
+          shouldRetry: (error) => error.message !== "fatal",
+        },
+      ),
+    ).rejects.toThrow("fatal");
+
+    expect(attempts).toBe(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
 });

--- a/base-action/test/run-droid-max-turns.test.ts
+++ b/base-action/test/run-droid-max-turns.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as core from "@actions/core";
+import { chmod, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runDroid } from "../src/run-droid";
+
+/**
+ * Stand-in for `droid exec` that emits one assistant turn per interval,
+ * forever, in stream-json format. Never exits on its own, so the only way
+ * the run ends is the turn cap killing it.
+ */
+const RUNAWAY_DROID = `#!/usr/bin/env bash
+i=0
+while true; do
+  i=$((i+1))
+  printf '{"type":"message","role":"assistant","id":"m'
+  sleep 0.01
+  echo ''"$i"'","text":"again","session_id":"s"}'
+  echo '{"type":"tool_call","id":"c'"$i"'","messageId":"m'"$i"'","toolId":"github_pr___submit_review"}'
+  sleep 0.05
+done
+`;
+
+describe("runDroid turn cap", () => {
+  let dir: string;
+  let fakeDroid: string;
+  let promptPath: string;
+  let outputs: Record<string, string>;
+  let setOutputSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "droid-max-turns-"));
+    fakeDroid = join(dir, "droid");
+    promptPath = join(dir, "prompt.txt");
+    await writeFile(fakeDroid, RUNAWAY_DROID);
+    await chmod(fakeDroid, 0o755);
+    await writeFile(promptPath, "loop forever");
+    outputs = {};
+    setOutputSpy = spyOn(core, "setOutput").mockImplementation(
+      (name: string, value: unknown) => {
+        outputs[name] = String(value);
+      },
+    );
+  });
+
+  afterEach(async () => {
+    setOutputSpy.mockRestore();
+    exitSpy?.mockRestore();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("kills a runaway agent at the cap without retrying it", async () => {
+    let exitCode: number | undefined;
+    exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    const started = Date.now();
+    await expect(
+      runDroid(promptPath, {
+        pathToDroidExecutable: fakeDroid,
+        maxTurns: "5",
+        showFullOutput: "false",
+      }),
+    ).rejects.toThrow("process.exit(1)");
+
+    expect(exitCode).toBe(1);
+    expect(outputs.conclusion).toBe("failure");
+    expect(outputs.error_message).toContain("maximum of 5 turns");
+    // A retry would have waited for the 5s backoff before re-spawning; the
+    // cap must short-circuit that.
+    expect(Date.now() - started).toBeLessThan(4000);
+  }, 15000);
+});

--- a/base-action/test/run-droid.test.ts
+++ b/base-action/test/run-droid.test.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect } from "bun:test";
-import { prepareRunConfig, type DroidOptions } from "../src/run-droid";
+import {
+  createTurnCounter,
+  parseMaxTurns,
+  prepareRunConfig,
+  type DroidOptions,
+} from "../src/run-droid";
 
 describe("prepareRunConfig", () => {
   test("should prepare config with basic arguments", () => {
@@ -86,5 +91,75 @@ describe("prepareRunConfig", () => {
         "/tmp/test-prompt.txt",
       ]);
     });
+  });
+
+  test("maxTurns is enforced by the action, not forwarded as a CLI flag", () => {
+    // `droid exec` rejects unknown options, so a forwarded --max-turns would
+    // fail every run instead of bounding it.
+    const prepared = prepareRunConfig("/tmp/test-prompt.txt", {
+      maxTurns: "40",
+    });
+
+    expect(prepared.droidArgs).not.toContain("--max-turns");
+  });
+});
+
+describe("parseMaxTurns", () => {
+  test("treats empty input as no limit", () => {
+    expect(parseMaxTurns(undefined)).toBeNull();
+    expect(parseMaxTurns("")).toBeNull();
+    expect(parseMaxTurns("   ")).toBeNull();
+  });
+
+  test("parses a positive integer", () => {
+    expect(parseMaxTurns("40")).toBe(40);
+    expect(parseMaxTurns(" 100 ")).toBe(100);
+  });
+
+  test("rejects non-positive or non-integer values", () => {
+    expect(() => parseMaxTurns("0")).toThrow(/positive integer/);
+    expect(() => parseMaxTurns("-3")).toThrow(/positive integer/);
+    expect(() => parseMaxTurns("2.5")).toThrow(/positive integer/);
+    expect(() => parseMaxTurns("lots")).toThrow(/positive integer/);
+  });
+});
+
+describe("createTurnCounter", () => {
+  const assistantTurn = (id: string) => [
+    { type: "reasoning", id, text: "thinking", session_id: "s" },
+    { type: "message", role: "assistant", id, text: "hi", session_id: "s" },
+    { type: "tool_call", id: `${id}-call-1`, messageId: id, toolId: "Read" },
+    { type: "tool_call", id: `${id}-call-2`, messageId: id, toolId: "Grep" },
+  ];
+
+  test("counts one turn per assistant message across its fan-out events", () => {
+    const counter = createTurnCounter();
+
+    for (const event of assistantTurn("m1")) counter.observe(event);
+    expect(counter.count).toBe(1);
+
+    for (const event of assistantTurn("m2")) counter.observe(event);
+    expect(counter.count).toBe(2);
+  });
+
+  test("ignores user messages, tool results, system and result events", () => {
+    const counter = createTurnCounter();
+
+    counter.observe({ type: "system", subtype: "init", session_id: "s" });
+    counter.observe({ type: "message", role: "user", id: "u1", text: "go" });
+    counter.observe({ type: "tool_result", id: "m1-call-1", value: "ok" });
+    counter.observe({ type: "result", num_turns: 12 });
+    counter.observe("not an object");
+    counter.observe(null);
+
+    expect(counter.count).toBe(0);
+  });
+
+  test("returns the running count from observe", () => {
+    const counter = createTurnCounter();
+
+    expect(counter.observe(assistantTurn("m1")[1])).toBe(1);
+    expect(counter.observe(assistantTurn("m1")[2])).toBe(1);
+    expect(counter.observe(assistantTurn("m2")[2])).toBe(2);
   });
 });

--- a/docs/gitlab-setup.md
+++ b/docs/gitlab-setup.md
@@ -149,7 +149,7 @@ Notes:
 Each MR pipeline produces:
 
 - **Inline review comments** anchored to the relevant diff lines, posted in a
-  single batched `submit_review` call. Findings are prefixed with priority
+  deterministic CI step after validation. Findings are prefixed with priority
   tags (`P0`, `P1`, `P2`, `P3`) and `[security]` for security findings.
 - **A sticky tracking note** on the MR with pipeline + job links, telemetry
   (`N turns • Xm Ys`), session IDs, and a security badge when

--- a/review/action.yml
+++ b/review/action.yml
@@ -40,11 +40,19 @@ inputs:
     description: "Include code suggestion blocks in review comments when the fix is high-confidence. Set to 'false' to disable suggestions."
     required: false
     default: "true"
+  candidates_max_turns:
+    description: "Maximum agent turns for the candidate-finding pass (pass 1) before the run is stopped. Empty disables the cap."
+    required: false
+    default: "100"
+  validator_max_turns:
+    description: "Maximum agent turns for the validation pass (pass 2) before the run is stopped. Empty disables the cap."
+    required: false
+    default: "40"
 
 outputs:
   conclusion:
     description: "Review conclusion (success/failure)"
-    value: ${{ steps.review.outputs.conclusion }}
+    value: ${{ steps.post_review.outputs.conclusion || steps.validator.outputs.conclusion || steps.review.outputs.conclusion }}
 
 runs:
   using: "composite"
@@ -113,6 +121,7 @@ runs:
         INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
         INPUT_DROID_ARGS: ${{ steps.prompt.outputs.droid_args }}
         INPUT_MCP_TOOLS: ${{ steps.prompt.outputs.mcp_tools }}
+        INPUT_MAX_TURNS: ${{ inputs.candidates_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
@@ -135,6 +144,7 @@ runs:
 
     - name: Run Validator
       id: validator
+      if: steps.prepare_validator.outputs.validator_should_run != 'false'
       shell: bash
       run: |
         bun run ${{ github.action_path }}/../base-action/src/index.ts
@@ -142,8 +152,21 @@ runs:
         INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
         INPUT_DROID_ARGS: ${{ steps.prepare_validator.outputs.droid_args }}
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
+        INPUT_MAX_TURNS: ${{ inputs.validator_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+
+    - name: Post Review
+      id: post_review
+      if: steps.prepare_validator.outputs.validator_should_run != 'false' && steps.validator.outputs.conclusion == 'success'
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/github-post-review.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
+        REVIEW_DIFF_PATH: ${{ runner.temp }}/droid-prompts/pr.diff
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json
 
     - name: Update tracking comment
       if: always() && inputs.tracking_comment_id
@@ -159,7 +182,9 @@ runs:
         OUTPUT_FILE: ${{ inputs.output_file }}
         TRIGGER_USERNAME: ${{ github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: "true"
-        DROID_SUCCESS: ${{ steps.validator.outcome == 'success' }}
+        DROID_SUCCESS: ${{ steps.review.outputs.conclusion == 'success' && (steps.prepare_validator.outputs.validator_should_run == 'false' || (steps.validator.outputs.conclusion == 'success' && steps.post_review.outputs.conclusion == 'success')) }}
         DROID_ERROR_MESSAGE: ${{ steps.review.outputs.error_message || '' }}
         DROID_VALIDATOR_ERROR_MESSAGE: ${{ steps.validator.outputs.error_message || '' }}
+        DROID_POST_ERROR_MESSAGE: ${{ steps.post_review.outputs.error_message || '' }}
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json
         MODEL_FALLBACK_NOTE: ${{ steps.prompt.outputs.model_fallback_note || steps.prepare_validator.outputs.model_fallback_note || steps.review.outputs.model_fallback_note || steps.validator.outputs.model_fallback_note || '' }}

--- a/review/action.yml
+++ b/review/action.yml
@@ -154,7 +154,8 @@ runs:
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
         INPUT_MAX_TURNS: ${{ inputs.validator_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
-        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        # No GITHUB_TOKEN: the validator only writes review_validated.json and
+        # keeps `Execute`, so it must not hold a credential. post_review posts.
 
     - name: Post Review
       id: post_review

--- a/security/action.yml
+++ b/security/action.yml
@@ -56,11 +56,19 @@ inputs:
     description: "Include code suggestion blocks in review comments."
     required: false
     default: "false"
+  candidates_max_turns:
+    description: "Maximum agent turns for the candidate-finding pass (pass 1) before the run is stopped. Empty disables the cap."
+    required: false
+    default: "100"
+  validator_max_turns:
+    description: "Maximum agent turns for the validation pass (pass 2) before the run is stopped. Empty disables the cap."
+    required: false
+    default: "40"
 
 outputs:
   conclusion:
     description: "Review conclusion (success/failure)"
-    value: ${{ steps.validator.outputs.conclusion }}
+    value: ${{ steps.post_review.outputs.conclusion || steps.validator.outputs.conclusion || steps.review.outputs.conclusion }}
 
 runs:
   using: "composite"
@@ -139,6 +147,7 @@ runs:
         INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
         INPUT_DROID_ARGS: ${{ steps.prompt.outputs.droid_args }}
         INPUT_MCP_TOOLS: ${{ steps.prompt.outputs.mcp_tools }}
+        INPUT_MAX_TURNS: ${{ inputs.candidates_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
         DROID_OUTPUT_FILE: ${{ inputs.output_file }}
@@ -150,6 +159,7 @@ runs:
         bun run ${{ github.action_path }}/../src/entrypoints/prepare-validator.ts
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
         REVIEW_CANDIDATES_PATH: ${{ inputs.review_candidates_path }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
@@ -160,6 +170,7 @@ runs:
 
     - name: Run Validator
       id: validator
+      if: steps.prepare_validator.outputs.validator_should_run != 'false'
       shell: bash
       run: |
         bun run ${{ github.action_path }}/../base-action/src/index.ts
@@ -167,8 +178,21 @@ runs:
         INPUT_PROMPT_FILE: ${{ runner.temp }}/droid-prompts/droid-prompt.txt
         INPUT_DROID_ARGS: ${{ steps.prepare_validator.outputs.droid_args }}
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
+        INPUT_MAX_TURNS: ${{ inputs.validator_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
         GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+
+    - name: Post Review
+      id: post_review
+      if: steps.prepare_validator.outputs.validator_should_run != 'false' && steps.validator.outputs.conclusion == 'success'
+      shell: bash
+      run: |
+        bun run ${{ github.action_path }}/../src/entrypoints/github-post-review.ts
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        REVIEW_VALIDATED_PATH: ${{ inputs.review_validated_path }}
+        REVIEW_DIFF_PATH: ${{ runner.temp }}/droid-prompts/pr.diff
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json
 
     - name: Update tracking comment
       if: always() && inputs.tracking_comment_id
@@ -184,4 +208,8 @@ runs:
         OUTPUT_FILE: ${{ inputs.output_file }}
         TRIGGER_USERNAME: ${{ github.event.pull_request.user.login || github.event.sender.login || github.triggering_actor || github.actor || '' }}
         PREPARE_SUCCESS: "true"
-        DROID_SUCCESS: ${{ steps.validator.outcome == 'success' }}
+        DROID_SUCCESS: ${{ steps.review.outputs.conclusion == 'success' && (steps.prepare_validator.outputs.validator_should_run == 'false' || (steps.validator.outputs.conclusion == 'success' && steps.post_review.outputs.conclusion == 'success')) }}
+        DROID_ERROR_MESSAGE: ${{ steps.review.outputs.error_message || '' }}
+        DROID_VALIDATOR_ERROR_MESSAGE: ${{ steps.validator.outputs.error_message || '' }}
+        DROID_POST_ERROR_MESSAGE: ${{ steps.post_review.outputs.error_message || '' }}
+        REVIEW_POST_RESULTS_PATH: ${{ runner.temp }}/droid-prompts/review_post_results.json

--- a/security/action.yml
+++ b/security/action.yml
@@ -180,7 +180,8 @@ runs:
         INPUT_MCP_TOOLS: ${{ steps.prepare_validator.outputs.mcp_tools }}
         INPUT_MAX_TURNS: ${{ inputs.validator_max_turns }}
         FACTORY_API_KEY: ${{ inputs.factory_api_key }}
-        GITHUB_TOKEN: ${{ steps.token.outputs.github_token }}
+        # No GITHUB_TOKEN: the validator only writes review_validated.json and
+        # keeps `Execute`, so it must not hold a credential. post_review posts.
 
     - name: Post Review
       id: post_review

--- a/src/core/review/prompts/types.ts
+++ b/src/core/review/prompts/types.ts
@@ -47,8 +47,7 @@ export interface ReviewTerminology {
   mutationToolForbiddance: string;
 
   // The fields below only apply to `postingMode: "tool"` (the agent posts
-  // its own findings through MCP). Platforms that post from CI instead
-  // (see `postingMode: "file"`) leave them undefined.
+  // its own findings through MCP). File-posting adapters leave them undefined.
 
   /** MCP tool name for posting a batched review (Pass 2) */
   submitReviewToolName?: string;

--- a/src/core/review/prompts/validator.ts
+++ b/src/core/review/prompts/validator.ts
@@ -5,12 +5,10 @@
  * each one, and writes a refined JSON to disk. What happens next depends
  * on `postingMode`:
  *
- *   - "tool" (GitHub): the agent posts the approved findings itself as a
- *     single batched call to the platform's submit-review MCP tool. Pass 2
- *     is the only place that tool is exposed (via `--enabled-tools`).
- *   - "file" (GitLab): the validated JSON *is* the deliverable, and a CI
- *     step posts it through the platform API. The agent holds no
- *     MR-mutation tools at all.
+ *   - "tool": the agent posts approved findings through an MCP tool.
+ *   - "file" (GitHub and GitLab): the validated JSON is the deliverable,
+ *     and a deterministic CI step posts it through the platform API. The
+ *     agent holds no PR/MR mutation tools.
  *
  * Both `src/create-prompt/templates/review-validator-prompt.ts` (GitHub)
  * and `src/gitlab/prompts/validator.ts` (GitLab) delegate to this builder
@@ -49,6 +47,8 @@ After writing \`${validatedPath}\`, post comments ONLY for \`status === "approve
 
 * Collect all approved comments and submit them as a **single batched review** via \`${submitReviewToolName}\`, passing them in the \`comments\` array parameter${t.submitReviewExtraArg ?? ""}.
 * Do **NOT** post comments individually — batch them all into one \`submit_review\` call.
+* Call \`submit_review\` **exactly once**. Once it returns a success message the review is posted; do NOT call it again to "confirm", retry, or re-post the same findings. If it reports that the review was already submitted, the review is complete — move on to the tracking comment and finish.
+* If there are no approved comments, do NOT call \`submit_review\` at all.
 * Do **NOT** include a \`body\` parameter in \`submit_review\`${t.submitReviewBodyExclusionTrailer ?? ""}.
 * Use \`${updateTrackingToolName}\` to update the ${t.trackingCommentName ?? "tracking comment"} with the review summary.
 * Do **NOT** post the summary as a separate ${t.summaryEntityName ?? "comment"}${t.summaryPostingExtraExclusion ?? ""}.
@@ -77,7 +77,7 @@ through the ${t.platformName} API, then updates the ${t.trackingCommentName ?? "
   every approved comment keeps its \`path\`, \`side\`, and \`line\` (\`side: "RIGHT"\`
   anchors to the new file line, \`side: "LEFT"\` anchors to the old file line).
 * A line anchor that is not part of the diff (neither added, removed, nor context
-  inside a hunk) cannot be posted inline and degrades to a plain ${t.entityNoun} comment —
+  inside a hunk) cannot be posted inline and degrades to a non-inline finding —
   prefer re-anchoring such findings to the nearest related changed line.
 `;
 }

--- a/src/core/review/tracking/results.ts
+++ b/src/core/review/tracking/results.ts
@@ -1,0 +1,102 @@
+import * as fs from "fs/promises";
+import type {
+  ReviewPostFailure,
+  ReviewPostOutcome,
+  ReviewPostResults,
+} from "./types";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function count(root: Record<string, unknown>, field: string): number {
+  const value = root[field];
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new Error(`review post results has invalid \`${field}\``);
+  }
+  return value as number;
+}
+
+export function parseReviewPostResults(raw: string): ReviewPostResults {
+  const root = asRecord(JSON.parse(raw));
+  if (!root) throw new Error("review post results is not an object");
+
+  if (
+    root.summaryBody !== null &&
+    root.summaryBody !== undefined &&
+    typeof root.summaryBody !== "string"
+  ) {
+    throw new Error("review post results has invalid `summaryBody`");
+  }
+  if (!Array.isArray(root.failures)) {
+    throw new Error("review post results has invalid `failures`");
+  }
+
+  const failures: ReviewPostFailure[] = root.failures.map((value, index) => {
+    const failure = asRecord(value);
+    if (
+      !failure ||
+      typeof failure.path !== "string" ||
+      (failure.line !== null &&
+        (!Number.isInteger(failure.line) || (failure.line as number) <= 0)) ||
+      typeof failure.error !== "string"
+    ) {
+      throw new Error(
+        `review post results has invalid failure at index ${index}`,
+      );
+    }
+    return {
+      path: failure.path,
+      line: failure.line as number | null,
+      error: failure.error,
+    };
+  });
+
+  return {
+    posted: count(root, "posted"),
+    fallbackPosted: count(root, "fallbackPosted"),
+    approved: count(root, "approved"),
+    rejected: count(root, "rejected"),
+    failed: count(root, "failed"),
+    skipped: count(root, "skipped"),
+    summaryBody: typeof root.summaryBody === "string" ? root.summaryBody : null,
+    failures,
+  };
+}
+
+export function reviewPostOutcome(
+  results: ReviewPostResults,
+): ReviewPostOutcome {
+  return {
+    posted: results.posted,
+    fallbackPosted: results.fallbackPosted,
+    failed: results.failed,
+    skipped: results.skipped,
+    summaryBody: results.summaryBody,
+  };
+}
+
+/**
+ * Reads results when present. A missing file means posting did not run;
+ * malformed output remains an error rather than masquerading as absence.
+ */
+export async function readReviewPostOutcome(
+  filePath: string,
+): Promise<ReviewPostOutcome | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return reviewPostOutcome(parseReviewPostResults(raw));
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/core/review/tracking/types.ts
+++ b/src/core/review/tracking/types.ts
@@ -3,11 +3,9 @@
  *
  * Both GitHub and GitLab keep a single "sticky" comment per PR/MR that
  * carries the live status of the Droid review pipeline (running →
- * success/failure) plus telemetry. The body-building mechanics differ
- * between platforms today — GitHub updates it from inside the agent via
- * the github-comment-server MCP tool, while GitLab builds the whole body
- * in TypeScript and writes it from CI — so we only share the contract
- * (state machine + telemetry shape) here, not the renderer itself.
+ * success/failure) plus telemetry. Both platforms deterministically render
+ * final review results from the posting-step JSON, while their markdown
+ * layouts and update APIs remain platform-specific.
  */
 
 export type ReviewTrackingState = "running" | "success" | "failure";
@@ -23,13 +21,13 @@ export type ReviewTrackingTelemetry = {
 /**
  * Outcome of the posting step, rendered into the sticky comment/note.
  *
- * Populated on platforms that post from CI (GitLab), where the numbers are
- * known only after the API calls have been made.
+ * Populated on platforms that post from CI, where the numbers are known
+ * only after the API calls have been made.
  */
 export type ReviewPostOutcome = {
   /** Inline comments successfully posted. */
   posted?: number | null;
-  /** Approved comments posted as plain notes (line outside the diff). */
+  /** Approved comments posted through a non-inline platform fallback. */
   fallbackPosted?: number | null;
   /** Approved comments that failed to post (inline discussion + note fallback). */
   failed?: number | null;
@@ -37,6 +35,24 @@ export type ReviewPostOutcome = {
   skipped?: number | null;
   /** The validator's overall assessment. */
   summaryBody?: string | null;
+};
+
+export type ReviewPostFailure = {
+  path: string;
+  line: number | null;
+  error: string;
+};
+
+/** Complete JSON contract written by deterministic platform posting steps. */
+export type ReviewPostResults = {
+  posted: number;
+  fallbackPosted: number;
+  approved: number;
+  rejected: number;
+  failed: number;
+  skipped: number;
+  summaryBody: string | null;
+  failures: ReviewPostFailure[];
 };
 
 export interface ReviewTrackingFields {

--- a/src/core/review/validated/diff.ts
+++ b/src/core/review/validated/diff.ts
@@ -1,0 +1,210 @@
+/**
+ * Line index shared by deterministic review-posting steps.
+ *
+ * Each hunk line is addressable from the new-file side, old-file side, or
+ * both. Platform adapters use this to avoid sending anchors that their API
+ * cannot resolve.
+ */
+export type FileLineIndex = {
+  /** New-file line number -> "added", or the old line it pairs with. */
+  newLines: Map<number, number | "added">;
+  /** Old-file line number -> "removed", or the new line it pairs with. */
+  oldLines: Map<number, number | "removed">;
+};
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+type DiffLineState = {
+  index: FileLineIndex;
+  oldLine: number;
+  newLine: number;
+  inHunk: boolean;
+};
+
+function createDiffLineState(): DiffLineState {
+  return {
+    index: { newLines: new Map(), oldLines: new Map() },
+    oldLine: 0,
+    newLine: 0,
+    inHunk: false,
+  };
+}
+
+function indexDiffLine(state: DiffLineState, raw: string): void {
+  const hunk = HUNK_HEADER.exec(raw);
+  if (hunk) {
+    state.oldLine = Number(hunk[1]);
+    state.newLine = Number(hunk[2]);
+    state.inHunk = true;
+    return;
+  }
+  if (!state.inHunk || raw.startsWith("\\")) return;
+
+  if (raw.startsWith("+")) {
+    state.index.newLines.set(state.newLine, "added");
+    state.newLine += 1;
+  } else if (raw.startsWith("-")) {
+    state.index.oldLines.set(state.oldLine, "removed");
+    state.oldLine += 1;
+  } else {
+    // Context lines normally start with a space. Treat an empty line as
+    // context too because some artifact producers strip the prefix.
+    state.index.newLines.set(state.newLine, state.oldLine);
+    state.index.oldLines.set(state.oldLine, state.newLine);
+    state.newLine += 1;
+    state.oldLine += 1;
+  }
+}
+
+/** Indexes the hunks for one file diff. */
+export function buildFileLineIndex(diff: string): FileLineIndex {
+  const state = createDiffLineState();
+
+  const lines = diff.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  for (const raw of lines) {
+    indexDiffLine(state, raw);
+  }
+
+  return state.index;
+}
+
+function decodeGitQuotedPath(value: string): string {
+  const bytes: number[] = [];
+
+  for (let i = 0; i < value.length; i += 1) {
+    const current = value[i]!;
+    if (current !== "\\") {
+      bytes.push(...Buffer.from(current));
+      continue;
+    }
+
+    const next = value[i + 1];
+    if (next === undefined) {
+      bytes.push("\\".charCodeAt(0));
+      continue;
+    }
+
+    const octal = value.slice(i + 1).match(/^[0-7]{1,3}/)?.[0];
+    if (octal) {
+      bytes.push(Number.parseInt(octal, 8));
+      i += octal.length;
+      continue;
+    }
+
+    const escapes: Record<string, string> = {
+      a: "\x07",
+      b: "\b",
+      f: "\f",
+      n: "\n",
+      r: "\r",
+      t: "\t",
+      v: "\v",
+      "\\": "\\",
+      '"': '"',
+    };
+    bytes.push(...Buffer.from(escapes[next] ?? next));
+    i += 1;
+  }
+
+  return Buffer.from(bytes).toString("utf8");
+}
+
+function normalizePatchPath(raw: string): string | null {
+  let value = raw.replace(/\r$/, "");
+
+  if (value.startsWith('"')) {
+    let escaped = false;
+    let closingQuote = -1;
+    for (let i = 1; i < value.length; i += 1) {
+      const current = value[i]!;
+      if (current === '"' && !escaped) {
+        closingQuote = i;
+        break;
+      }
+      escaped = current === "\\" && !escaped;
+      if (current !== "\\") escaped = false;
+    }
+    if (closingQuote > 0) {
+      value = decodeGitQuotedPath(value.slice(1, closingQuote));
+    }
+  } else {
+    value = value.split("\t", 1)[0]!;
+  }
+
+  if (value === "/dev/null") return null;
+  return value.startsWith("a/") || value.startsWith("b/")
+    ? value.slice(2)
+    : value;
+}
+
+function pathsFromDiffHeader(line: string): {
+  oldPath: string | null;
+  newPath: string | null;
+} {
+  const value = line.slice("diff --git ".length);
+  if (value.startsWith('"')) {
+    // Quoted headers can contain spaces and escapes. The authoritative
+    // `---`/`+++` lines below carry the same paths and are easier to parse.
+    return { oldPath: null, newPath: null };
+  }
+
+  const separator = value.lastIndexOf(" b/");
+  if (separator < 0) return { oldPath: null, newPath: null };
+  return {
+    oldPath: normalizePatchPath(value.slice(0, separator)),
+    newPath: normalizePatchPath(value.slice(separator + 1)),
+  };
+}
+
+/**
+ * Splits a combined `git diff`/`gh pr diff` artifact and indexes each file.
+ * Renames are registered under both the old and new paths.
+ */
+export function buildUnifiedDiffIndex(
+  diff: string,
+): Map<string, FileLineIndex> {
+  const files = new Map<string, FileLineIndex>();
+  let current:
+    | {
+        oldPath: string | null;
+        newPath: string | null;
+        state: DiffLineState;
+      }
+    | undefined;
+
+  const flush = (): void => {
+    if (!current) return;
+    if (current.newPath) files.set(current.newPath, current.state.index);
+    if (current.oldPath && current.oldPath !== current.newPath) {
+      files.set(current.oldPath, current.state.index);
+    }
+  };
+
+  const lines = diff.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  for (const raw of lines) {
+    if (raw.startsWith("diff --git ")) {
+      flush();
+      current = {
+        ...pathsFromDiffHeader(raw),
+        state: createDiffLineState(),
+      };
+      continue;
+    }
+    if (!current) continue;
+
+    if (!current.state.inHunk && raw.startsWith("--- ")) {
+      current.oldPath = normalizePatchPath(raw.slice(4));
+    } else if (!current.state.inHunk && raw.startsWith("+++ ")) {
+      current.newPath = normalizePatchPath(raw.slice(4));
+    }
+
+    indexDiffLine(current.state, raw);
+  }
+  flush();
+
+  return files;
+}

--- a/src/core/review/validated/parse.ts
+++ b/src/core/review/validated/parse.ts
@@ -1,0 +1,152 @@
+/**
+ * Parser for the `review_validated.json` that Pass 2 writes.
+ *
+ * This is the trust boundary between the model and the platform API on
+ * every platform that posts from CI: the file comes from a model, so only
+ * entries explicitly marked `"approved"` with a usable line anchor make it
+ * through, and everything else is counted but never posted. Both
+ * `src/entrypoints/gitlab-post-review.ts` and
+ * `src/entrypoints/github-post-review.ts` consume the parsed shape.
+ */
+
+export type ValidatedReviewComment = {
+  path: string;
+  body: string;
+  /** New-file line (RIGHT) or, for LEFT comments without `old_line`, the old-file line. */
+  line: number | null;
+  /** Start of a multi-line anchor; null when the comment is single-line. */
+  startLine: number | null;
+  side: "LEFT" | "RIGHT";
+  old_path: string | null;
+  old_line: number | null;
+};
+
+export type ParsedValidatedReview = {
+  approved: ValidatedReviewComment[];
+  approvedCount: number;
+  rejectedCount: number;
+  skipped: Array<{ index: number; path: string | null; reason: string }>;
+  summaryBody: string | null;
+};
+
+export class InvalidValidatedReviewError extends Error {
+  constructor(message: string) {
+    super(`Invalid validated review file: ${message}`);
+    this.name = "InvalidValidatedReviewError";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asPositiveInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/** The line a comment anchors to, on whichever side applies. */
+export function validatedAnchorLine(
+  comment: ValidatedReviewComment,
+): number | null {
+  return comment.side === "LEFT"
+    ? (comment.old_line ?? comment.line)
+    : comment.line;
+}
+
+export function parseValidatedReview(raw: string): ParsedValidatedReview {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new InvalidValidatedReviewError(
+      `not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+
+  const root = asRecord(parsed);
+  if (!root) {
+    throw new InvalidValidatedReviewError("top level is not an object");
+  }
+
+  const results = root.results;
+  if (!Array.isArray(results)) {
+    throw new InvalidValidatedReviewError("missing `results` array");
+  }
+
+  const approved: ValidatedReviewComment[] = [];
+  const skipped: ParsedValidatedReview["skipped"] = [];
+  let approvedCount = 0;
+  let rejectedCount = 0;
+
+  results.forEach((entry, index) => {
+    const skip = (reason: string, p: string | null = null): void => {
+      skipped.push({ index, path: p, reason });
+    };
+
+    const record = asRecord(entry);
+    if (!record) return skip("entry is not an object");
+
+    if (record.status !== "approved") {
+      // Anything not explicitly approved never reaches the PR/MR; an unknown
+      // status counts the same as rejected.
+      rejectedCount += 1;
+      return;
+    }
+    approvedCount += 1;
+
+    const comment = asRecord(record.comment);
+    if (!comment) return skip("approved entry has no `comment` object");
+
+    const filePath = asNonEmptyString(comment.path);
+    const body = asNonEmptyString(comment.body);
+    if (!filePath || !body) {
+      return skip("approved comment is missing `path` or `body`", filePath);
+    }
+
+    if (
+      comment.side !== undefined &&
+      comment.side !== null &&
+      comment.side !== "LEFT" &&
+      comment.side !== "RIGHT"
+    ) {
+      return skip("approved comment has an invalid `side`", filePath);
+    }
+    const side = comment.side === "LEFT" ? "LEFT" : "RIGHT";
+    const line = asPositiveInt(comment.line);
+    const oldLine = asPositiveInt(comment.old_line);
+    const anchor = side === "LEFT" ? (oldLine ?? line) : line;
+    if (anchor === null) {
+      return skip(`no usable line anchor (side=${side})`, filePath);
+    }
+
+    const startLine = asPositiveInt(comment.startLine);
+
+    approved.push({
+      path: filePath,
+      body,
+      line,
+      startLine: startLine !== null && startLine < anchor ? startLine : null,
+      side,
+      old_path: asNonEmptyString(comment.old_path),
+      old_line: oldLine,
+    });
+  });
+
+  const summary = asRecord(root.reviewSummary);
+
+  return {
+    approved,
+    approvedCount,
+    rejectedCount,
+    skipped,
+    summaryBody: summary ? asNonEmptyString(summary.body) : null,
+  };
+}

--- a/src/core/review/validated/parse.ts
+++ b/src/core/review/validated/parse.ts
@@ -27,6 +27,12 @@ export type ParsedValidatedReview = {
   rejectedCount: number;
   skipped: Array<{ index: number; path: string | null; reason: string }>;
   summaryBody: string | null;
+  /**
+   * The head commit the validator reviewed against, taken from `meta.headSha`
+   * and the approved comments' `commit_id`. Null when the file names no
+   * single SHA; the poster then omits `commit_id` rather than guess one.
+   */
+  commitId: string | null;
 };
 
 export class InvalidValidatedReviewError extends Error {
@@ -50,6 +56,15 @@ function asPositiveInt(value: unknown): number | null {
 
 function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+const GIT_SHA = /^[0-9a-f]{7,64}$/i;
+
+/** A model-written SHA is only trusted when it looks like one. */
+function asCommitSha(value: unknown): string | null {
+  return typeof value === "string" && GIT_SHA.test(value.trim())
+    ? value.trim()
+    : null;
 }
 
 /** The line a comment anchors to, on whichever side applies. */
@@ -85,6 +100,11 @@ export function parseValidatedReview(raw: string): ParsedValidatedReview {
   const skipped: ParsedValidatedReview["skipped"] = [];
   let approvedCount = 0;
   let rejectedCount = 0;
+
+  const meta = asRecord(root.meta);
+  const shas = new Set<string>();
+  const metaSha = meta ? asCommitSha(meta.headSha) : null;
+  if (metaSha) shas.add(metaSha.toLowerCase());
 
   results.forEach((entry, index) => {
     const skip = (reason: string, p: string | null = null): void => {
@@ -128,6 +148,8 @@ export function parseValidatedReview(raw: string): ParsedValidatedReview {
     }
 
     const startLine = asPositiveInt(comment.startLine);
+    const commentSha = asCommitSha(comment.commit_id);
+    if (commentSha) shas.add(commentSha.toLowerCase());
 
     approved.push({
       path: filePath,
@@ -142,11 +164,16 @@ export function parseValidatedReview(raw: string): ParsedValidatedReview {
 
   const summary = asRecord(root.reviewSummary);
 
+  // Disagreeing SHAs mean the model anchored comments against more than one
+  // commit; pinning to any of them would misplace the others.
+  const commitId = shas.size === 1 ? [...shas][0]! : null;
+
   return {
     approved,
     approvedCount,
     rejectedCount,
     skipped,
     summaryBody: summary ? asNonEmptyString(summary.body) : null,
+    commitId,
   };
 }

--- a/src/create-prompt/templates/review-validator-prompt.ts
+++ b/src/create-prompt/templates/review-validator-prompt.ts
@@ -4,7 +4,8 @@
  * Delegates to the platform-agnostic builder in
  * `src/core/review/prompts/validator.ts`, mapping the GitHub
  * `PreparedContext` shape onto the shared `ReviewPromptContext` and
- * supplying `GITHUB_TERMINOLOGY`.
+ * supplying `GITHUB_TERMINOLOGY`. GitHub uses file-only posting: the
+ * validator writes JSON, then a deterministic CI step posts it.
  */
 
 import { generateValidatorPrompt } from "../../core/review/prompts/validator";
@@ -22,6 +23,7 @@ export function generateReviewValidatorPrompt(
 
   return generateValidatorPrompt({
     terminology: GITHUB_TERMINOLOGY,
+    postingMode: "file",
     entityNumber: prNumber,
     repoOrProject: context.repository,
     headRef: context.prBranchData?.headRefName ?? "unknown",

--- a/src/create-prompt/templates/security-review-prompt.ts
+++ b/src/create-prompt/templates/security-review-prompt.ts
@@ -88,7 +88,7 @@ Write output to \`${reviewCandidatesPath}\` using this exact schema:
 - **comments**: Array of comment objects
   - \`path\`: Relative file path
   - \`body\`: Comment text starting with priority tag [P0|P1|P2|P3] and \`[security]\` tag, then title, then 1 paragraph explanation
-  - \`line\`: Target line number (single-line) or end line number (multi-line). Must be >= 0.
+  - \`line\`: Target line number (single-line) or end line number (multi-line). Must be a positive integer.
   - \`startLine\`: \`null\` for single-line comments, or start line number for multi-line comments
   - \`side\`: "RIGHT" for new/modified code (default), "LEFT" only for removed code
   - \`commit_id\`: "${prHeadSha}"

--- a/src/create-prompt/terminology.ts
+++ b/src/create-prompt/terminology.ts
@@ -18,19 +18,12 @@ export const GITHUB_TERMINOLOGY: ReviewTerminology = {
   repoExample: "owner/repo",
   pathFieldDescription: 'Relative file path (e.g., "src/index.ts")',
   lineFieldDescription:
-    "Target line number (single-line) or end line number (multi-line). Must be ≥ 0. " +
+    "Target line number (single-line) or end line number (multi-line). Must be a positive integer. " +
     "Must be a line that appears in the PR diff; GitHub rejects inline comments on lines " +
     "outside the diff, so a finding about untouched code should anchor to the nearest " +
     "related changed line instead.",
   mutationToolForbiddance:
     "(inline comments, submit review, delete/minimize/reply/resolve, etc.)",
-  submitReviewToolName: "github_pr___submit_review",
-  submitReviewExtraArg: "",
-  submitReviewBodyExclusionTrailer: "",
-  updateTrackingToolName: "github_comment___update_droid_comment",
   trackingCommentName: "tracking comment",
-  summaryEntityName: "comment",
-  summaryPostingExtraExclusion: " or as the body of `submit_review`",
-  approvalChangesNote: "Do not approve or request changes.",
   // No security-badge instruction on GitHub today; left undefined intentionally.
 };

--- a/src/entrypoints/github-post-review.ts
+++ b/src/entrypoints/github-post-review.ts
@@ -1,0 +1,376 @@
+#!/usr/bin/env bun
+
+/**
+ * Deterministic GitHub posting step for the two-pass review pipeline.
+ *
+ * Pass 2 writes `review_validated.json` and has no GitHub mutation tools.
+ * This step validates the model-written file, checks every anchor against
+ * the precomputed PR diff, and creates one batched GitHub review.
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as core from "@actions/core";
+import { createOctokit } from "../github/api/client";
+import {
+  isEntityContext,
+  parseGitHubContext,
+  type ParsedGitHubContext,
+} from "../github/context";
+import {
+  buildUnifiedDiffIndex,
+  type FileLineIndex,
+} from "../core/review/validated/diff";
+import {
+  parseValidatedReview,
+  validatedAnchorLine,
+  type ValidatedReviewComment,
+} from "../core/review/validated/parse";
+import type { ReviewPostResults } from "../core/review/tracking/types";
+import {
+  createGitHubCommentReview,
+  type GitHubReviewCommentPayload,
+  type GitHubReviewCreateClient,
+} from "../github/operations/reviews";
+
+export const MAX_GITHUB_REVIEW_COMMENTS = 30;
+export const MAX_GITHUB_REVIEW_BODY_BYTES = 60 * 1024;
+
+type GitHubInlineComment = GitHubReviewCommentPayload & {
+  line: number;
+  side: "LEFT" | "RIGHT";
+  start_line?: number;
+  start_side?: "LEFT" | "RIGHT";
+};
+
+export type GitHubReviewClient = GitHubReviewCreateClient;
+
+type FallbackFinding = {
+  comment: ValidatedReviewComment;
+  reason: string;
+};
+
+export type GitHubPostReviewResult = {
+  reviewId: number | undefined;
+  posted: number;
+  fallbackPosted: number;
+  failures: Array<{ path: string; line: number | null; error: string }>;
+};
+
+export type GitHubPostResults = ReviewPostResults;
+
+function promptsDir(): string {
+  return path.join(process.env.RUNNER_TEMP || "/tmp", "droid-prompts");
+}
+
+export function validatedReviewFilePath(): string {
+  return (
+    process.env.REVIEW_VALIDATED_PATH ||
+    path.join(promptsDir(), "review_validated.json")
+  );
+}
+
+export function reviewDiffFilePath(): string {
+  return process.env.REVIEW_DIFF_PATH || path.join(promptsDir(), "pr.diff");
+}
+
+export function githubPostResultsFilePath(): string {
+  return (
+    process.env.REVIEW_POST_RESULTS_PATH ||
+    path.join(promptsDir(), "review_post_results.json")
+  );
+}
+
+function indexedLine(
+  comment: ValidatedReviewComment,
+  file: FileLineIndex | undefined,
+): boolean {
+  const line = validatedAnchorLine(comment);
+  if (line === null || !file) return false;
+  return comment.side === "LEFT"
+    ? file.oldLines.has(line)
+    : file.newLines.has(line);
+}
+
+function inlineComment(
+  comment: ValidatedReviewComment,
+  file: FileLineIndex,
+): GitHubInlineComment {
+  const line = validatedAnchorLine(comment)!;
+  const result: GitHubInlineComment = {
+    path: comment.path,
+    body: comment.body,
+    line,
+    side: comment.side,
+  };
+
+  if (
+    comment.startLine !== null &&
+    comment.startLine < line &&
+    (comment.side === "LEFT"
+      ? file.oldLines.has(comment.startLine)
+      : file.newLines.has(comment.startLine))
+  ) {
+    result.start_line = comment.startLine;
+    result.start_side = comment.side;
+  }
+
+  return result;
+}
+
+/**
+ * Turns approved comments into API-ready inline anchors and review-body
+ * fallbacks. This runs before posting, so known-bad lines never reach GitHub.
+ */
+export function prepareGitHubReview(
+  comments: ValidatedReviewComment[],
+  diffIndex: Map<string, FileLineIndex>,
+): { inline: GitHubInlineComment[]; fallback: FallbackFinding[] } {
+  const inline: GitHubInlineComment[] = [];
+  const fallback: FallbackFinding[] = [];
+
+  for (const comment of comments) {
+    const file =
+      diffIndex.get(comment.path) ??
+      (comment.old_path ? diffIndex.get(comment.old_path) : undefined);
+    const line = validatedAnchorLine(comment);
+
+    if (!indexedLine(comment, file)) {
+      fallback.push({
+        comment,
+        reason:
+          line === null
+            ? "no usable line anchor"
+            : `${comment.side === "LEFT" ? "old line" : "line"} ${line} is not part of the PR diff`,
+      });
+      continue;
+    }
+
+    if (inline.length >= MAX_GITHUB_REVIEW_COMMENTS) {
+      fallback.push({
+        comment,
+        reason: `GitHub reviews accept at most ${MAX_GITHUB_REVIEW_COMMENTS} inline comments`,
+      });
+      continue;
+    }
+
+    inline.push(inlineComment(comment, file!));
+  }
+
+  return { inline, fallback };
+}
+
+export function fallbackReviewBody(findings: FallbackFinding[]): string {
+  const sections = findings.map(({ comment, reason }) => {
+    const line = validatedAnchorLine(comment);
+    const location = line === null ? comment.path : `${comment.path}:${line}`;
+    return `### \`${location}\`\n\n${comment.body}\n\n<sub>Posted in the review body because ${reason}.</sub>`;
+  });
+
+  return [
+    "## Findings without inline anchors",
+    "",
+    "These approved findings could not be attached to an inline diff position.",
+    "",
+    ...sections,
+  ].join("\n");
+}
+
+function fitFallbackFindings(findings: FallbackFinding[]): {
+  included: FallbackFinding[];
+  omitted: FallbackFinding[];
+} {
+  const included: FallbackFinding[] = [];
+  const omitted: FallbackFinding[] = [];
+
+  for (const finding of findings) {
+    const candidate = fallbackReviewBody([...included, finding]);
+    if (Buffer.byteLength(candidate, "utf8") <= MAX_GITHUB_REVIEW_BODY_BYTES) {
+      included.push(finding);
+    } else {
+      omitted.push(finding);
+    }
+  }
+
+  return { included, omitted };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function createReview(
+  client: GitHubReviewClient,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  comments: GitHubInlineComment[],
+  fallback: FallbackFinding[],
+): Promise<number | undefined> {
+  return createGitHubCommentReview({
+    client,
+    owner,
+    repo,
+    prNumber,
+    comments,
+    ...(fallback.length > 0 ? { body: fallbackReviewBody(fallback) } : {}),
+  });
+}
+
+/**
+ * Makes exactly one GitHub API call. Known-invalid anchors and comments over
+ * GitHub's inline limit are included in that same review's body. A failed
+ * response is never retried here because an ambiguous network failure may
+ * have created the review remotely.
+ */
+export async function postGitHubReview(options: {
+  client: GitHubReviewClient;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  comments: ValidatedReviewComment[];
+  diff: string;
+}): Promise<GitHubPostReviewResult> {
+  const { client, owner, repo, prNumber, comments, diff } = options;
+  const result: GitHubPostReviewResult = {
+    reviewId: undefined,
+    posted: 0,
+    fallbackPosted: 0,
+    failures: [],
+  };
+  if (comments.length === 0) return result;
+
+  const prepared = prepareGitHubReview(comments, buildUnifiedDiffIndex(diff));
+  const fallback = fitFallbackFindings(prepared.fallback);
+  result.failures = fallback.omitted.map(({ comment }) => ({
+    path: comment.path,
+    line: validatedAnchorLine(comment),
+    error: `finding exceeds the ${MAX_GITHUB_REVIEW_BODY_BYTES}-byte review body budget`,
+  }));
+
+  if (prepared.inline.length === 0 && fallback.included.length === 0) {
+    return result;
+  }
+
+  try {
+    result.reviewId = await createReview(
+      client,
+      owner,
+      repo,
+      prNumber,
+      prepared.inline,
+      fallback.included,
+    );
+    result.posted = prepared.inline.length;
+    result.fallbackPosted = fallback.included.length;
+    return result;
+  } catch (error) {
+    const message = errorMessage(error);
+    result.failures = comments.map((comment) => ({
+      path: comment.path,
+      line: validatedAnchorLine(comment),
+      error: message,
+    }));
+    return result;
+  }
+}
+
+export async function run(
+  options: {
+    context?: ParsedGitHubContext;
+    client?: GitHubReviewClient;
+  } = {},
+): Promise<GitHubPostResults> {
+  const context = options.context ?? parseGitHubContext();
+  if (!isEntityContext(context) || !context.isPR) {
+    throw new Error("github-post-review requires a pull request context");
+  }
+
+  const validatedPath = validatedReviewFilePath();
+  let validatedRaw: string;
+  try {
+    validatedRaw = await fs.readFile(validatedPath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `github-post-review could not read validated review: ${errorMessage(error)}`,
+    );
+  }
+
+  const parsed = parseValidatedReview(validatedRaw);
+  let posted: GitHubPostReviewResult = {
+    reviewId: undefined,
+    posted: 0,
+    fallbackPosted: 0,
+    failures: [],
+  };
+
+  if (parsed.approved.length > 0) {
+    const diffPath = reviewDiffFilePath();
+    let diff: string;
+    try {
+      diff = await fs.readFile(diffPath, "utf8");
+    } catch (error) {
+      throw new Error(
+        `github-post-review could not read PR diff: ${errorMessage(error)}`,
+      );
+    }
+
+    const token = process.env.GITHUB_TOKEN;
+    if (!options.client && !token) {
+      throw new Error("GITHUB_TOKEN is required to post the review");
+    }
+    const client = options.client ?? createOctokit(token!);
+    posted = await postGitHubReview({
+      client,
+      owner: context.repository.owner,
+      repo: context.repository.repo,
+      prNumber: context.entityNumber,
+      comments: parsed.approved,
+      diff,
+    });
+  }
+
+  const results: GitHubPostResults = {
+    posted: posted.posted,
+    fallbackPosted: posted.fallbackPosted,
+    approved: parsed.approvedCount,
+    rejected: parsed.rejectedCount,
+    failed: posted.failures.length,
+    skipped: parsed.skipped.length,
+    summaryBody: parsed.summaryBody,
+    failures: posted.failures,
+  };
+
+  const resultsPath = githubPostResultsFilePath();
+  await fs.mkdir(path.dirname(resultsPath), { recursive: true });
+  await fs.writeFile(resultsPath, JSON.stringify(results, null, 2));
+  console.log(
+    `Posted ${results.posted}/${parsed.approved.length} inline comments ` +
+      `(${results.fallbackPosted} in the review body) on PR #${context.entityNumber} ` +
+      `(results: ${resultsPath}).`,
+  );
+
+  if (
+    parsed.approved.length > 0 &&
+    results.posted === 0 &&
+    results.fallbackPosted === 0
+  ) {
+    throw new Error(
+      `github-post-review: all ${parsed.approved.length} approved comments failed to post. ` +
+        `First error: ${results.failures[0]?.error ?? "unknown"}`,
+    );
+  }
+
+  core.setOutput("conclusion", "success");
+  return results;
+}
+
+if (import.meta.main) {
+  run().catch((error) => {
+    const message = errorMessage(error);
+    console.error("github-post-review failed:", message);
+    core.setOutput("conclusion", "failure");
+    core.setOutput("error_message", message);
+    process.exit(1);
+  });
+}

--- a/src/entrypoints/github-post-review.ts
+++ b/src/entrypoints/github-post-review.ts
@@ -206,6 +206,7 @@ async function createReview(
   prNumber: number,
   comments: GitHubInlineComment[],
   fallback: FallbackFinding[],
+  commitId: string | null,
 ): Promise<number | undefined> {
   return createGitHubCommentReview({
     client,
@@ -213,6 +214,7 @@ async function createReview(
     repo,
     prNumber,
     comments,
+    commitId,
     ...(fallback.length > 0 ? { body: fallbackReviewBody(fallback) } : {}),
   });
 }
@@ -222,6 +224,9 @@ async function createReview(
  * GitHub's inline limit are included in that same review's body. A failed
  * response is never retried here because an ambiguous network failure may
  * have created the review remotely.
+ *
+ * `commitId` is the head SHA the validator reviewed; passing it keeps the
+ * anchors bound to that commit even if the PR head has moved since.
  */
 export async function postGitHubReview(options: {
   client: GitHubReviewClient;
@@ -230,8 +235,10 @@ export async function postGitHubReview(options: {
   prNumber: number;
   comments: ValidatedReviewComment[];
   diff: string;
+  commitId?: string | null;
 }): Promise<GitHubPostReviewResult> {
   const { client, owner, repo, prNumber, comments, diff } = options;
+  const commitId = options.commitId ?? null;
   const result: GitHubPostReviewResult = {
     reviewId: undefined,
     posted: 0,
@@ -260,6 +267,7 @@ export async function postGitHubReview(options: {
       prNumber,
       prepared.inline,
       fallback.included,
+      commitId,
     );
     result.posted = prepared.inline.length;
     result.fallbackPosted = fallback.included.length;
@@ -320,6 +328,11 @@ export async function run(
       throw new Error("GITHUB_TOKEN is required to post the review");
     }
     const client = options.client ?? createOctokit(token!);
+    if (!parsed.commitId) {
+      core.warning(
+        "review_validated.json names no single head SHA; posting against the PR's current head",
+      );
+    }
     posted = await postGitHubReview({
       client,
       owner: context.repository.owner,
@@ -327,6 +340,7 @@ export async function run(
       prNumber: context.entityNumber,
       comments: parsed.approved,
       diff,
+      commitId: parsed.commitId,
     });
   }
 

--- a/src/entrypoints/gitlab-post-review.ts
+++ b/src/entrypoints/gitlab-post-review.ts
@@ -4,12 +4,12 @@
  * Posting step for the GitLab CI/CD Component: turns the
  * `review_validated.json` written by Pass 2 into inline MR discussions.
  *
- * `parseValidatedReview` is the trust boundary — the file comes from a
- * model, so only entries explicitly marked `"approved"` with a usable line
- * anchor can post. A hard failure (no state, no validated file, unusable
- * JSON, API refusing every call) exits non-zero so the tracking note
- * reports failure; a single comment that will not anchor is recorded and
- * the step still succeeds.
+ * `parseValidatedReview` (shared in `src/core/review/validated/parse.ts`)
+ * is the trust boundary — the file comes from a model, so only entries
+ * explicitly marked `"approved"` with a usable line anchor can post. A hard
+ * failure (no state, no validated file, unusable JSON, API refusing every
+ * call) exits non-zero so the tracking note reports failure; a single
+ * comment that will not anchor is recorded and the step still succeeds.
  *
  * Inputs (env): GITLAB_TOKEN, DROID_STATE_FILE, REVIEW_VALIDATED_PATH,
  * REVIEW_POST_RESULTS_PATH, CI_API_V4_URL.
@@ -22,34 +22,33 @@ import { setupGitlabToken } from "../gitlab/token";
 import { GitlabClient } from "../gitlab/api/client";
 import type { GitlabMrDiff, GitlabPosition } from "../gitlab/types";
 import {
+  buildFileLineIndex,
+  type FileLineIndex,
+} from "../core/review/validated/diff";
+import {
+  InvalidValidatedReviewError,
+  parseValidatedReview,
+  validatedAnchorLine,
+  type ParsedValidatedReview,
+  type ValidatedReviewComment,
+} from "../core/review/validated/parse";
+import type { ReviewPostResults } from "../core/review/tracking/types";
+import {
   promptsDir,
   stateFilePath,
   validatedFilePath,
   type PrepareState,
 } from "./gitlab-prepare";
 
-export type ReviewComment = {
-  path: string;
-  body: string;
-  line: number | null;
-  /** Start of a multi-line anchor; null when the comment is single-line. */
-  startLine: number | null;
-  side: "LEFT" | "RIGHT";
-  old_path: string | null;
-  old_line: number | null;
+export type ReviewComment = ValidatedReviewComment;
+export {
+  InvalidValidatedReviewError,
+  parseValidatedReview,
+  type ParsedValidatedReview,
 };
+export type { FileLineIndex };
 
-export type PostResults = {
-  posted: number;
-  /** Approved comments that could not anchor inline and went out as notes. */
-  fallbackPosted: number;
-  approved: number;
-  rejected: number;
-  failed: number;
-  skipped: number;
-  summaryBody: string | null;
-  failures: Array<{ path: string; line: number | null; error: string }>;
-};
+export type PostResults = ReviewPostResults;
 
 /** Written here, read by gitlab-update-comment-link. */
 export function postResultsFilePath(): string {
@@ -59,140 +58,7 @@ export function postResultsFilePath(): string {
   );
 }
 
-// --- review_validated.json -------------------------------------------------
-
-export type ParsedValidatedReview = {
-  approved: ReviewComment[];
-  approvedCount: number;
-  rejectedCount: number;
-  skipped: Array<{ index: number; path: string | null; reason: string }>;
-  summaryBody: string | null;
-};
-
-export class InvalidValidatedReviewError extends Error {
-  constructor(message: string) {
-    super(`Invalid validated review file: ${message}`);
-    this.name = "InvalidValidatedReviewError";
-  }
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function asPositiveInt(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.trunc(value)
-    : null;
-}
-
-function asNonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
-}
-
-export function parseValidatedReview(raw: string): ParsedValidatedReview {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new InvalidValidatedReviewError(
-      `not valid JSON (${error instanceof Error ? error.message : String(error)})`,
-    );
-  }
-
-  const root = asRecord(parsed);
-  if (!root) {
-    throw new InvalidValidatedReviewError("top level is not an object");
-  }
-
-  const results = root.results;
-  if (!Array.isArray(results)) {
-    throw new InvalidValidatedReviewError("missing `results` array");
-  }
-
-  const approved: ReviewComment[] = [];
-  const skipped: ParsedValidatedReview["skipped"] = [];
-  let approvedCount = 0;
-  let rejectedCount = 0;
-
-  results.forEach((entry, index) => {
-    const skip = (reason: string, p: string | null = null): void => {
-      skipped.push({ index, path: p, reason });
-    };
-
-    const record = asRecord(entry);
-    if (!record) return skip("entry is not an object");
-
-    if (record.status !== "approved") {
-      // Anything not explicitly approved never reaches the MR; an unknown
-      // status counts the same as rejected.
-      rejectedCount += 1;
-      return;
-    }
-    approvedCount += 1;
-
-    const comment = asRecord(record.comment);
-    if (!comment) return skip("approved entry has no `comment` object");
-
-    const filePath = asNonEmptyString(comment.path);
-    const body = asNonEmptyString(comment.body);
-    if (!filePath || !body) {
-      return skip("approved comment is missing `path` or `body`", filePath);
-    }
-
-    const side = comment.side === "LEFT" ? "LEFT" : "RIGHT";
-    const line = asPositiveInt(comment.line);
-    const oldLine = asPositiveInt(comment.old_line);
-    const anchor = side === "LEFT" ? (oldLine ?? line) : line;
-    if (anchor === null) {
-      return skip(`no usable line anchor (side=${side})`, filePath);
-    }
-
-    const startLine = asPositiveInt(comment.startLine);
-
-    approved.push({
-      path: filePath,
-      body,
-      line,
-      startLine: startLine !== null && startLine < anchor ? startLine : null,
-      side,
-      old_path: asNonEmptyString(comment.old_path),
-      old_line: oldLine,
-    });
-  });
-
-  const summary = asRecord(root.reviewSummary);
-
-  return {
-    approved,
-    approvedCount,
-    rejectedCount,
-    skipped,
-    summaryBody: summary ? asNonEmptyString(summary.body) : null,
-  };
-}
-
 // --- diff index ------------------------------------------------------------
-
-/**
- * Per-file map of which lines a positioned discussion can anchor to.
- *
- * GitLab's rules (Discussions API, "Create a new thread in the merge
- * request diff"): an added line takes `new_line` only, a removed line takes
- * `old_line` only, and an unchanged context line requires BOTH numbers. A
- * line absent from every hunk cannot be anchored at all, no matter the
- * payload.
- */
-export type FileLineIndex = {
-  /** new-file line number -> "added", or the old line it pairs with. */
-  newLines: Map<number, number | "added">;
-  /** old-file line number -> "removed", or the new line it pairs with. */
-  oldLines: Map<number, number | "removed">;
-};
-
-const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
 /** Indexes every hunk line, keyed by both `new_path` and `old_path`. */
 export function buildDiffIndex(
@@ -202,38 +68,7 @@ export function buildDiffIndex(
 
   for (const change of changes) {
     if (typeof change?.diff !== "string") continue;
-    const index: FileLineIndex = { newLines: new Map(), oldLines: new Map() };
-
-    const lines = change.diff.split("\n");
-    if (lines[lines.length - 1] === "") lines.pop();
-
-    let oldN = 0;
-    let newN = 0;
-    let inHunk = false;
-    for (const raw of lines) {
-      const hunk = HUNK_HEADER.exec(raw);
-      if (hunk) {
-        oldN = Number(hunk[1]);
-        newN = Number(hunk[2]);
-        inHunk = true;
-        continue;
-      }
-      if (!inHunk || raw.startsWith("\\")) continue;
-      if (raw.startsWith("+")) {
-        index.newLines.set(newN, "added");
-        newN += 1;
-      } else if (raw.startsWith("-")) {
-        index.oldLines.set(oldN, "removed");
-        oldN += 1;
-      } else {
-        // Context line (" " prefix, or "" when trailing whitespace was
-        // stripped somewhere along the way).
-        index.newLines.set(newN, oldN);
-        index.oldLines.set(oldN, newN);
-        newN += 1;
-        oldN += 1;
-      }
-    }
+    const index = buildFileLineIndex(change.diff);
 
     if (change.new_path) files.set(change.new_path, index);
     if (change.old_path && change.old_path !== change.new_path) {
@@ -255,12 +90,7 @@ export type PostReviewResult = {
   failures: Array<{ path: string; line: number | null; error: string }>;
 };
 
-/** The line the anchor points at, on whichever side applies. */
-function anchorLine(comment: ReviewComment): number | null {
-  return comment.side === "LEFT"
-    ? (comment.old_line ?? comment.line)
-    : comment.line;
-}
+const anchorLine = validatedAnchorLine;
 
 /**
  * GitLab identifies a diff line by `<sha1(path)>_<old line>_<new line>`,

--- a/src/entrypoints/gitlab-update-comment-link.ts
+++ b/src/entrypoints/gitlab-update-comment-link.ts
@@ -24,28 +24,19 @@ import { setupGitlabToken } from "../gitlab/token";
 import { GitlabClient } from "../gitlab/api/client";
 import { buildTrackingNoteBody } from "../gitlab/operations/tracking-note";
 import { collectExecTelemetry } from "../gitlab/data/exec-telemetry";
-import type { ReviewPostOutcome } from "../core/review/tracking/types";
-import { postResultsFilePath, type PostResults } from "./gitlab-post-review";
+import { readReviewPostOutcome } from "../core/review/tracking/results";
+import { postResultsFilePath } from "./gitlab-post-review";
 import { stateFilePath, type PrepareState } from "./gitlab-prepare";
 
-async function readPostResults(): Promise<ReviewPostOutcome | null> {
+async function readPostResults() {
   const filePath = postResultsFilePath();
-  try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const results = JSON.parse(raw) as PostResults;
-    return {
-      posted: results.posted ?? null,
-      fallbackPosted: results.fallbackPosted ?? null,
-      failed: results.failed ?? null,
-      skipped: results.skipped ?? null,
-      summaryBody: results.summaryBody ?? null,
-    };
-  } catch {
+  const results = await readReviewPostOutcome(filePath);
+  if (!results) {
     // Absent whenever posting did not get that far (skipped review, failed
     // pass). The note still renders, just without review counts.
     console.log(`No post-results file at ${filePath}; omitting review counts.`);
-    return null;
   }
+  return results;
 }
 
 async function readState(): Promise<PrepareState | null> {

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -15,6 +15,18 @@ import { GITHUB_SERVER_URL } from "../github/api/config";
 
 import { updateDroidComment } from "../github/operations/comments/update-droid-comment";
 import { fetchDroidComment } from "../github/operations/comments/fetch-droid-comment";
+import { readReviewPostOutcome } from "../core/review/tracking/results";
+
+export async function readReviewPostResults() {
+  const filePath =
+    process.env.REVIEW_POST_RESULTS_PATH ||
+    `${process.env.RUNNER_TEMP || "/tmp"}/droid-prompts/review_post_results.json`;
+  const results = await readReviewPostOutcome(filePath);
+  if (!results) {
+    console.log(`No review post-results file at ${filePath}; omitting counts.`);
+  }
+  return results;
+}
 
 async function run() {
   try {
@@ -115,6 +127,7 @@ async function run() {
       errorDetails = prepareError;
     } else {
       const droidErrorMessage =
+        process.env.DROID_POST_ERROR_MESSAGE?.trim() ||
         process.env.DROID_VALIDATOR_ERROR_MESSAGE?.trim() ||
         process.env.DROID_ERROR_MESSAGE?.trim();
       if (process.env.DROID_SUCCESS === "false" && droidErrorMessage) {
@@ -154,6 +167,8 @@ async function run() {
       }
     }
 
+    const review = await readReviewPostResults();
+
     // Prepare input for updateCommentBody function
     const commentInput: CommentUpdateInput = {
       currentBody,
@@ -167,6 +182,7 @@ async function run() {
       errorDetails,
       notice: process.env.MODEL_FALLBACK_NOTE?.trim() || undefined,
       securityReviewRan: process.env.AUTOMATIC_SECURITY_REVIEW === "true",
+      review,
     };
 
     const updatedBody = updateCommentBody(commentInput);

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -1,4 +1,5 @@
 import { GITHUB_SERVER_URL } from "../api/config";
+import type { ReviewPostOutcome } from "../../core/review/tracking/types";
 
 export type ExecutionDetails = {
   cost_usd?: number;
@@ -18,6 +19,7 @@ export type CommentUpdateInput = {
   errorDetails?: string;
   notice?: string;
   securityReviewRan?: boolean;
+  review?: ReviewPostOutcome | null;
 };
 
 const MODEL_POLICY_ERROR_PATTERN =
@@ -102,6 +104,7 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     errorDetails,
     notice,
     securityReviewRan,
+    review,
   } = input;
 
   // Extract content from the original comment body
@@ -256,6 +259,45 @@ export function updateCommentBody(input: CommentUpdateInput): string {
 
   if (securityReviewRan && !bodyContent.includes("security%20review-ran")) {
     bodyContent = `${SECURITY_REVIEW_BADGE}\n\n${bodyContent}`.trim();
+  }
+
+  if (review) {
+    const reviewContent: string[] = [];
+    const summary = review.summaryBody?.trim();
+    if (summary) reviewContent.push(summary);
+
+    const counts: string[] = [];
+    if (typeof review.posted === "number") {
+      counts.push(
+        `${review.posted} inline ${review.posted === 1 ? "comment" : "comments"} posted`,
+      );
+    }
+    if (
+      typeof review.fallbackPosted === "number" &&
+      review.fallbackPosted > 0
+    ) {
+      counts.push(
+        `${review.fallbackPosted} ${
+          review.fallbackPosted === 1 ? "finding" : "findings"
+        } posted in the review body`,
+      );
+    }
+    if (typeof review.failed === "number" && review.failed > 0) {
+      counts.push(
+        `${review.failed} ${review.failed === 1 ? "finding" : "findings"} could not be posted`,
+      );
+    }
+    if (typeof review.skipped === "number" && review.skipped > 0) {
+      counts.push(`${review.skipped} skipped`);
+    }
+    if (counts.length > 0) reviewContent.push(counts.join(" • "));
+
+    if (reviewContent.length > 0) {
+      bodyContent = reviewContent.join("\n\n");
+      if (securityReviewRan && !bodyContent.includes("security%20review-ran")) {
+        bodyContent = `${SECURITY_REVIEW_BADGE}\n\n${bodyContent}`;
+      }
+    }
   }
 
   // Add the cleaned body content

--- a/src/github/operations/reviews.ts
+++ b/src/github/operations/reviews.ts
@@ -1,0 +1,38 @@
+export type GitHubReviewCommentPayload = {
+  path: string;
+  body: string;
+  line?: number;
+  side?: string;
+  start_line?: number;
+  start_side?: string;
+  position?: number;
+};
+
+export type GitHubReviewCreateClient = {
+  rest: {
+    pulls: {
+      createReview: (...args: any[]) => Promise<{ data: { id?: number } }>;
+    };
+  };
+};
+
+/** Creates one COMMENT review and returns its GitHub review ID. */
+export async function createGitHubCommentReview(options: {
+  client: GitHubReviewCreateClient;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  body?: string;
+  comments?: GitHubReviewCommentPayload[];
+}): Promise<number | undefined> {
+  const { client, owner, repo, prNumber, body, comments } = options;
+  const response = await client.rest.pulls.createReview({
+    owner,
+    repo,
+    pull_number: prNumber,
+    event: "COMMENT",
+    ...(body ? { body } : {}),
+    ...(comments && comments.length > 0 ? { comments } : {}),
+  });
+  return response.data.id;
+}

--- a/src/github/operations/reviews.ts
+++ b/src/github/operations/reviews.ts
@@ -16,7 +16,14 @@ export type GitHubReviewCreateClient = {
   };
 };
 
-/** Creates one COMMENT review and returns its GitHub review ID. */
+/**
+ * Creates one COMMENT review and returns its GitHub review ID.
+ *
+ * `commitId` pins the review to the commit the anchors were computed
+ * against. Without it GitHub resolves `line`/`side` against the PR's
+ * current head, so a push that lands between diff generation and posting
+ * makes the anchors point at different code or fail the whole review.
+ */
 export async function createGitHubCommentReview(options: {
   client: GitHubReviewCreateClient;
   owner: string;
@@ -24,13 +31,15 @@ export async function createGitHubCommentReview(options: {
   prNumber: number;
   body?: string;
   comments?: GitHubReviewCommentPayload[];
+  commitId?: string | null;
 }): Promise<number | undefined> {
-  const { client, owner, repo, prNumber, body, comments } = options;
+  const { client, owner, repo, prNumber, body, comments, commitId } = options;
   const response = await client.rest.pulls.createReview({
     owner,
     repo,
     pull_number: prNumber,
     event: "COMMENT",
+    ...(commitId ? { commit_id: commitId } : {}),
     ...(body ? { body } : {}),
     ...(comments && comments.length > 0 ? { comments } : {}),
   });

--- a/src/gitlab/prompts/terminology.ts
+++ b/src/gitlab/prompts/terminology.ts
@@ -27,7 +27,7 @@ export const GITLAB_TERMINOLOGY: ReviewTerminology = {
   pathFieldDescription:
     'Relative file path (use the new_path from the diff, e.g., "src/index.ts")',
   lineFieldDescription:
-    "Target line number in the new file (single-line) or end line number (multi-line). Must be ≥ 0. " +
+    "Target line number in the new file (single-line) or end line number (multi-line). Must be a positive integer. " +
     "Must be a line that appears in the MR diff (an added or context line inside a hunk); " +
     "GitLab cannot anchor inline comments to lines outside the diff, so a finding about " +
     "untouched code should anchor to the nearest related changed line instead.",

--- a/src/mcp/github-pr-server.ts
+++ b/src/mcp/github-pr-server.ts
@@ -5,6 +5,10 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { Octokit } from "@octokit/rest";
 import { GITHUB_API_URL } from "../github/api/config";
+import {
+  createGitHubCommentReview,
+  type GitHubReviewCommentPayload,
+} from "../github/operations/reviews";
 
 const PLACEHOLDER_REGEX = /@droid\s+fill(?:\s+description)?/gi;
 const PLACEHOLDER_LINE_REGEX =
@@ -181,15 +185,194 @@ export async function listReviewAndIssueComments({
   };
 }
 
-type ReviewComment = {
-  path: string;
-  body: string;
-  line?: number;
-  side?: string;
-  start_line?: number;
-  start_side?: string;
-  position?: number;
+export type ReviewComment = GitHubReviewCommentPayload;
+
+/**
+ * Upper bound on `submit_review` calls that reach GitHub in one server
+ * process, successful or not. A failed post is not treated as "submitted"
+ * so a bad line anchor can be corrected and retried, which is why failures
+ * need their own ceiling.
+ */
+export const MAX_SUBMIT_REVIEW_ATTEMPTS = 5;
+
+/** Identity of an inline comment for duplicate detection. */
+export function reviewCommentKey(comment: ReviewComment): string {
+  return JSON.stringify([
+    comment.path,
+    comment.side ?? "RIGHT",
+    comment.line ?? null,
+    comment.body.trim(),
+  ]);
+}
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+export type SubmittedReview = {
+  reviewId: number | undefined;
+  /** Keys (see {@link reviewCommentKey}) of every comment the review carried. */
+  commentKeys: Set<string>;
+  commentCount: number;
 };
+
+export type SubmitReviewGuard = {
+  /** The review this process has already posted, if any. */
+  readonly submitted: SubmittedReview | null;
+  /**
+   * Message to return instead of calling GitHub, or null when the call may
+   * proceed. Throws when the process has run out of attempts.
+   */
+  refusal(input: {
+    prNumber: number;
+    comments?: ReviewComment[];
+  }): string | null;
+  /** Atomically reserves one GitHub submission attempt. */
+  beginAttempt(): void;
+  recordSuccess(input: {
+    reviewId: number | undefined;
+    comments?: ReviewComment[];
+  }): void;
+  recordFailure(): void;
+};
+
+/**
+ * Makes `submit_review` idempotent for the lifetime of the MCP server
+ * process, which is exactly one `droid exec` run. Once one review has been
+ * created every further call is answered from memory with an explicit
+ * "already submitted" result and never reaches GitHub.
+ */
+export function createSubmitReviewGuard({
+  maxAttempts = MAX_SUBMIT_REVIEW_ATTEMPTS,
+}: { maxAttempts?: number } = {}): SubmitReviewGuard {
+  let submitted: SubmittedReview | null = null;
+  let attempts = 0;
+  let inFlight = false;
+
+  return {
+    get submitted() {
+      return submitted;
+    },
+
+    refusal() {
+      if (submitted) {
+        const reviewRef =
+          submitted.reviewId !== undefined
+            ? String(submitted.reviewId)
+            : "unknown";
+        return (
+          `A review with these ${submitted.commentCount} comments was already submitted as review ${reviewRef}. ` +
+          "Do not call submit_review again."
+        );
+      }
+
+      if (inFlight) {
+        return (
+          "A review submission is already in progress. " +
+          "Do not call submit_review again."
+        );
+      }
+
+      if (attempts >= maxAttempts) {
+        throw new Error(
+          `submit_review has been attempted ${pluralize(attempts, "time")} in this run without GitHub accepting the review, which is the maximum. ` +
+            "Refusing to call GitHub again. Do not call submit_review again; report the failure in the tracking comment and finish.",
+        );
+      }
+
+      return null;
+    },
+
+    beginAttempt() {
+      if (inFlight) {
+        throw new Error("A review submission is already in progress");
+      }
+      inFlight = true;
+      attempts += 1;
+    },
+
+    recordSuccess({ reviewId, comments }) {
+      inFlight = false;
+      const commentKeys = new Set<string>();
+      for (const comment of comments ?? []) {
+        commentKeys.add(reviewCommentKey(comment));
+      }
+      submitted = {
+        reviewId,
+        commentKeys,
+        commentCount: comments?.length ?? 0,
+      };
+    },
+
+    recordFailure() {
+      inFlight = false;
+    },
+  };
+}
+
+export type SubmitReviewOutcome = {
+  text: string;
+  /** True when the call was answered from memory or refused without posting. */
+  isError: boolean;
+};
+
+export async function handleSubmitReview({
+  owner,
+  repo,
+  prNumber,
+  body,
+  comments,
+  octokit,
+  guard,
+}: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  body?: string;
+  comments?: ReviewComment[];
+  octokit: OctokitLike;
+  guard: SubmitReviewGuard;
+}): Promise<SubmitReviewOutcome> {
+  const refusal = guard.refusal({ prNumber, comments });
+  if (refusal) {
+    return { text: refusal, isError: true };
+  }
+
+  const hasBody = Boolean(body?.trim());
+  const hasComments = (comments?.length ?? 0) > 0;
+  if (!hasBody && !hasComments) {
+    return {
+      text:
+        "submit_review was called with no comments and no body, so there is nothing to post. " +
+        "If there are no approved findings, do not call submit_review; update the tracking comment and finish.",
+      isError: true,
+    };
+  }
+
+  let reviewId: number | undefined;
+  guard.beginAttempt();
+  try {
+    reviewId = await submitReviewWithComments({
+      owner,
+      repo,
+      prNumber,
+      body,
+      comments,
+      octokit,
+    });
+  } catch (error) {
+    guard.recordFailure();
+    throw error;
+  }
+  guard.recordSuccess({ reviewId, comments });
+
+  return {
+    text:
+      `Submitted review${reviewId !== undefined ? ` ${reviewId}` : ""} for PR #${prNumber} with ${pluralize(comments?.length ?? 0, "inline comment")}. ` +
+      "The review is posted. Do not call submit_review again.",
+    isError: false,
+  };
+}
 
 export async function submitReviewWithComments({
   owner,
@@ -206,16 +389,14 @@ export async function submitReviewWithComments({
   comments?: ReviewComment[];
   octokit: OctokitLike;
 }): Promise<number | undefined> {
-  const response = await octokit.rest.pulls.createReview({
+  return createGitHubCommentReview({
+    client: octokit,
     owner,
     repo,
-    pull_number: prNumber,
-    event: "COMMENT",
-    ...(body ? { body } : {}),
-    ...(comments && comments.length > 0 ? { comments } : {}),
+    prNumber,
+    body,
+    comments,
   });
-
-  return response.data.id;
 }
 
 export async function deletePullRequestComment({
@@ -442,12 +623,14 @@ export interface ServerDependencies {
   owner: string;
   repo: string;
   octokit: OctokitLike;
+  submitReviewGuard?: SubmitReviewGuard;
 }
 
 export function createGitHubPRServer({
   owner,
   repo,
   octokit,
+  submitReviewGuard = createSubmitReviewGuard(),
 }: ServerDependencies) {
   const server = new McpServer({
     name: "GitHub PR Server",
@@ -614,7 +797,9 @@ export function createGitHubPRServer({
   server.tool(
     "submit_review",
     "Submit a PR review with all inline comments batched into a single review. " +
-      "Use line/side to anchor comments to specific lines in the diff.",
+      "Use line/side to anchor comments to specific lines in the diff. " +
+      "This tool posts exactly one review per run: once a call succeeds, every " +
+      "further call is refused without posting anything.",
     {
       pr_number: z.number().int().describe("PR number to review"),
       body: z.string().describe("Optional summary body").optional(),
@@ -661,22 +846,24 @@ export function createGitHubPRServer({
     },
     async ({ pr_number, body, comments }) => {
       try {
-        const reviewId = await submitReviewWithComments({
+        const outcome = await handleSubmitReview({
           owner,
           repo,
           prNumber: pr_number,
           body,
           comments,
           octokit,
+          guard: submitReviewGuard,
         });
 
         return {
           content: [
             {
               type: "text",
-              text: `Submitted review${reviewId ? ` ${reviewId}` : ""} for PR #${pr_number}`,
+              text: outcome.text,
             },
           ],
+          ...(outcome.isError ? { error: outcome.text, isError: true } : {}),
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -5,24 +5,22 @@ import type { Octokits } from "../../github/api/client";
 import { fetchPRBranchData } from "../../github/data/pr-fetcher";
 import { createPrompt } from "../../create-prompt";
 import type { ReviewArtifacts } from "../../create-prompt/types";
-import { prepareMcpTools } from "../../mcp/install-mcp-server";
-import { normalizeDroidArgs, parseAllowedTools } from "../../utils/parse-tools";
+import {
+  normalizeDroidArgs,
+  stripToolSelectionArgs,
+} from "../../utils/parse-tools";
 import type { PrepareResult } from "../../prepare/types";
 import { generateReviewValidatorPrompt } from "../../create-prompt/templates/review-validator-prompt";
 import { resolveReviewConfig } from "../../utils/review-depth";
 import { applyModelPolicyFallback } from "../../utils/model-policy";
 
-export async function prepareReviewValidatorMode({
-  context,
-  octokit,
-  githubToken,
-  trackingCommentId,
-}: {
+export async function prepareReviewValidatorMode(options: {
   context: GitHubContext;
   octokit: Octokits;
   githubToken: string;
   trackingCommentId: number;
 }): Promise<PrepareResult> {
+  const { context, octokit, trackingCommentId } = options;
   if (!isEntityContext(context) || !context.isPR) {
     throw new Error("review validator mode requires pull request context");
   }
@@ -66,11 +64,12 @@ export async function prepareReviewValidatorMode({
   core.exportVariable("DROID_EXEC_RUN_TYPE", "droid-review");
 
   const rawUserArgs = process.env.DROID_ARGS || "";
-  const normalizedUserArgs = normalizeDroidArgs(rawUserArgs);
-  const userAllowedMCPTools = parseAllowedTools(normalizedUserArgs).filter(
-    (tool) => tool.startsWith("github_") && tool.includes("___"),
+  const normalizedUserArgs = stripToolSelectionArgs(
+    normalizeDroidArgs(rawUserArgs),
   );
 
+  // Pass 2 only writes review_validated.json. It receives no GitHub mutation
+  // tools; github-post-review.ts performs the sole API write afterwards.
   const baseTools = [
     "Read",
     "Grep",
@@ -80,24 +79,11 @@ export async function prepareReviewValidatorMode({
     "ApplyPatch",
     "Create",
     "Edit",
-    "github_comment___update_droid_comment",
+    "Skill",
   ];
 
-  const validatorTools = ["github_pr___submit_review"];
-
-  const allowedTools = Array.from(
-    new Set([...baseTools, ...validatorTools, ...userAllowedMCPTools]),
-  );
-
-  const mcpTools = await prepareMcpTools({
-    githubToken,
-    owner: context.repository.owner,
-    repo: context.repository.repo,
-    droidCommentId: trackingCommentId.toString(),
-    allowedTools,
-    mode: "tag",
-    context,
-  });
+  const allowedTools = Array.from(new Set(baseTools));
+  const mcpTools = JSON.stringify({ mcpServers: {} });
 
   const droidArgParts: string[] = [];
   droidArgParts.push(`--enabled-tools "${allowedTools.join(",")}"`);

--- a/src/tag/commands/review-validator.ts
+++ b/src/tag/commands/review-validator.ts
@@ -69,7 +69,9 @@ export async function prepareReviewValidatorMode(options: {
   );
 
   // Pass 2 only writes review_validated.json. It receives no GitHub mutation
-  // tools; github-post-review.ts performs the sole API write afterwards.
+  // tools, and the action steps that run it withhold GITHUB_TOKEN, so a
+  // prompt-injected diff has neither a tool nor a credential to reach GitHub
+  // through `Execute`. github-post-review.ts performs the sole API write.
   const baseTools = [
     "Read",
     "Grep",

--- a/src/utils/parse-tools.ts
+++ b/src/utils/parse-tools.ts
@@ -46,3 +46,20 @@ export function normalizeDroidArgs(args: string): string {
       .trim()
   );
 }
+
+/**
+ * Removes user-provided tool selection flags from an argument string.
+ *
+ * File-only review validation owns its exact tool allowlist. Keeping a
+ * second `--enabled-tools` flag in custom args could re-enable GitHub
+ * mutation tools after the action deliberately removed them.
+ */
+export function stripToolSelectionArgs(args: string): string {
+  return args
+    .replace(
+      /(?:^|\s)--(?:enabled-tools|disabled-tools)\s+(?:"[^"]*"|'[^']*'|[^\s]+)/g,
+      " ",
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -3,6 +3,12 @@ export type RetryOptions = {
   initialDelayMs?: number;
   maxDelayMs?: number;
   backoffFactor?: number;
+  /**
+   * Decides whether a failed attempt is worth retrying. Returning false
+   * rethrows the error immediately, skipping the backoff and any remaining
+   * attempts. Defaults to retrying every error.
+   */
+  shouldRetry?: (error: Error) => boolean;
 };
 
 export async function retryWithBackoff<T>(
@@ -14,6 +20,7 @@ export async function retryWithBackoff<T>(
     initialDelayMs = 5000,
     maxDelayMs = 20000,
     backoffFactor = 2,
+    shouldRetry,
   } = options;
 
   let delayMs = initialDelayMs;
@@ -26,6 +33,11 @@ export async function retryWithBackoff<T>(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       console.error(`Attempt ${attempt} failed:`, lastError.message);
+
+      if (shouldRetry && !shouldRetry(lastError)) {
+        console.error("Error is not retryable; giving up");
+        throw lastError;
+      }
 
       if (attempt < maxAttempts) {
         console.log(`Retrying in ${delayMs / 1000} seconds...`);

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -14,6 +14,46 @@ describe("updateCommentBody", () => {
     triggerUsername: undefined,
   };
 
+  it("renders the deterministic review summary and posting counts", () => {
+    const result = updateCommentBody({
+      ...baseInput,
+      currentBody: "Droid is reviewing code…",
+      triggerUsername: "reviewer",
+      review: {
+        posted: 3,
+        fallbackPosted: 1,
+        failed: 1,
+        skipped: 2,
+        summaryBody: "Three issues should be fixed before merge.",
+      },
+    });
+
+    expect(result).toContain("Three issues should be fixed before merge.");
+    expect(result).toContain("3 inline comments posted");
+    expect(result).toContain("1 finding posted in the review body");
+    expect(result).toContain("1 finding could not be posted");
+    expect(result).toContain("2 skipped");
+    expect(result).not.toContain("Droid is reviewing code");
+  });
+
+  it("replaces stale model-written content when post results are present", () => {
+    const result = updateCommentBody({
+      ...baseInput,
+      currentBody: "An outdated model-written summary.",
+      review: {
+        posted: 0,
+        fallbackPosted: 0,
+        failed: 0,
+        skipped: 0,
+        summaryBody: "LGTM — no issues found.",
+      },
+    });
+
+    expect(result).toContain("LGTM — no issues found.");
+    expect(result).toContain("0 inline comments posted");
+    expect(result).not.toContain("outdated model-written summary");
+  });
+
   describe("working message replacement", () => {
     it("includes success message header with duration", () => {
       const input = {

--- a/test/core/review/tracking/results.test.ts
+++ b/test/core/review/tracking/results.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import {
+  parseReviewPostResults,
+  readReviewPostOutcome,
+} from "../../../../src/core/review/tracking/results";
+
+const valid = {
+  posted: 2,
+  fallbackPosted: 1,
+  approved: 3,
+  rejected: 4,
+  failed: 0,
+  skipped: 1,
+  summaryBody: "Summary",
+  failures: [],
+};
+
+describe("review post results", () => {
+  const temporary: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporary.map((directory) =>
+        fs.rm(directory, { recursive: true, force: true }),
+      ),
+    );
+    temporary.length = 0;
+  });
+
+  it("validates and maps the complete posting result", () => {
+    expect(parseReviewPostResults(JSON.stringify(valid))).toEqual(valid);
+    expect(() =>
+      parseReviewPostResults(JSON.stringify({ ...valid, posted: -1 })),
+    ).toThrow("invalid `posted`");
+    expect(() =>
+      parseReviewPostResults(JSON.stringify({ ...valid, failures: null })),
+    ).toThrow("invalid `failures`");
+  });
+
+  it("returns null only for a missing file and rejects malformed output", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "review-results-"),
+    );
+    temporary.push(directory);
+    const filePath = path.join(directory, "results.json");
+
+    expect(await readReviewPostOutcome(filePath)).toBeNull();
+
+    await fs.writeFile(filePath, "{bad json");
+    await expect(readReviewPostOutcome(filePath)).rejects.toThrow();
+
+    await fs.writeFile(filePath, JSON.stringify(valid));
+    expect(await readReviewPostOutcome(filePath)).toEqual({
+      posted: 2,
+      fallbackPosted: 1,
+      failed: 0,
+      skipped: 1,
+      summaryBody: "Summary",
+    });
+  });
+});

--- a/test/core/review/validated/diff.test.ts
+++ b/test/core/review/validated/diff.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildFileLineIndex,
+  buildUnifiedDiffIndex,
+} from "../../../../src/core/review/validated/diff";
+
+describe("buildFileLineIndex", () => {
+  it("classifies additions, removals, context, and multiple hunks", () => {
+    const index = buildFileLineIndex(
+      "@@ -8,5 +8,5 @@\n a\n b\n+c\n d\n-e\n f\n" +
+        "@@ -30,1 +31,2 @@\n x\n+y\n",
+    );
+
+    expect(index.newLines.get(10)).toBe("added");
+    expect(index.newLines.get(11)).toBe(10);
+    expect(index.oldLines.get(11)).toBe("removed");
+    expect(index.oldLines.get(12)).toBe(12);
+    expect(index.newLines.get(31)).toBe(30);
+    expect(index.newLines.get(32)).toBe("added");
+  });
+});
+
+describe("buildUnifiedDiffIndex", () => {
+  it("splits a combined diff and registers renames under both paths", () => {
+    const index = buildUnifiedDiffIndex(`diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,2 +1,2 @@
+-old
++new
+ context
+diff --git a/src/old name.ts b/src/new name.ts
+similarity index 90%
+rename from src/old name.ts
+rename to src/new name.ts
+--- a/src/old name.ts
++++ b/src/new name.ts
+@@ -4 +4 @@
+-before
++after
+`);
+
+    expect(index.get("src/a.ts")!.oldLines.get(1)).toBe("removed");
+    expect(index.get("src/a.ts")!.newLines.get(1)).toBe("added");
+    expect(index.get("src/a.ts")!.newLines.get(2)).toBe(2);
+    expect(index.get("src/old name.ts")!).toBe(index.get("src/new name.ts")!);
+    expect(index.get("src/new name.ts")!.newLines.get(4)).toBe("added");
+  });
+
+  it("handles new, deleted, and quoted UTF-8 paths", () => {
+    const index = buildUnifiedDiffIndex(`diff --git a/new.ts b/new.ts
+new file mode 100644
+--- /dev/null
++++ b/new.ts
+@@ -0,0 +1 @@
++new
+diff --git a/gone.ts b/gone.ts
+deleted file mode 100644
+--- a/gone.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-gone
+diff --git "a/docs/\\303\\251.txt" "b/docs/\\303\\251.txt"
+--- "a/docs/\\303\\251.txt"
++++ "b/docs/\\303\\251.txt"
+@@ -1 +1 @@
+-old
++new
+`);
+
+    expect(index.get("new.ts")!.newLines.get(1)).toBe("added");
+    expect(index.get("gone.ts")!.oldLines.get(1)).toBe("removed");
+    expect(index.get("docs/é.txt")!.newLines.get(1)).toBe("added");
+  });
+
+  it("does not mistake source lines for file path markers", () => {
+    const index = buildUnifiedDiffIndex(`diff --git a/options.txt b/options.txt
+--- a/options.txt
++++ b/options.txt
+@@ -1 +1 @@
+--- old option
++++ new option
+`);
+
+    expect(index.has("options.txt")).toBe(true);
+    expect(index.has("old option")).toBe(false);
+    expect(index.has("new option")).toBe(false);
+  });
+});

--- a/test/create-prompt/templates/review-validator-prompt.test.ts
+++ b/test/create-prompt/templates/review-validator-prompt.test.ts
@@ -70,15 +70,27 @@ describe("generateReviewValidatorPrompt", () => {
     );
   });
 
-  it("instructs to post summary in tracking comment, not in submit_review body", () => {
+  it("makes the validated file the deliverable and forbids model-side posting", () => {
     const context = createBaseContext();
     const prompt = generateReviewValidatorPrompt(context);
 
-    expect(prompt).toContain("github_comment___update_droid_comment");
-    expect(prompt).toContain("Do **NOT** include a `body` parameter");
     expect(prompt).toContain(
-      "Do **NOT** post the summary as a separate comment or as the body of `submit_review`",
+      "Writing `$RUNNER_TEMP/droid-prompts/review_validated.json` is your final action",
     );
+    expect(prompt).toContain("through the GitHub API");
+    expect(prompt).toContain("Do **NOT** attempt to post");
+    expect(prompt).not.toContain("submit_review");
+    expect(prompt).not.toContain("github_comment___update_droid_comment");
+  });
+
+  it("keeps the summary only in the validated file for the CI step", () => {
+    const context = createBaseContext();
+    const prompt = generateReviewValidatorPrompt(context);
+
+    expect(prompt).toContain(
+      "Do **NOT** write a summary anywhere other than the `reviewSummary` field",
+    );
+    expect(prompt).toContain("updates the tracking comment");
   });
 
   it("includes correct PR context", () => {

--- a/test/entrypoints/github-post-review.test.ts
+++ b/test/entrypoints/github-post-review.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import {
+  MAX_GITHUB_REVIEW_BODY_BYTES,
+  MAX_GITHUB_REVIEW_COMMENTS,
+  fallbackReviewBody,
+  postGitHubReview,
+  prepareGitHubReview,
+  run,
+  type GitHubReviewClient,
+} from "../../src/entrypoints/github-post-review";
+import { buildUnifiedDiffIndex } from "../../src/core/review/validated/diff";
+import type { ValidatedReviewComment } from "../../src/core/review/validated/parse";
+import { createMockContext } from "../mockContext";
+
+const DIFF = `diff --git a/src/x.ts b/src/x.ts
+--- a/src/x.ts
++++ b/src/x.ts
+@@ -8,5 +8,5 @@
+ a
+ b
++c
+ d
+-e
+ f
+`;
+
+const comment = (
+  overrides: Partial<ValidatedReviewComment> = {},
+): ValidatedReviewComment => ({
+  path: "src/x.ts",
+  body: "[P1] Finding",
+  line: 10,
+  startLine: null,
+  side: "RIGHT",
+  old_path: null,
+  old_line: null,
+  ...overrides,
+});
+
+describe("prepareGitHubReview", () => {
+  it("keeps valid RIGHT/LEFT anchors and moves out-of-diff lines to the body", () => {
+    const prepared = prepareGitHubReview(
+      [
+        comment(),
+        comment({ side: "LEFT", line: null, old_line: 11 }),
+        comment({ path: "missing.ts", line: 99 }),
+      ],
+      buildUnifiedDiffIndex(DIFF),
+    );
+
+    expect(prepared.inline).toEqual([
+      {
+        path: "src/x.ts",
+        body: "[P1] Finding",
+        line: 10,
+        side: "RIGHT",
+      },
+      {
+        path: "src/x.ts",
+        body: "[P1] Finding",
+        line: 11,
+        side: "LEFT",
+      },
+    ]);
+    expect(prepared.fallback).toHaveLength(1);
+    expect(prepared.fallback[0]!.reason).toContain("not part of the PR diff");
+  });
+
+  it("caps inline comments at GitHub's per-review limit", () => {
+    const comments = Array.from(
+      { length: MAX_GITHUB_REVIEW_COMMENTS + 2 },
+      (_, index) =>
+        comment({
+          line: 10,
+          body: `[P1] Finding ${index}`,
+        }),
+    );
+    const prepared = prepareGitHubReview(comments, buildUnifiedDiffIndex(DIFF));
+
+    expect(prepared.inline).toHaveLength(MAX_GITHUB_REVIEW_COMMENTS);
+    expect(prepared.fallback).toHaveLength(2);
+  });
+});
+
+describe("fallbackReviewBody", () => {
+  it("includes each location, finding, and fallback reason", () => {
+    const body = fallbackReviewBody([
+      { comment: comment(), reason: "line is not part of the PR diff" },
+    ]);
+
+    expect(body).toContain("## Findings without inline anchors");
+    expect(body).toContain("`src/x.ts:10`");
+    expect(body).toContain("[P1] Finding");
+    expect(body).toContain("line is not part of the PR diff");
+  });
+});
+
+describe("postGitHubReview", () => {
+  it("creates one review containing inline and body-fallback findings", async () => {
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 123 },
+    }));
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    const result = await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [comment(), comment({ path: "missing.ts", line: 99 })],
+      diff: DIFF,
+    });
+
+    expect(result).toEqual({
+      reviewId: 123,
+      posted: 1,
+      fallbackPosted: 1,
+      failures: [],
+    });
+    expect(createReview).toHaveBeenCalledTimes(1);
+    const payload = createReview.mock.calls[0]![0] as any;
+    expect(payload.comments).toHaveLength(1);
+    expect(payload.body).toContain("missing.ts:99");
+    expect(payload.event).toBe("COMMENT");
+  });
+
+  it("preserves a valid multi-line anchor in the single API call", async () => {
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 456 },
+    }));
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    const result = await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [comment({ line: 11, startLine: 9 })],
+      diff: DIFF,
+    });
+
+    expect(result.posted).toBe(1);
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect((createReview.mock.calls[0]![0] as any).comments[0]).toMatchObject({
+      start_line: 9,
+      start_side: "RIGHT",
+    });
+  });
+
+  it("does not retry when GitHub rejects the review", async () => {
+    const createReview = mock(async (_payload: any) => {
+      throw new Error("ambiguous API failure");
+    });
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    const result = await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [comment()],
+      diff: DIFF,
+    });
+
+    expect(result.posted).toBe(0);
+    expect(result.fallbackPosted).toBe(0);
+    expect(result.failures[0]!.error).toBe("ambiguous API failure");
+    expect(createReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send a fallback body over GitHub's size budget", async () => {
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 789 },
+    }));
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    const result = await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [
+        comment({
+          path: "missing.ts",
+          body: "x".repeat(MAX_GITHUB_REVIEW_BODY_BYTES),
+        }),
+      ],
+      diff: DIFF,
+    });
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]!.error).toContain("review body budget");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});
+
+describe("github-post-review entrypoint", () => {
+  const ENV_KEYS = [
+    "RUNNER_TEMP",
+    "REVIEW_VALIDATED_PATH",
+    "REVIEW_DIFF_PATH",
+    "REVIEW_POST_RESULTS_PATH",
+    "GITHUB_TOKEN",
+  ] as const;
+  let savedEnv: Record<string, string | undefined>;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-post-review-"));
+    process.env.RUNNER_TEMP = tmpDir;
+    await fs.mkdir(path.join(tmpDir, "droid-prompts"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads validated output and diff, posts once, and writes result counts", async () => {
+    const prompts = path.join(tmpDir, "droid-prompts");
+    await fs.writeFile(path.join(prompts, "pr.diff"), DIFF);
+    await fs.writeFile(
+      path.join(prompts, "review_validated.json"),
+      JSON.stringify({
+        version: 1,
+        results: [
+          { status: "approved", comment: comment() },
+          {
+            status: "rejected",
+            comment: comment({ body: "[P2] Rejected" }),
+          },
+        ],
+        reviewSummary: { body: "One issue should be fixed." },
+      }),
+    );
+
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 999 },
+    }));
+    const context = createMockContext({
+      isPR: true,
+      entityNumber: 42,
+      repository: { owner: "o", repo: "r", full_name: "o/r" },
+    });
+
+    const results = await run({
+      context,
+      client: {
+        rest: { pulls: { createReview } },
+      },
+    });
+
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(results).toEqual({
+      posted: 1,
+      fallbackPosted: 0,
+      approved: 1,
+      rejected: 1,
+      failed: 0,
+      skipped: 0,
+      summaryBody: "One issue should be fixed.",
+      failures: [],
+    });
+    expect(
+      JSON.parse(
+        await fs.readFile(
+          path.join(prompts, "review_post_results.json"),
+          "utf8",
+        ),
+      ),
+    ).toEqual(results);
+  });
+
+  it("does not require a diff, token, or client when nothing is approved", async () => {
+    const prompts = path.join(tmpDir, "droid-prompts");
+    await fs.writeFile(
+      path.join(prompts, "review_validated.json"),
+      JSON.stringify({
+        version: 1,
+        results: [
+          {
+            status: "rejected",
+            comment: comment({ body: "[P2] Rejected" }),
+          },
+        ],
+        reviewSummary: { body: "LGTM — no issues found." },
+      }),
+    );
+
+    const results = await run({
+      context: createMockContext({ isPR: true, entityNumber: 42 }),
+    });
+
+    expect(results.posted).toBe(0);
+    expect(results.rejected).toBe(1);
+    expect(results.summaryBody).toBe("LGTM — no issues found.");
+  });
+});

--- a/test/entrypoints/github-post-review.test.ts
+++ b/test/entrypoints/github-post-review.test.ts
@@ -127,6 +127,32 @@ describe("postGitHubReview", () => {
     expect(payload.comments).toHaveLength(1);
     expect(payload.body).toContain("missing.ts:99");
     expect(payload.event).toBe("COMMENT");
+    // Without a validated SHA the poster must not invent one.
+    expect(payload).not.toHaveProperty("commit_id");
+  });
+
+  it("pins the review to the validated head commit", async () => {
+    const createReview = mock(async (_payload: any) => ({
+      data: { id: 124 },
+    }));
+    const client = {
+      rest: { pulls: { createReview } },
+    } as GitHubReviewClient;
+
+    await postGitHubReview({
+      client,
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      comments: [comment()],
+      diff: DIFF,
+      commitId: "0123456789abcdef0123456789abcdef01234567",
+    });
+
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect((createReview.mock.calls[0]![0] as any).commit_id).toBe(
+      "0123456789abcdef0123456789abcdef01234567",
+    );
   });
 
   it("preserves a valid multi-line anchor in the single API call", async () => {
@@ -236,14 +262,19 @@ describe("github-post-review entrypoint", () => {
   });
 
   it("reads validated output and diff, posts once, and writes result counts", async () => {
+    const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
     const prompts = path.join(tmpDir, "droid-prompts");
     await fs.writeFile(path.join(prompts, "pr.diff"), DIFF);
     await fs.writeFile(
       path.join(prompts, "review_validated.json"),
       JSON.stringify({
         version: 1,
+        meta: { headSha: HEAD_SHA },
         results: [
-          { status: "approved", comment: comment() },
+          {
+            status: "approved",
+            comment: { ...comment(), commit_id: HEAD_SHA },
+          },
           {
             status: "rejected",
             comment: comment({ body: "[P2] Rejected" }),
@@ -270,6 +301,7 @@ describe("github-post-review entrypoint", () => {
     });
 
     expect(createReview).toHaveBeenCalledTimes(1);
+    expect((createReview.mock.calls[0]![0] as any).commit_id).toBe(HEAD_SHA);
     expect(results).toEqual({
       posted: 1,
       fallbackPosted: 0,

--- a/test/gitlab/post-review.test.ts
+++ b/test/gitlab/post-review.test.ts
@@ -382,6 +382,32 @@ describe("parseValidatedReview", () => {
       /missing `results` array/,
     );
   });
+
+  it("skips approved comments with fractional lines or unknown sides", () => {
+    const parsed = parseValidatedReview(
+      validated([
+        {
+          status: "approved",
+          comment: { path: "fraction.ts", body: "bad", line: 3.5 },
+        },
+        {
+          status: "approved",
+          comment: {
+            path: "side.ts",
+            body: "bad",
+            line: 4,
+            side: "MIDDLE",
+          },
+        },
+      ]),
+    );
+
+    expect(parsed.approved).toHaveLength(0);
+    expect(parsed.skipped.map((skip) => skip.reason)).toEqual([
+      "no usable line anchor (side=RIGHT)",
+      "approved comment has an invalid `side`",
+    ]);
+  });
 });
 
 describe("gitlab-post-review entrypoint", () => {

--- a/test/gitlab/post-review.test.ts
+++ b/test/gitlab/post-review.test.ts
@@ -408,6 +408,109 @@ describe("parseValidatedReview", () => {
       "approved comment has an invalid `side`",
     ]);
   });
+
+  describe("commitId", () => {
+    const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+    it("reads the validated head SHA from meta and comments when they agree", () => {
+      const parsed = parseValidatedReview(
+        JSON.stringify({
+          version: 1,
+          meta: { headSha: SHA },
+          results: [
+            {
+              status: "approved",
+              comment: { path: "a.ts", body: "b", line: 3, commit_id: SHA },
+            },
+            {
+              status: "approved",
+              comment: {
+                path: "b.ts",
+                body: "b",
+                line: 4,
+                commit_id: SHA.toUpperCase(),
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(parsed.commitId).toBe(SHA);
+    });
+
+    it("falls back to the comments' commit_id when meta is absent", () => {
+      const parsed = parseValidatedReview(
+        validated([
+          {
+            status: "approved",
+            comment: { path: "a.ts", body: "b", line: 3, commit_id: SHA },
+          },
+        ]),
+      );
+
+      expect(parsed.commitId).toBe(SHA);
+    });
+
+    it("is null when the file names no SHA or names conflicting SHAs", () => {
+      expect(
+        parseValidatedReview(
+          validated([
+            {
+              status: "approved",
+              comment: { path: "a.ts", body: "b", line: 3 },
+            },
+          ]),
+        ).commitId,
+      ).toBeNull();
+
+      expect(
+        parseValidatedReview(
+          JSON.stringify({
+            version: 1,
+            meta: { headSha: SHA },
+            results: [
+              {
+                status: "approved",
+                comment: {
+                  path: "a.ts",
+                  body: "b",
+                  line: 3,
+                  commit_id: "fedcba9876543210fedcba9876543210fedcba98",
+                },
+              },
+            ],
+          }),
+        ).commitId,
+      ).toBeNull();
+    });
+
+    it("ignores values that are not commit SHAs", () => {
+      const parsed = parseValidatedReview(
+        JSON.stringify({
+          version: 1,
+          meta: { headSha: "unknown" },
+          results: [
+            {
+              status: "approved",
+              comment: {
+                path: "a.ts",
+                body: "b",
+                line: 3,
+                commit_id: "<head sha>",
+              },
+            },
+            {
+              // Rejected entries never influence the pinned commit.
+              status: "rejected",
+              candidate: { path: "b.ts", body: "b", line: 4, commit_id: SHA },
+            },
+          ],
+        }),
+      );
+
+      expect(parsed.commitId).toBeNull();
+    });
+  });
 });
 
 describe("gitlab-post-review entrypoint", () => {

--- a/test/mcp/github-pr-server.test.ts
+++ b/test/mcp/github-pr-server.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import {
+  MAX_SUBMIT_REVIEW_ATTEMPTS,
+  createGitHubPRServer,
+  createSubmitReviewGuard,
   deletePullRequestComment,
+  handleSubmitReview,
   listReviewAndIssueComments,
   minimizeComment,
   replyToPullRequestComment,
   submitReviewWithComments,
   resolveReviewThread,
   type OctokitLike,
+  type ReviewComment,
 } from "../../src/mcp/github-pr-server";
 
 function createOctokitStub() {
@@ -299,5 +304,231 @@ describe("github-pr-server helpers", () => {
       threadId: "thread-xyz",
       headers: { accept: "application/vnd.github.comfort-fade-preview+json" },
     });
+  });
+});
+
+describe("submit_review idempotency guard", () => {
+  const commentA: ReviewComment = {
+    path: "src/a.ts",
+    line: 10,
+    side: "RIGHT",
+    body: "[P1] Null deref",
+  };
+  const commentB: ReviewComment = {
+    path: "src/b.ts",
+    line: 20,
+    side: "RIGHT",
+    body: "[P2] Missing await",
+  };
+
+  function submit(
+    client: OctokitLike,
+    guard: ReturnType<typeof createSubmitReviewGuard>,
+    input: { body?: string; comments?: ReviewComment[] },
+  ) {
+    return handleSubmitReview({
+      owner: "o",
+      repo: "r",
+      prNumber: 7,
+      octokit: client,
+      guard,
+      ...input,
+    });
+  }
+
+  it("posts the first call, then answers every repeat from memory without touching GitHub", async () => {
+    const { client, calls } = createOctokitStub();
+    const guard = createSubmitReviewGuard();
+
+    const first = await submit(client, guard, {
+      comments: [commentA, commentB],
+    });
+    expect(first.isError).toBe(false);
+    expect(first.text).toContain("Submitted review 9001");
+    expect(first.text).toContain("2 inline comments");
+    expect(calls.createReview).toHaveLength(1);
+
+    // The failure mode from AUT-2090: the model re-submits the same batch
+    // hundreds of times because nothing tells it the review already exists.
+    for (let i = 0; i < 5; i++) {
+      const again = await submit(client, guard, {
+        comments: [commentA, commentB],
+      });
+      expect(again.isError).toBe(true);
+      expect(again.text).toBe(
+        "A review with these 2 comments was already submitted as review 9001. " +
+          "Do not call submit_review again.",
+      );
+    }
+    expect(calls.createReview).toHaveLength(1);
+  });
+
+  it("atomically refuses a concurrent call while the first is in flight", async () => {
+    const { client, calls } = createOctokitStub();
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    client.rest.pulls.createReview = async (...args: any[]) => {
+      calls.createReview.push(args);
+      await pending;
+      return { data: { id: 9001 } };
+    };
+    const guard = createSubmitReviewGuard();
+
+    const first = submit(client, guard, { comments: [commentA] });
+    await Promise.resolve();
+    const concurrent = await submit(client, guard, { comments: [commentA] });
+
+    expect(concurrent).toEqual({
+      text:
+        "A review submission is already in progress. " +
+        "Do not call submit_review again.",
+      isError: true,
+    });
+    expect(calls.createReview).toHaveLength(1);
+
+    release();
+    expect((await first).isError).toBe(false);
+  });
+
+  it("refuses a second review even when it carries new or reworded comments", async () => {
+    const { client, calls } = createOctokitStub();
+    const guard = createSubmitReviewGuard();
+
+    await submit(client, guard, { comments: [commentA] });
+
+    const reworded = await submit(client, guard, {
+      comments: [{ ...commentA, body: "[P1] Null deref (reworded)" }],
+    });
+    expect(reworded.isError).toBe(true);
+    expect(reworded.text).toBe(
+      "A review with these 1 comments was already submitted as review 9001. " +
+        "Do not call submit_review again.",
+    );
+
+    const mixed = await submit(client, guard, {
+      comments: [commentA, commentB],
+    });
+    expect(mixed.isError).toBe(true);
+    expect(mixed.text).toBe(
+      "A review with these 1 comments was already submitted as review 9001. " +
+        "Do not call submit_review again.",
+    );
+
+    const bodyOnly = await submit(client, guard, { body: "Summary" });
+    expect(bodyOnly.isError).toBe(true);
+
+    expect(calls.createReview).toHaveLength(1);
+  });
+
+  it("recognises the same comment regardless of surrounding whitespace or an explicit default side", async () => {
+    const { client } = createOctokitStub();
+    const guard = createSubmitReviewGuard();
+
+    await submit(client, guard, { comments: [commentA] });
+    const again = await submit(client, guard, {
+      comments: [{ path: "src/a.ts", line: 10, body: "  [P1] Null deref \n" }],
+    });
+
+    expect(again.isError).toBe(true);
+    // Every comment matched, so no "not part of that review" note.
+    expect(again.text).not.toContain("not part of that review");
+  });
+
+  it("rejects a call with nothing to post without calling GitHub or consuming the submission", async () => {
+    const { client, calls } = createOctokitStub();
+    const guard = createSubmitReviewGuard();
+
+    const empty = await submit(client, guard, {});
+    expect(empty.isError).toBe(true);
+    expect(empty.text).toContain("no comments and no body");
+    const blank = await submit(client, guard, { body: "   ", comments: [] });
+    expect(blank.isError).toBe(true);
+    expect(calls.createReview).toHaveLength(0);
+
+    const real = await submit(client, guard, { comments: [commentA] });
+    expect(real.isError).toBe(false);
+    expect(calls.createReview).toHaveLength(1);
+  });
+
+  it("lets a failed post be corrected and retried, but bounds total GitHub attempts", async () => {
+    const { client, calls } = createOctokitStub();
+    let failuresLeft = 2;
+    client.rest.pulls.createReview = async (...args: any[]) => {
+      calls.createReview.push(args);
+      if (failuresLeft > 0) {
+        failuresLeft -= 1;
+        throw new Error("Validation Failed: line must be part of the diff");
+      }
+      return { data: { id: 9002 } };
+    };
+    const guard = createSubmitReviewGuard();
+
+    await expect(
+      submit(client, guard, { comments: [commentA] }),
+    ).rejects.toThrow(/part of the diff/);
+    await expect(
+      submit(client, guard, { comments: [commentA] }),
+    ).rejects.toThrow(/part of the diff/);
+
+    // A failed post is not a submission, so the corrected retry still posts.
+    const fixed = await submit(client, guard, {
+      comments: [{ ...commentA, line: 11 }],
+    });
+    expect(fixed.isError).toBe(false);
+    expect(fixed.text).toContain("Submitted review 9002");
+    expect(calls.createReview).toHaveLength(3);
+
+    const flaky = createOctokitStub();
+    flaky.client.rest.pulls.createReview = async (...args: any[]) => {
+      flaky.calls.createReview.push(args);
+      throw new Error("boom");
+    };
+    const flakyGuard = createSubmitReviewGuard();
+    for (let i = 0; i < MAX_SUBMIT_REVIEW_ATTEMPTS; i++) {
+      await expect(
+        submit(flaky.client, flakyGuard, { comments: [commentA] }),
+      ).rejects.toThrow("boom");
+    }
+    await expect(
+      submit(flaky.client, flakyGuard, { comments: [commentA] }),
+    ).rejects.toThrow(/attempted 5 times .* maximum/);
+    expect(flaky.calls.createReview).toHaveLength(MAX_SUBMIT_REVIEW_ATTEMPTS);
+  });
+
+  it("reports repeat calls as tool errors through the MCP server", async () => {
+    const { client, calls } = createOctokitStub();
+    const guard = createSubmitReviewGuard();
+    const server = createGitHubPRServer({
+      owner: "o",
+      repo: "r",
+      octokit: client,
+      submitReviewGuard: guard,
+    });
+    // Drive the registered tool the way the SDK's CallTool handler does, so
+    // the zod defaults (e.g. side) apply exactly as they would in production.
+    const internal = server as any;
+    const tool = internal._registeredTools?.submit_review;
+    expect(tool).toBeDefined();
+    const call = async (args: Record<string, unknown>) => {
+      const validated = await internal.validateToolInput(
+        tool,
+        args,
+        "submit_review",
+      );
+      return internal.executeToolHandler(tool, validated, {});
+    };
+
+    const first = await call({ pr_number: 7, comments: [commentA] });
+    expect(first.isError).toBeUndefined();
+    expect(first.content[0].text).toContain("Submitted review 9001");
+
+    const second = await call({ pr_number: 7, comments: [commentA] });
+    expect(second.isError).toBe(true);
+    expect(second.content[0].text).toContain(
+      "already submitted as review 9001",
+    );
+    expect(calls.createReview).toHaveLength(1);
   });
 });

--- a/test/modes/tag/review-validator-command.test.ts
+++ b/test/modes/tag/review-validator-command.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as core from "@actions/core";
+import * as promptModule from "../../../src/create-prompt";
+import * as prFetcher from "../../../src/github/data/pr-fetcher";
+import { prepareReviewValidatorMode } from "../../../src/tag/commands/review-validator";
+import { createMockContext } from "../../mockContext";
+
+describe("prepareReviewValidatorMode", () => {
+  const savedArgs = process.env.DROID_ARGS;
+  const savedFactoryKey = process.env.FACTORY_API_KEY;
+  const savedRunnerTemp = process.env.RUNNER_TEMP;
+
+  beforeEach(() => {
+    process.env.RUNNER_TEMP = "/tmp/test-runner";
+    delete process.env.FACTORY_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedArgs === undefined) delete process.env.DROID_ARGS;
+    else process.env.DROID_ARGS = savedArgs;
+    if (savedFactoryKey === undefined) delete process.env.FACTORY_API_KEY;
+    else process.env.FACTORY_API_KEY = savedFactoryKey;
+    if (savedRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+    else process.env.RUNNER_TEMP = savedRunnerTemp;
+  });
+
+  it("exposes only file-writing tools and strips custom tool flags", async () => {
+    process.env.DROID_ARGS =
+      '--enabled-tools "github_pr___submit_review,github_comment___update_droid_comment" --verbose';
+
+    const fetchSpy = spyOn(prFetcher, "fetchPRBranchData").mockResolvedValue({
+      baseRefName: "main",
+      headRefName: "feature",
+      headRefOid: "abc123",
+      title: "PR",
+      body: "",
+    });
+    const promptSpy = spyOn(promptModule, "createPrompt").mockResolvedValue();
+    const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    const exportSpy = spyOn(core, "exportVariable").mockImplementation(
+      () => {},
+    );
+
+    const result = await prepareReviewValidatorMode({
+      context: createMockContext({ isPR: true, entityNumber: 24 }),
+      octokit: {} as any,
+      githubToken: "token",
+      trackingCommentId: 555,
+    });
+
+    const args = setOutputSpy.mock.calls.find(
+      (call: unknown[]) => call[0] === "droid_args",
+    )?.[1] as string;
+    expect(args).toContain(
+      "Read,Grep,Glob,LS,Execute,ApplyPatch,Create,Edit,Skill",
+    );
+    expect(args).toContain("--verbose");
+    expect(args).not.toContain("github_pr___submit_review");
+    expect(args).not.toContain("github_comment___update_droid_comment");
+    expect(setOutputSpy).toHaveBeenCalledWith("mcp_tools", '{"mcpServers":{}}');
+    expect(result.mcpTools).toBe('{"mcpServers":{}}');
+
+    fetchSpy.mockRestore();
+    promptSpy.mockRestore();
+    setOutputSpy.mockRestore();
+    exportSpy.mockRestore();
+  });
+});

--- a/test/review-posting-wiring.test.ts
+++ b/test/review-posting-wiring.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+
+const root = join(import.meta.dir, "..");
+const loadAction = (relativePath: string): any =>
+  parse(readFileSync(join(root, relativePath), "utf8"));
+
+const stepById = (action: any, id: string): any =>
+  action.runs.steps.find((step: any) => step.id === id);
+
+describe("review safety wiring", () => {
+  it("wires candidate/validator caps and deterministic posting in the main action", () => {
+    const action = loadAction("action.yml");
+
+    expect(action.inputs.review_candidates_max_turns.default).toBe("100");
+    expect(action.inputs.review_validator_max_turns.default).toBe("40");
+    expect(stepById(action, "droid").env.INPUT_MAX_TURNS).toContain(
+      "review_candidates_max_turns",
+    );
+    expect(stepById(action, "droid_validator").env.INPUT_MAX_TURNS).toContain(
+      "review_validator_max_turns",
+    );
+    expect(stepById(action, "post_review").run).toContain(
+      "github-post-review.ts",
+    );
+    expect(stepById(action, "post_review").env.REVIEW_VALIDATED_PATH).toContain(
+      "review_validated_path",
+    );
+  });
+
+  for (const relativePath of ["review/action.yml", "security/action.yml"]) {
+    it(`wires both caps and posting in ${relativePath}`, () => {
+      const action = loadAction(relativePath);
+
+      expect(action.inputs.candidates_max_turns.default).toBe("100");
+      expect(action.inputs.validator_max_turns.default).toBe("40");
+      expect(stepById(action, "review").env.INPUT_MAX_TURNS).toContain(
+        "candidates_max_turns",
+      );
+      expect(stepById(action, "validator").env.INPUT_MAX_TURNS).toContain(
+        "validator_max_turns",
+      );
+      expect(stepById(action, "post_review").run).toContain(
+        "github-post-review.ts",
+      );
+      expect(action.outputs.conclusion.value).toContain("post_review");
+    });
+  }
+
+  it("exposes max_turns through the reusable base action", () => {
+    const action = loadAction("base-action/action.yml");
+
+    expect(action.inputs.max_turns).toBeDefined();
+    expect(stepById(action, "run_droid").env.INPUT_MAX_TURNS).toContain(
+      "max_turns",
+    );
+  });
+});

--- a/test/review-posting-wiring.test.ts
+++ b/test/review-posting-wiring.test.ts
@@ -30,6 +30,17 @@ describe("review safety wiring", () => {
     );
   });
 
+  // The validator keeps `Execute` and reads the untrusted PR diff, so it must
+  // never hold a GitHub credential; only the deterministic post step may.
+  it("withholds GITHUB_TOKEN from the validator process in the main action", () => {
+    const action = loadAction("action.yml");
+
+    expect(stepById(action, "droid_validator").env).not.toHaveProperty(
+      "GITHUB_TOKEN",
+    );
+    expect(stepById(action, "post_review").env.GITHUB_TOKEN).toBeDefined();
+  });
+
   for (const relativePath of ["review/action.yml", "security/action.yml"]) {
     it(`wires both caps and posting in ${relativePath}`, () => {
       const action = loadAction(relativePath);
@@ -46,6 +57,15 @@ describe("review safety wiring", () => {
         "github-post-review.ts",
       );
       expect(action.outputs.conclusion.value).toContain("post_review");
+    });
+
+    it(`withholds GITHUB_TOKEN from the validator process in ${relativePath}`, () => {
+      const action = loadAction(relativePath);
+
+      expect(stepById(action, "validator").env).not.toHaveProperty(
+        "GITHUB_TOKEN",
+      );
+      expect(stepById(action, "post_review").env.GITHUB_TOKEN).toBeDefined();
     });
   }
 

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -69,4 +69,25 @@ describe("retryWithBackoff", () => {
       | undefined;
     expect(firstCall?.[1]).toBe(5);
   });
+
+  it("rethrows immediately, without backoff, when shouldRetry returns false", async () => {
+    let attempts = 0;
+
+    await expect(
+      retryWithBackoff(
+        async () => {
+          attempts += 1;
+          throw new Error(attempts === 1 ? "fatal" : "transient");
+        },
+        {
+          maxAttempts: 3,
+          initialDelayMs: 5,
+          shouldRetry: (error) => error.message !== "fatal",
+        },
+      ),
+    ).rejects.toThrow("fatal");
+
+    expect(attempts).toBe(1);
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Description

Merge the current `dev` branch into `main`. This release ships the deterministic review posting pipeline (#138) and a small CI trigger change (#137).

**Deterministic review posting (#138)**

- `submit_review` is atomic and idempotent per MCP process, with a hard refusal after a successful or in-flight submission.
- Action-side turn limits for both review passes (100 candidate turns, 40 validator turns), without retrying runaway sessions.
- The validator is file-only: it writes `review_validated.json` and a new `github-post-review.ts` step posts it through one GitHub API call.
- Diff anchors are validated against the precomputed PR diff, GitHub payloads are bounded, and posting results are rendered in the tracking comment.
- The posted review is pinned to the validated head commit via top-level `commit_id`, so a push between diff generation and posting cannot shift the anchors.
- `GITHUB_TOKEN` is withheld from the validator `droid exec` step in all three actions; only the prepare and post steps hold it.
- Validated-review, diff-index, review-posting, and result-parsing primitives are shared with the GitLab flow.

**CI (#137)**

- Allow `factory-droid` (alongside `dependabot`) to trigger Droid Auto Review in this repo's workflow.

## Related Issue

FAC-21658 (#137). Release synchronization otherwise.

## Potential Risk & Impact

- Review posting now happens in a dedicated action step after the validator instead of from inside the model run. Workflows that call the `review/` or `security/` actions get this automatically; no input changes are required.
- New inputs `review_candidates_max_turns` / `review_validator_max_turns` (main action) and `candidates_max_turns` / `validator_max_turns` (review and security actions) default to 100 and 40. Set them empty to disable the cap.
- The validator process no longer receives `GITHUB_TOKEN`. It never used it through MCP, but any custom `droid_args` that relied on shelling out to `gh` during validation will lose that access by design.
- If `review_validated.json` does not name a single head SHA, posting falls back to GitHub's default (current PR head) and logs a warning rather than failing.

## How Has This Been Tested?

- Full droid-action test suite: 626 passed
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- CI green on `dev` head `9be8880`
- `git merge-tree origin/main origin/dev`: clean, no conflicts
